### PR TITLE
[IDLE-213] 휴대폰 인증번호 타이머 구현 및 적용

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <application
         android:name=".CareApplication"
         android:allowBackup="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,16 @@
+<network-security-config>
+    <debug-overrides>
+        <trust-anchors>
+            <!-- Trust user added CAs while debuggable only -->
+            <certificates src="user" />
+            <certificates src="system" />
+        </trust-anchors>
+    </debug-overrides>
+
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/build-logic/src/main/java/com/idle/app/TestKotlin.kt
+++ b/build-logic/src/main/java/com/idle/app/TestKotlin.kt
@@ -9,7 +9,9 @@ internal fun Project.configureTest() {
     configureJUnit()
     val libs = extensions.libs
     dependencies {
-        add("testImplementation",libs.findLibrary("junit4").get())
+        add("testImplementation", libs.findLibrary("junit4").get())
+        add("testImplementation", libs.findLibrary("junit-jupiter").get())
+        add("testImplementation", libs.findLibrary("coroutines-test").get())
     }
 }
 

--- a/build-logic/src/main/java/com/idle/app/care.kotlin.library.gradle.kts
+++ b/build-logic/src/main/java/com/idle/app/care.kotlin.library.gradle.kts
@@ -1,7 +1,9 @@
 import com.idle.app.configureKotlin
+import com.idle.app.configureTest
 
 plugins {
     kotlin("jvm")
 }
 
 configureKotlin()
+configureTest()

--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/TextField.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/TextField.kt
@@ -17,16 +17,18 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import com.idle.designsystem.compose.foundation.CareTheme
 
 @Composable
 fun CareTextField(
     value: String,
-    hint: String,
+    hint: String = "",
     readOnly: Boolean = false,
     isError: Boolean = false,
     supportingText: String = "",
+    visualTransformation: VisualTransformation = VisualTransformation.None,
     onValueChanged: (String) -> Unit,
     onDone: () -> Unit = {},
     leftComponent: @Composable () -> Unit = {},
@@ -72,6 +74,7 @@ fun CareTextField(
                 ),
                 singleLine = true,
                 readOnly = readOnly,
+                visualTransformation = visualTransformation,
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                 keyboardActions = KeyboardActions(onDone = {
                     onDone()
@@ -94,16 +97,14 @@ fun CareTextField(
             leftComponent()
         }
 
-        if (supportingText.isNotBlank()) {
-            Text(
-                text = supportingText,
-                style = CareTheme.typography.caption,
-                color = if (isError) {
-                    CareTheme.colors.red
-                } else {
-                    CareTheme.colors.gray300
-                },
-            )
-        }
+        Text(
+            text = supportingText,
+            style = CareTheme.typography.caption,
+            color = if (isError) {
+                CareTheme.colors.red
+            } else {
+                CareTheme.colors.gray300
+            },
+        )
     }
 }

--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/TextField.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/TextField.kt
@@ -2,8 +2,7 @@ package com.idle.designsystem.compose.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -25,12 +24,13 @@ fun CareTextField(
     hint: String,
     onValueChanged: (String) -> Unit,
     onDone: () -> Unit = {},
+    leftComponent: @Composable () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
 
-    Box(
-        contentAlignment = Alignment.CenterStart,
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
             .height(44.dp)
             .background(color = CareTheme.colors.white000, shape = RoundedCornerShape(6.dp))
@@ -50,7 +50,7 @@ fun CareTextField(
                 onDone()
                 keyboardController?.hide()
             }),
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.weight(1f)
                 .padding(horizontal = 16.dp, vertical = 10.dp),
             decorationBox = { innerTextField ->
                 if (value.isEmpty()) {
@@ -63,5 +63,7 @@ fun CareTextField(
                 innerTextField()
             }
         )
+
+        leftComponent()
     }
 }

--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/TextField.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/TextField.kt
@@ -38,7 +38,8 @@ fun CareTextField(
                 width = 1.dp,
                 color = CareTheme.colors.gray100,
                 shape = RoundedCornerShape(6.dp)
-            ),
+            )
+            .padding(horizontal = 16.dp),
     ) {
         BasicTextField(
             value = value,
@@ -51,7 +52,7 @@ fun CareTextField(
                 keyboardController?.hide()
             }),
             modifier = Modifier.weight(1f)
-                .padding(horizontal = 16.dp, vertical = 10.dp),
+                .padding(top = 10.dp, bottom = 10.dp, end = 8.dp),
             decorationBox = { innerTextField ->
                 if (value.isEmpty()) {
                     Text(

--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/TextField.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/TextField.kt
@@ -2,6 +2,8 @@ package com.idle.designsystem.compose.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -22,6 +24,9 @@ import com.idle.designsystem.compose.foundation.CareTheme
 fun CareTextField(
     value: String,
     hint: String,
+    readOnly: Boolean = false,
+    isError: Boolean = false,
+    supportingText: String = "",
     onValueChanged: (String) -> Unit,
     onDone: () -> Unit = {},
     leftComponent: @Composable () -> Unit = {},
@@ -29,42 +34,76 @@ fun CareTextField(
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
 
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
+    Column(
+        verticalArrangement = Arrangement.spacedBy(4.dp),
         modifier = modifier
-            .height(44.dp)
-            .background(color = CareTheme.colors.white000, shape = RoundedCornerShape(6.dp))
-            .border(
-                width = 1.dp,
-                color = CareTheme.colors.gray100,
-                shape = RoundedCornerShape(6.dp)
-            )
-            .padding(horizontal = 16.dp),
     ) {
-        BasicTextField(
-            value = value,
-            onValueChange = onValueChanged,
-            textStyle = CareTheme.typography.body3,
-            singleLine = true,
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-            keyboardActions = KeyboardActions(onDone = {
-                onDone()
-                keyboardController?.hide()
-            }),
-            modifier = Modifier.weight(1f)
-                .padding(top = 10.dp, bottom = 10.dp, end = 8.dp),
-            decorationBox = { innerTextField ->
-                if (value.isEmpty()) {
-                    Text(
-                        text = hint,
-                        style = CareTheme.typography.body3,
-                        color = CareTheme.colors.gray200,
-                    )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .height(44.dp)
+                .background(
+                    color = if (readOnly) {
+                        CareTheme.colors.gray050
+                    } else {
+                        CareTheme.colors.white000
+                    }, shape = RoundedCornerShape(6.dp)
+                )
+                .border(
+                    width = 1.dp,
+                    color = if (isError) {
+                        CareTheme.colors.red
+                    } else {
+                        CareTheme.colors.gray100
+                    },
+                    shape = RoundedCornerShape(6.dp)
+                )
+                .padding(horizontal = 16.dp),
+        ) {
+            BasicTextField(
+                value = value,
+                onValueChange = onValueChanged,
+                textStyle = CareTheme.typography.body3.copy(
+                    color = if (readOnly) {
+                        CareTheme.colors.gray300
+                    } else {
+                        CareTheme.colors.gray900
+                    },
+                ),
+                singleLine = true,
+                readOnly = readOnly,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(onDone = {
+                    onDone()
+                    keyboardController?.hide()
+                }),
+                modifier = Modifier.weight(1f)
+                    .padding(top = 10.dp, bottom = 10.dp, end = 8.dp),
+                decorationBox = { innerTextField ->
+                    if (value.isEmpty()) {
+                        Text(
+                            text = hint,
+                            style = CareTheme.typography.body3,
+                            color = CareTheme.colors.gray200,
+                        )
+                    }
+                    innerTextField()
                 }
-                innerTextField()
-            }
-        )
+            )
 
-        leftComponent()
+            leftComponent()
+        }
+
+        if (supportingText.isNotBlank()) {
+            Text(
+                text = supportingText,
+                style = CareTheme.typography.caption,
+                color = if (isError) {
+                    CareTheme.colors.red
+                } else {
+                    CareTheme.colors.gray300
+                },
+            )
+        }
     }
 }

--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/foundation/Color.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/foundation/Color.kt
@@ -3,6 +3,7 @@ package com.idle.designsystem.compose.foundation
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 
+val Red = Color(0xffFD4F43)
 val Orange100 = Color(0xffFFE4CC)
 val Orange200 = Color(0xffFFCA99)
 val Orange300 = Color(0xffFFAF66)
@@ -25,6 +26,7 @@ val Gray900 = Color(0xff131417)
 
 @Immutable
 data class CareColors(
+    val red: Color = Red,
     val orange100: Color = Orange100,
     val orange200: Color = Orange200,
     val orange300: Color = Orange300,

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -3,4 +3,6 @@ plugins {
     id("care.kotlin.hilt")
 }
 
-dependencies { }
+dependencies {
+    implementation(libs.coroutines.core)
+}

--- a/core/domain/src/main/kotlin/com/idle/domain/model/CountDownTimer.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/model/CountDownTimer.kt
@@ -1,20 +1,19 @@
-package com.idle.domain.usecase.auth
+package com.idle.domain.model
 
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.isActive
 import javax.inject.Inject
+import kotlin.coroutines.coroutineContext
 
 class CountDownTimer @Inject constructor() {
     private var remainTime: Long = 0
-    private var timerJob: Job? = null
 
     @Throws(IllegalStateException::class)
-    fun start(limitTime: Long, scope: CoroutineScope): Flow<Long> {
+    fun start(limitTime: Long): Flow<Long> {
         require((limitTime % TICK_INTERVAL == 0L)) {
             "초 단위의 시간만 측정할 수 있습니다."
         }
@@ -22,25 +21,15 @@ class CountDownTimer @Inject constructor() {
         return flow {
             remainTime = limitTime
 
-            while (remainTime > 0) {
+            while (remainTime > 0 && coroutineContext.isActive) {
                 delay(TICK_INTERVAL)
                 remainTime -= TICK_INTERVAL
                 emit(remainTime)
             }
         }.onStart {
             emit(limitTime)
-        }.also {
-            timerJob?.cancel()
-            timerJob = null
-            timerJob = it.launchIn(scope)
         }
     }
-
-    fun cancel() {
-        timerJob?.cancel()
-        timerJob = null
-    }
-
 
     companion object {
         const val SECONDS_PER_MINUTE = 60

--- a/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/CountDownTimer.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/CountDownTimer.kt
@@ -1,0 +1,49 @@
+package com.idle.domain.usecase.auth
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onStart
+import javax.inject.Inject
+
+class CountDownTimer @Inject constructor() {
+    private var remainTime: Long = 0
+    private var timerJob: Job? = null
+
+    @Throws(IllegalStateException::class)
+    fun start(limitTime: Long, scope: CoroutineScope): Flow<Long> {
+        require((limitTime % TICK_INTERVAL == 0L)) {
+            "초 단위의 시간만 측정할 수 있습니다."
+        }
+
+        return flow {
+            remainTime = limitTime
+
+            while (remainTime > 0) {
+                delay(TICK_INTERVAL)
+                remainTime -= TICK_INTERVAL
+                emit(remainTime)
+            }
+        }.onStart {
+            emit(limitTime)
+        }.also {
+            timerJob?.cancel()
+            timerJob = null
+            timerJob = it.launchIn(scope)
+        }
+    }
+
+    fun cancel() {
+        timerJob?.cancel()
+        timerJob = null
+    }
+
+
+    companion object {
+        const val SECONDS_PER_MINUTE = 60
+        const val TICK_INTERVAL = 1000L
+    }
+}

--- a/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/SendPhoneNumberUseCase.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/SendPhoneNumberUseCase.kt
@@ -6,5 +6,20 @@ import javax.inject.Inject
 class SendPhoneNumberUseCase @Inject constructor(
     private val authRepository: AuthRepository,
 ) {
-    suspend operator fun invoke(phoneNumber: String) = authRepository.sendPhoneNumber(phoneNumber)
+    suspend operator fun invoke(phoneNumber: String): Result<Unit> = runCatching {
+        val formattedPhoneNumber = formatPhoneNumber(phoneNumber)
+        authRepository.sendPhoneNumber(formattedPhoneNumber)
+    }
+
+    private fun formatPhoneNumber(phoneNumber: String): String {
+        // 입력된 전화번호가 11자리 숫자인 경우에만 포맷팅을 적용
+        return if (phoneNumber.length == 11) {
+            phoneNumber.replaceFirst(
+                Regex("(\\d{3})(\\d{4})(\\d{4})"),
+                "$1-$2-$3"
+            )
+        } else {
+            phoneNumber  // 비정상적인 경우 원본 번호 반환
+        }
+    }
 }

--- a/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/ValidateBusinessRegistrationNumberUseCase.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/ValidateBusinessRegistrationNumberUseCase.kt
@@ -1,12 +1,27 @@
 package com.idle.domain.usecase.auth
 
+import com.idle.domain.model.auth.BusinessRegistrationInfo
 import com.idle.domain.repositorry.auth.AuthRepository
 import javax.inject.Inject
 
 class ValidateBusinessRegistrationNumberUseCase @Inject constructor(
-    private val authRepository: AuthRepository,
+    private val authRepository: AuthRepository
 ) {
+    suspend operator fun invoke(businessRegistrationNumber: String): Result<BusinessRegistrationInfo> =
+        runCatching {
+            val formattedNumber = when (businessRegistrationNumber.length) {
+                10 -> formatTenDigitNumber(businessRegistrationNumber)
+                12 -> businessRegistrationNumber
+                else -> throw IllegalArgumentException("사업자 등록번호 형식이 맞지 않습니다.")
+            }
 
-    suspend operator fun invoke(businessRegistrationNumber: String) =
-        authRepository.validateBusinessRegistrationNumber(businessRegistrationNumber)
+            return authRepository.validateBusinessRegistrationNumber(formattedNumber)
+        }
+
+    private fun formatTenDigitNumber(number: String): String {
+        return number.replaceFirst(
+            Regex("(\\d{3})(\\d{2})(\\d{5})"),
+            "$1-$2-$3"
+        )
+    }
 }

--- a/core/domain/src/test/kotlin/com/idle/domain/model/CountDownTimerTest.kt
+++ b/core/domain/src/test/kotlin/com/idle/domain/model/CountDownTimerTest.kt
@@ -1,0 +1,56 @@
+package com.idle.domain.model
+
+import com.idle.domain.model.CountDownTimer.Companion.TICK_INTERVAL
+import kotlinx.coroutines.flow.cancellable
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CountDownTimerTest {
+
+    private lateinit var countDownTimer: CountDownTimer
+
+    @BeforeEach
+    fun setUp() {
+        countDownTimer = CountDownTimer()
+    }
+
+    @Test
+    fun `타이머는 1초 단위로 값을 방출한다`() = runTest {
+        // given
+        val totalDuration = TICK_INTERVAL * 5
+
+        // when
+        val actual = countDownTimer.start(totalDuration).toList()
+
+        // then
+        val expected = listOf(5000L, 4000L, 3000L, 2000L, 1000L, 0L)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `타이머는 취소되면 더 이상 값을 방출하지 않는다`() = runTest {
+        // given
+        val totalDuration = TICK_INTERVAL * 5
+        val flow = countDownTimer.start(totalDuration)
+        val results = mutableListOf<Long>()
+
+        // when
+        val job = launch {
+            flow.cancellable().collect {
+                results.add(it)
+            }
+        }
+
+        advanceTimeBy(2500L)
+        job.cancel()  // 직접 취소 호출
+
+        // then
+        val expected = listOf(5000L, 4000L, 3000L)  // 2.5초 후면 이 값들이 수집될 것으로 예상
+        assertEquals(expected, results)
+    }
+}

--- a/core/network/src/main/java/com/idle/network/model/auth/ConfirmAuthCodeRequest.kt
+++ b/core/network/src/main/java/com/idle/network/model/auth/ConfirmAuthCodeRequest.kt
@@ -1,9 +1,10 @@
 package com.idle.network.model.auth
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class ConfirmAuthCodeRequest(
     val phoneNumber: String,
-    val authCode: String,
+    @SerialName("verificationNumber") val authCode: String,
 )

--- a/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpFragment.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpFragment.kt
@@ -1,6 +1,12 @@
 package com.idle.signin.center
 
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -140,46 +146,60 @@ internal fun CenterSignUpScreen(
                 modifier = Modifier.fillMaxWidth(),
             )
 
-            when (signUpProcess) {
-                CenterSignUpProcess.NAME ->
-                    CenterNameScreen(
-                        centerName = centerName,
-                        onCenterNameChanged = onCenterNameChanged,
-                        setSignUpProcess = setSignUpProcess,
-                    )
+            AnimatedContent(
+                targetState = signUpProcess,
+                transitionSpec = {
+                    if (targetState.ordinal > initialState.ordinal) {
+                        slideInHorizontally(initialOffsetX = { it }) + fadeIn() togetherWith
+                                slideOutHorizontally(targetOffsetX = { -it }) + fadeOut()
+                    } else {
+                        slideInHorizontally(initialOffsetX = { -it }) + fadeIn() togetherWith
+                                slideOutHorizontally(targetOffsetX = { it }) + fadeOut()
+                    }
+                },
+                label = "센터의 회원가입을 관리하는 애니메이션",
+            ) { signUpProcess ->
+                when (signUpProcess) {
+                    CenterSignUpProcess.NAME ->
+                        CenterNameScreen(
+                            centerName = centerName,
+                            onCenterNameChanged = onCenterNameChanged,
+                            setSignUpProcess = setSignUpProcess,
+                        )
 
-                CenterSignUpProcess.PHONE_NUMBER ->
-                    CenterPhoneNumberScreen(
-                        centerPhoneNumber = centerPhoneNumber,
-                        centerAuthCode = centerCertificateNumber,
-                        onCenterPhoneNumberChanged = onCenterPhoneNumberChanged,
-                        onCenterAuthCodeChanged = onCenterAuthCodeChanged,
-                        setSignUpProcess = setSignUpProcess,
-                        sendPhoneNumber = sendPhoneNumber,
-                        confirmAuthCode = confirmAuthCode,
-                    )
+                    CenterSignUpProcess.PHONE_NUMBER ->
+                        CenterPhoneNumberScreen(
+                            centerPhoneNumber = centerPhoneNumber,
+                            centerAuthCode = centerCertificateNumber,
+                            onCenterPhoneNumberChanged = onCenterPhoneNumberChanged,
+                            onCenterAuthCodeChanged = onCenterAuthCodeChanged,
+                            setSignUpProcess = setSignUpProcess,
+                            sendPhoneNumber = sendPhoneNumber,
+                            confirmAuthCode = confirmAuthCode,
+                        )
 
-                CenterSignUpProcess.BUSINESS_REGISTRAION_NUMBER ->
-                    BusinessRegistrationScreen(
-                        businessRegistrationNumber = businessRegistrationNumber,
-                        businessRegistrationInfo = businessRegistrationInfo,
-                        onBusinessRegistrationNumberChanged = onBusinessRegistrationNumberChanged,
-                        validateBusinessRegistrationNumber = validateBusinessRegistrationNumber,
-                        setSignUpProcess = setSignUpProcess,
-                    )
+                    CenterSignUpProcess.BUSINESS_REGISTRATION_NUMBER ->
+                        BusinessRegistrationScreen(
+                            businessRegistrationNumber = businessRegistrationNumber,
+                            businessRegistrationInfo = businessRegistrationInfo,
+                            onBusinessRegistrationNumberChanged = onBusinessRegistrationNumberChanged,
+                            validateBusinessRegistrationNumber = validateBusinessRegistrationNumber,
+                            setSignUpProcess = setSignUpProcess,
+                        )
 
-                CenterSignUpProcess.ID_PASSWORD ->
-                    IdPasswordScreen(
-                        centerId = centerId,
-                        centerPassword = centerPassword,
-                        centerPasswordForConfirm = centerPasswordForConfirm,
-                        onCenterIdChanged = onCenterIdChanged,
-                        onCenterPasswordChanged = onCenterPasswordChanged,
-                        onCenterPasswordForConfirmChanged = onCenterPasswordForConfirmChanged,
-                        setSignUpProcess = setSignUpProcess,
-                        validateIdentifier = validateIdentifier,
-                        signUpCenter = signUpCenter,
-                    )
+                    CenterSignUpProcess.ID_PASSWORD ->
+                        IdPasswordScreen(
+                            centerId = centerId,
+                            centerPassword = centerPassword,
+                            centerPasswordForConfirm = centerPasswordForConfirm,
+                            onCenterIdChanged = onCenterIdChanged,
+                            onCenterPasswordChanged = onCenterPasswordChanged,
+                            onCenterPasswordForConfirmChanged = onCenterPasswordForConfirmChanged,
+                            setSignUpProcess = setSignUpProcess,
+                            validateIdentifier = validateIdentifier,
+                            signUpCenter = signUpCenter,
+                        )
+                }
             }
         }
     }

--- a/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpFragment.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpFragment.kt
@@ -134,7 +134,7 @@ internal fun CenterSignUpScreen(
 ) {
     val onBackPressedDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
     val focusManager = LocalFocusManager.current
-    var (businessRegistrationProcessed, setBusinessRegistrationProcessed)
+    val (businessRegistrationProcessed, setBusinessRegistrationProcessed)
             = remember { mutableStateOf(false) }
 
     Scaffold(

--- a/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpFragment.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpFragment.kt
@@ -16,6 +16,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -129,6 +131,8 @@ internal fun CenterSignUpScreen(
 ) {
     val onBackPressedDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
     val focusManager = LocalFocusManager.current
+    var (businessRegistrationProcessed, setBusinessRegistrationProcessed)
+            = remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -183,11 +187,13 @@ internal fun CenterSignUpScreen(
                             centerAuthCodeTimerSeconds = centerAuthCodeTimerSeconds,
                             centerAuthCode = centerAuthCode,
                             isConfirmAuthCode = isConfirmAuthCode,
+                            businessRegistrationProcessed = businessRegistrationProcessed,
                             onCenterPhoneNumberChanged = onCenterPhoneNumberChanged,
                             onCenterAuthCodeChanged = onCenterAuthCodeChanged,
                             setSignUpProcess = setSignUpProcess,
                             sendPhoneNumber = sendPhoneNumber,
                             confirmAuthCode = confirmAuthCode,
+                            setBusinessRegistrationProcessed = setBusinessRegistrationProcessed,
                         )
 
                     CenterSignUpProcess.BUSINESS_REGISTRATION_NUMBER ->

--- a/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpFragment.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpFragment.kt
@@ -61,6 +61,7 @@ internal class CenterSignUpFragment : BaseComposeFragment() {
                     by businessRegistrationNumber.collectAsStateWithLifecycle()
             val businessRegistrationInfo by businessRegistrationInfo.collectAsStateWithLifecycle()
             val centerId by centerId.collectAsStateWithLifecycle()
+            val centerIdResult by centerIdResult.collectAsStateWithLifecycle()
             val centerPassword by centerPassword.collectAsStateWithLifecycle()
             val centerPasswordForConfirm by centerPasswordForConfirm.collectAsStateWithLifecycle()
 
@@ -75,6 +76,7 @@ internal class CenterSignUpFragment : BaseComposeFragment() {
                 businessRegistrationNumber = businessRegistrationNumber,
                 businessRegistrationInfo = businessRegistrationInfo,
                 centerId = centerId,
+                centerIdResult = centerIdResult,
                 centerPassword = centerPassword,
                 centerPasswordForConfirm = centerPasswordForConfirm,
                 setSignUpProcess = ::setCenterSignUpProcess,
@@ -113,6 +115,7 @@ internal fun CenterSignUpScreen(
     businessRegistrationNumber: String,
     businessRegistrationInfo: BusinessRegistrationInfo?,
     centerId: String,
+    centerIdResult: Boolean,
     centerPassword: String,
     centerPasswordForConfirm: String,
     setSignUpProcess: (CenterSignUpProcess) -> Unit,
@@ -208,6 +211,7 @@ internal fun CenterSignUpScreen(
                     CenterSignUpProcess.ID_PASSWORD ->
                         IdPasswordScreen(
                             centerId = centerId,
+                            centerIdResult = centerIdResult,
                             centerPassword = centerPassword,
                             centerPasswordForConfirm = centerPasswordForConfirm,
                             onCenterIdChanged = onCenterIdChanged,

--- a/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpFragment.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpFragment.kt
@@ -51,7 +51,8 @@ internal class CenterSignUpFragment : BaseComposeFragment() {
             val signUpProcess by signUpProcess.collectAsStateWithLifecycle()
             val centerName by centerName.collectAsStateWithLifecycle()
             val centerPhoneNumber by centerPhoneNumber.collectAsStateWithLifecycle()
-            val centerAuthCodeTimer by centerAuthCodeTimer.collectAsStateWithLifecycle()
+            val centerAuthCodeTimerMinute by centerAuthCodeTimerMinute.collectAsStateWithLifecycle()
+            val centerAuthCodeTimerSeconds by centerAuthCodeTimerSeconds.collectAsStateWithLifecycle()
             val centerAuthCode by centerAuthCode.collectAsStateWithLifecycle()
             val businessRegistrationNumber
                     by businessRegistrationNumber.collectAsStateWithLifecycle()
@@ -64,7 +65,8 @@ internal class CenterSignUpFragment : BaseComposeFragment() {
                 signUpProcess = signUpProcess,
                 centerName = centerName,
                 centerPhoneNumber = centerPhoneNumber,
-                centerAuthCodeTimer = centerAuthCodeTimer,
+                centerAuthCodeTimerMinute = centerAuthCodeTimerMinute,
+                centerAuthCodeTimerSeconds = centerAuthCodeTimerSeconds,
                 centerAuthCode = centerAuthCode,
                 businessRegistrationNumber = businessRegistrationNumber,
                 businessRegistrationInfo = businessRegistrationInfo,
@@ -100,7 +102,8 @@ internal fun CenterSignUpScreen(
     signUpProcess: CenterSignUpProcess,
     centerName: String,
     centerPhoneNumber: String,
-    centerAuthCodeTimer: Long?,
+    centerAuthCodeTimerMinute: String,
+    centerAuthCodeTimerSeconds: String,
     centerAuthCode: String,
     businessRegistrationNumber: String,
     businessRegistrationInfo: BusinessRegistrationInfo?,
@@ -173,7 +176,8 @@ internal fun CenterSignUpScreen(
                     CenterSignUpProcess.PHONE_NUMBER ->
                         CenterPhoneNumberScreen(
                             centerPhoneNumber = centerPhoneNumber,
-                            centerAuthCodeTimer = centerAuthCodeTimer,
+                            centerAuthCodeTimerMinute = centerAuthCodeTimerMinute,
+                            centerAuthCodeTimerSeconds = centerAuthCodeTimerSeconds,
                             centerAuthCode = centerAuthCode,
                             onCenterPhoneNumberChanged = onCenterPhoneNumberChanged,
                             onCenterAuthCodeChanged = onCenterAuthCodeChanged,

--- a/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpFragment.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpFragment.kt
@@ -54,6 +54,7 @@ internal class CenterSignUpFragment : BaseComposeFragment() {
             val centerAuthCodeTimerMinute by centerAuthCodeTimerMinute.collectAsStateWithLifecycle()
             val centerAuthCodeTimerSeconds by centerAuthCodeTimerSeconds.collectAsStateWithLifecycle()
             val centerAuthCode by centerAuthCode.collectAsStateWithLifecycle()
+            val isConfirmAuthCode by isConfirmAuthCode.collectAsStateWithLifecycle()
             val businessRegistrationNumber
                     by businessRegistrationNumber.collectAsStateWithLifecycle()
             val businessRegistrationInfo by businessRegistrationInfo.collectAsStateWithLifecycle()
@@ -68,6 +69,7 @@ internal class CenterSignUpFragment : BaseComposeFragment() {
                 centerAuthCodeTimerMinute = centerAuthCodeTimerMinute,
                 centerAuthCodeTimerSeconds = centerAuthCodeTimerSeconds,
                 centerAuthCode = centerAuthCode,
+                isConfirmAuthCode = isConfirmAuthCode,
                 businessRegistrationNumber = businessRegistrationNumber,
                 businessRegistrationInfo = businessRegistrationInfo,
                 centerId = centerId,
@@ -105,6 +107,7 @@ internal fun CenterSignUpScreen(
     centerAuthCodeTimerMinute: String,
     centerAuthCodeTimerSeconds: String,
     centerAuthCode: String,
+    isConfirmAuthCode: Boolean,
     businessRegistrationNumber: String,
     businessRegistrationInfo: BusinessRegistrationInfo?,
     centerId: String,
@@ -179,6 +182,7 @@ internal fun CenterSignUpScreen(
                             centerAuthCodeTimerMinute = centerAuthCodeTimerMinute,
                             centerAuthCodeTimerSeconds = centerAuthCodeTimerSeconds,
                             centerAuthCode = centerAuthCode,
+                            isConfirmAuthCode = isConfirmAuthCode,
                             onCenterPhoneNumberChanged = onCenterPhoneNumberChanged,
                             onCenterAuthCodeChanged = onCenterAuthCodeChanged,
                             setSignUpProcess = setSignUpProcess,

--- a/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpFragment.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpFragment.kt
@@ -51,7 +51,8 @@ internal class CenterSignUpFragment : BaseComposeFragment() {
             val signUpProcess by signUpProcess.collectAsStateWithLifecycle()
             val centerName by centerName.collectAsStateWithLifecycle()
             val centerPhoneNumber by centerPhoneNumber.collectAsStateWithLifecycle()
-            val centerCertificateNumber by centerConfirmNumber.collectAsStateWithLifecycle()
+            val centerAuthCodeTimer by centerAuthCodeTimer.collectAsStateWithLifecycle()
+            val centerAuthCode by centerAuthCode.collectAsStateWithLifecycle()
             val businessRegistrationNumber
                     by businessRegistrationNumber.collectAsStateWithLifecycle()
             val businessRegistrationInfo by businessRegistrationInfo.collectAsStateWithLifecycle()
@@ -63,7 +64,8 @@ internal class CenterSignUpFragment : BaseComposeFragment() {
                 signUpProcess = signUpProcess,
                 centerName = centerName,
                 centerPhoneNumber = centerPhoneNumber,
-                centerCertificateNumber = centerCertificateNumber,
+                centerAuthCodeTimer = centerAuthCodeTimer,
+                centerAuthCode = centerAuthCode,
                 businessRegistrationNumber = businessRegistrationNumber,
                 businessRegistrationInfo = businessRegistrationInfo,
                 centerId = centerId,
@@ -98,7 +100,8 @@ internal fun CenterSignUpScreen(
     signUpProcess: CenterSignUpProcess,
     centerName: String,
     centerPhoneNumber: String,
-    centerCertificateNumber: String,
+    centerAuthCodeTimer: Long?,
+    centerAuthCode: String,
     businessRegistrationNumber: String,
     businessRegistrationInfo: BusinessRegistrationInfo?,
     centerId: String,
@@ -170,7 +173,8 @@ internal fun CenterSignUpScreen(
                     CenterSignUpProcess.PHONE_NUMBER ->
                         CenterPhoneNumberScreen(
                             centerPhoneNumber = centerPhoneNumber,
-                            centerAuthCode = centerCertificateNumber,
+                            centerAuthCodeTimer = centerAuthCodeTimer,
+                            centerAuthCode = centerAuthCode,
                             onCenterPhoneNumberChanged = onCenterPhoneNumberChanged,
                             onCenterAuthCodeChanged = onCenterAuthCodeChanged,
                             setSignUpProcess = setSignUpProcess,

--- a/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpViewModel.kt
@@ -43,8 +43,11 @@ class CenterSignUpViewModel @Inject constructor(
     private val _centerPhoneNumber = MutableStateFlow("")
     val centerPhoneNumber = _centerPhoneNumber.asStateFlow()
 
-    private val _centerAuthCodeTimer = MutableStateFlow<Long?>(null)
-    val centerAuthCodeTimer = _centerAuthCodeTimer.asStateFlow()
+    private val _centerAuthCodeTimerMinute = MutableStateFlow("")
+    val centerAuthCodeTimerMinute = _centerAuthCodeTimerMinute.asStateFlow()
+
+    private val _centerAuthCodeTimerSeconds = MutableStateFlow("")
+    val centerAuthCodeTimerSeconds = _centerAuthCodeTimerSeconds.asStateFlow()
 
     private var timerJob: Job? = null
 
@@ -113,14 +116,27 @@ class CenterSignUpViewModel @Inject constructor(
     }
 
     private fun startTimer() {
+        cancelTimer()
+
         timerJob = viewModelScope.launch {
             countDownTimer.start(limitTime = TICK_INTERVAL * SECONDS_PER_MINUTE * 5)
-                .collect { _centerAuthCodeTimer.value = it }
+                .collect { timeMillis ->
+                    updateTimerDisplay(timeMillis)
+                }
         }
+    }
+
+    private fun updateTimerDisplay(timeMillis: Long) {
+        val minutes = (timeMillis / (TICK_INTERVAL * SECONDS_PER_MINUTE)).toString().padStart(2, '0')
+        val seconds = ((timeMillis % (TICK_INTERVAL * SECONDS_PER_MINUTE)) / TICK_INTERVAL).toString().padStart(2, '0')
+
+        _centerAuthCodeTimerMinute.value = minutes
+        _centerAuthCodeTimerSeconds.value = seconds
     }
 
     private fun cancelTimer() {
         timerJob?.cancel()
+        timerJob = null
     }
 
     internal fun confirmAuthCode() = viewModelScope.launch {

--- a/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpViewModel.kt
@@ -54,6 +54,9 @@ class CenterSignUpViewModel @Inject constructor(
     private val _centerAuthCode = MutableStateFlow("")
     val centerAuthCode = _centerAuthCode.asStateFlow()
 
+    private val _isConfirmAuthCode = MutableStateFlow(false)
+    val isConfirmAuthCode = _isConfirmAuthCode.asStateFlow()
+
     private val _businessRegistrationNumber = MutableStateFlow("")
     val businessRegistrationNumber = _businessRegistrationNumber.asStateFlow()
 
@@ -108,10 +111,7 @@ class CenterSignUpViewModel @Inject constructor(
 
     internal fun sendPhoneNumber() = viewModelScope.launch {
         sendPhoneNumberUseCase(_centerPhoneNumber.value)
-            .onSuccess {
-                Log.d("test", "성공!")
-                startTimer()
-            }
+            .onSuccess { startTimer() }
             .onFailure { Log.d("test", "실패! ${it}") }
     }
 
@@ -127,8 +127,11 @@ class CenterSignUpViewModel @Inject constructor(
     }
 
     private fun updateTimerDisplay(timeMillis: Long) {
-        val minutes = (timeMillis / (TICK_INTERVAL * SECONDS_PER_MINUTE)).toString().padStart(2, '0')
-        val seconds = ((timeMillis % (TICK_INTERVAL * SECONDS_PER_MINUTE)) / TICK_INTERVAL).toString().padStart(2, '0')
+        val minutes =
+            (timeMillis / (TICK_INTERVAL * SECONDS_PER_MINUTE)).toString().padStart(2, '0')
+        val seconds =
+            ((timeMillis % (TICK_INTERVAL * SECONDS_PER_MINUTE)) / TICK_INTERVAL).toString()
+                .padStart(2, '0')
 
         _centerAuthCodeTimerMinute.value = minutes
         _centerAuthCodeTimerSeconds.value = seconds
@@ -140,10 +143,11 @@ class CenterSignUpViewModel @Inject constructor(
     }
 
     internal fun confirmAuthCode() = viewModelScope.launch {
-        cancelTimer()
-
         confirmAuthCodeUseCase(_centerPhoneNumber.value, _centerAuthCode.value)
-            .onSuccess { Log.d("test", "성공!") }
+            .onSuccess {
+                cancelTimer()
+                _isConfirmAuthCode.value = true
+            }
             .onFailure { Log.d("test", "실패! ${it}") }
     }
 

--- a/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpViewModel.kt
@@ -7,6 +7,7 @@ import com.idle.domain.model.auth.BusinessRegistrationInfo
 import com.idle.domain.usecase.auth.ConfirmAuthCodeUseCase
 import com.idle.domain.usecase.auth.SendPhoneNumberUseCase
 import com.idle.domain.usecase.auth.SignUpCenterUseCase
+import com.idle.domain.usecase.auth.CountDownTimer
 import com.idle.domain.usecase.auth.ValidateBusinessRegistrationNumberUseCase
 import com.idle.domain.usecase.auth.ValidateIdentifierUseCase
 import com.idle.signin.center.CenterSignUpProcess.NAME
@@ -25,6 +26,7 @@ class CenterSignUpViewModel @Inject constructor(
     private val signUpCenterUseCase: SignUpCenterUseCase,
     private val validateIdentifierUseCase: ValidateIdentifierUseCase,
     private val validateBusinessRegistrationNumberUseCase: ValidateBusinessRegistrationNumberUseCase,
+    private val countDownTimer: CountDownTimer,
 ) : ViewModel() {
     private val _eventFlow = MutableSharedFlow<CenterSignUpEvent>()
     val eventFlow = _eventFlow.asSharedFlow()
@@ -37,6 +39,9 @@ class CenterSignUpViewModel @Inject constructor(
 
     private val _centerPhoneNumber = MutableStateFlow("")
     val centerPhoneNumber = _centerPhoneNumber.asStateFlow()
+
+    private val _centerAuthCodeTimer = MutableStateFlow<Long?>(null)
+    val centerAuthCodeTimer = _centerAuthCodeTimer.asStateFlow()
 
     private val _centerAuthCode = MutableStateFlow("")
     val centerConfirmNumber = _centerAuthCode.asStateFlow()
@@ -97,6 +102,10 @@ class CenterSignUpViewModel @Inject constructor(
         sendPhoneNumberUseCase(_centerPhoneNumber.value)
             .onSuccess { Log.d("test", "성공!") }
             .onFailure { Log.d("test", "실패! ${it}") }
+    }
+
+    internal fun startTimer() = viewModelScope.launch {
+
     }
 
     internal fun confirmAuthCode() = viewModelScope.launch {

--- a/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpViewModel.kt
@@ -136,5 +136,5 @@ sealed class CenterSignUpEvent {
 }
 
 enum class CenterSignUpProcess(val step: Int) {
-    NAME(1), PHONE_NUMBER(2), BUSINESS_REGISTRAION_NUMBER(3), ID_PASSWORD(4)
+    NAME(1), PHONE_NUMBER(2), BUSINESS_REGISTRATION_NUMBER(3), ID_PASSWORD(4)
 }

--- a/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpViewModel.kt
@@ -60,18 +60,21 @@ class CenterSignUpViewModel @Inject constructor(
     private val _businessRegistrationNumber = MutableStateFlow("")
     val businessRegistrationNumber = _businessRegistrationNumber.asStateFlow()
 
+    private val _businessRegistrationInfo: MutableStateFlow<BusinessRegistrationInfo?> =
+        MutableStateFlow(null)
+    val businessRegistrationInfo = _businessRegistrationInfo.asStateFlow()
+
     private val _centerId = MutableStateFlow("")
     val centerId = _centerId.asStateFlow()
+
+    private val _centerIdResult = MutableStateFlow(false)
+    val centerIdResult = _centerIdResult.asStateFlow()
 
     private val _centerPassword = MutableStateFlow("")
     val centerPassword = _centerPassword.asStateFlow()
 
     private val _centerPasswordForConfirm = MutableStateFlow("")
     val centerPasswordForConfirm = _centerPasswordForConfirm.asStateFlow()
-
-    private val _businessRegistrationInfo: MutableStateFlow<BusinessRegistrationInfo?> =
-        MutableStateFlow(null)
-    val businessRegistrationInfo = _businessRegistrationInfo.asStateFlow()
 
     internal fun event(event: CenterSignUpEvent) = viewModelScope.launch {
         _eventFlow.emit(event)
@@ -95,10 +98,12 @@ class CenterSignUpViewModel @Inject constructor(
 
     internal fun setBusinessRegistrationNumber(businessRegistrationNumber: String) {
         _businessRegistrationNumber.value = businessRegistrationNumber
+        _businessRegistrationInfo.value = null
     }
 
     internal fun setCenterId(id: String) {
         _centerId.value = id
+        _centerIdResult.value = false
     }
 
     internal fun setCenterPassword(password: String) {
@@ -165,7 +170,7 @@ class CenterSignUpViewModel @Inject constructor(
 
     internal fun validateIdentifier() = viewModelScope.launch {
         validateIdentifierUseCase(_centerId.value)
-            .onSuccess { Log.d("test", "성공!") }
+            .onSuccess { _centerIdResult.value = true }
             .onFailure { Log.d("test", it.toString()) }
     }
 

--- a/feature/signup/src/main/java/com/idle/signup/center/process/BusinessRegistrationScreen.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/process/BusinessRegistrationScreen.kt
@@ -15,10 +15,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -44,7 +41,6 @@ internal fun BusinessRegistrationScreen(
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusRequester = remember { FocusRequester() }
-    var forTest by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
@@ -76,7 +72,11 @@ internal fun BusinessRegistrationScreen(
                     value = businessRegistrationNumber,
                     hint = "사업자 등록번호를 입력해주세요.",
                     onValueChanged = onBusinessRegistrationNumberChanged,
-                    onDone = { forTest = true },
+                    onDone = {
+                        if (businessRegistrationNumber.isNotBlank()) {
+                            validateBusinessRegistrationNumber()
+                        }
+                    },
                     modifier = Modifier.weight(1f)
                         .focusRequester(focusRequester),
                 )

--- a/feature/signup/src/main/java/com/idle/signup/center/process/BusinessRegistrationScreen.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/process/BusinessRegistrationScreen.kt
@@ -64,7 +64,7 @@ internal fun BusinessRegistrationScreen(
             verticalArrangement = Arrangement.spacedBy(6.dp, Alignment.CenterVertically),
         ) {
             Row(
-                verticalAlignment = Alignment.CenterVertically,
+                verticalAlignment = Alignment.Top,
                 horizontalArrangement = Arrangement.spacedBy(4.dp),
                 modifier = Modifier.fillMaxWidth()
             ) {

--- a/feature/signup/src/main/java/com/idle/signup/center/process/CenterNameScreen.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/process/CenterNameScreen.kt
@@ -46,7 +46,11 @@ internal fun CenterNameScreen(
             value = centerName,
             hint = "성함을 입력해주세요.",
             onValueChanged = onCenterNameChanged,
-            onDone = { setSignUpProcess(CenterSignUpProcess.PHONE_NUMBER) },
+            onDone = {
+                if (centerName.isNotBlank()) {
+                    setSignUpProcess(CenterSignUpProcess.PHONE_NUMBER)
+                }
+            },
             modifier = Modifier.fillMaxWidth()
                 .focusRequester(focusRequester)
         )

--- a/feature/signup/src/main/java/com/idle/signup/center/process/CenterPhoneNumberScreen.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/process/CenterPhoneNumberScreen.kt
@@ -3,10 +3,12 @@ package com.idle.signup.center.process
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -28,6 +30,7 @@ internal fun CenterPhoneNumberScreen(
     centerAuthCodeTimerMinute: String,
     centerAuthCodeTimerSeconds: String,
     centerAuthCode: String,
+    isConfirmAuthCode: Boolean,
     onCenterPhoneNumberChanged: (String) -> Unit,
     onCenterAuthCodeChanged: (String) -> Unit,
     setSignUpProcess: (CenterSignUpProcess) -> Unit,
@@ -66,19 +69,22 @@ internal fun CenterPhoneNumberScreen(
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(4.dp),
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
             ) {
                 CareTextField(
                     value = centerPhoneNumber,
                     hint = "전화번호를 입력해주세요.",
                     onValueChanged = onCenterPhoneNumberChanged,
+                    readOnly = (centerAuthCodeTimerMinute != "" && centerAuthCodeTimerSeconds != ""),
+                    supportingText = if (isConfirmAuthCode) "인증이 완료되었습니다." else "",
                     onDone = { sendPhoneNumber() },
                     modifier = Modifier.weight(1f)
                         .focusRequester(focusRequester),
                 )
 
                 CareButtonSmall(
-                    enable = centerPhoneNumber.length == 13,
+                    enable = centerPhoneNumber.length == 11 &&
+                            !(centerAuthCodeTimerMinute != "" && centerAuthCodeTimerSeconds != ""),
                     text = "인증",
                     onClick = sendPhoneNumber,
                 )
@@ -99,12 +105,18 @@ internal fun CenterPhoneNumberScreen(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(4.dp),
                 modifier = Modifier.fillMaxWidth()
+                    .height(IntrinsicSize.Min),
             ) {
                 CareTextField(
                     value = centerAuthCode,
                     hint = "",
                     onValueChanged = onCenterAuthCodeChanged,
-                    onDone = { confirmAuthCode() },
+                    readOnly = !(centerAuthCodeTimerMinute != "" && centerAuthCodeTimerSeconds != ""),
+                    onDone = {
+                        if (centerAuthCode.isNotBlank()) {
+                            confirmAuthCode()
+                        }
+                    },
                     leftComponent = {
                         if (centerAuthCodeTimerMinute != "" && centerAuthCodeTimerSeconds != "") {
                             Text(
@@ -129,7 +141,7 @@ internal fun CenterPhoneNumberScreen(
 
         CareButtonLarge(
             text = "다음",
-            enable = centerAuthCode.isNotBlank(),
+            enable = isConfirmAuthCode,
             onClick = { setSignUpProcess(CenterSignUpProcess.BUSINESS_REGISTRATION_NUMBER) },
             modifier = Modifier.fillMaxWidth(),
         )

--- a/feature/signup/src/main/java/com/idle/signup/center/process/CenterPhoneNumberScreen.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/process/CenterPhoneNumberScreen.kt
@@ -119,7 +119,7 @@ internal fun CenterPhoneNumberScreen(
         CareButtonLarge(
             text = "다음",
             enable = centerAuthCode.isNotBlank(),
-            onClick = { setSignUpProcess(CenterSignUpProcess.BUSINESS_REGISTRAION_NUMBER) },
+            onClick = { setSignUpProcess(CenterSignUpProcess.BUSINESS_REGISTRATION_NUMBER) },
             modifier = Modifier.fillMaxWidth(),
         )
     }

--- a/feature/signup/src/main/java/com/idle/signup/center/process/CenterPhoneNumberScreen.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/process/CenterPhoneNumberScreen.kt
@@ -25,6 +25,7 @@ import com.idle.signin.center.CenterSignUpProcess
 @Composable
 internal fun CenterPhoneNumberScreen(
     centerPhoneNumber: String,
+    centerAuthCodeTimer: Long?,
     centerAuthCode: String,
     onCenterPhoneNumberChanged: (String) -> Unit,
     onCenterAuthCodeChanged: (String) -> Unit,
@@ -103,6 +104,11 @@ internal fun CenterPhoneNumberScreen(
                     hint = "",
                     onValueChanged = onCenterAuthCodeChanged,
                     onDone = { confirmAuthCode() },
+                    leftComponent = {
+                        if (centerAuthCodeTimer != null) {
+                            Text(text = centerAuthCodeTimer.toString())
+                        }
+                    },
                     modifier = Modifier.weight(1f),
                 )
 

--- a/feature/signup/src/main/java/com/idle/signup/center/process/CenterPhoneNumberScreen.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/process/CenterPhoneNumberScreen.kt
@@ -25,7 +25,8 @@ import com.idle.signin.center.CenterSignUpProcess
 @Composable
 internal fun CenterPhoneNumberScreen(
     centerPhoneNumber: String,
-    centerAuthCodeTimer: Long?,
+    centerAuthCodeTimerMinute: String,
+    centerAuthCodeTimerSeconds: String,
     centerAuthCode: String,
     onCenterPhoneNumberChanged: (String) -> Unit,
     onCenterAuthCodeChanged: (String) -> Unit,
@@ -105,8 +106,12 @@ internal fun CenterPhoneNumberScreen(
                     onValueChanged = onCenterAuthCodeChanged,
                     onDone = { confirmAuthCode() },
                     leftComponent = {
-                        if (centerAuthCodeTimer != null) {
-                            Text(text = centerAuthCodeTimer.toString())
+                        if (centerAuthCodeTimerMinute != "" && centerAuthCodeTimerSeconds != "") {
+                            Text(
+                                text = "$centerAuthCodeTimerMinute:$centerAuthCodeTimerSeconds",
+                                style = CareTheme.typography.body3,
+                                color = CareTheme.colors.gray500,
+                            )
                         }
                     },
                     modifier = Modifier.weight(1f),

--- a/feature/signup/src/main/java/com/idle/signup/center/process/CenterPhoneNumberScreen.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/process/CenterPhoneNumberScreen.kt
@@ -116,8 +116,7 @@ internal fun CenterPhoneNumberScreen(
             Row(
                 verticalAlignment = Alignment.Top,
                 horizontalArrangement = Arrangement.spacedBy(4.dp),
-                modifier = Modifier.fillMaxWidth()
-                    .height(IntrinsicSize.Min),
+                modifier = Modifier.fillMaxWidth(),
             ) {
                 CareTextField(
                     value = centerAuthCode,

--- a/feature/signup/src/main/java/com/idle/signup/center/process/CenterPhoneNumberScreen.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/process/CenterPhoneNumberScreen.kt
@@ -80,7 +80,7 @@ internal fun CenterPhoneNumberScreen(
             )
 
             Row(
-                verticalAlignment = Alignment.CenterVertically,
+                verticalAlignment = Alignment.Top,
                 horizontalArrangement = Arrangement.spacedBy(4.dp),
                 modifier = Modifier.fillMaxWidth(),
             ) {
@@ -105,7 +105,7 @@ internal fun CenterPhoneNumberScreen(
 
         Column(
             horizontalAlignment = Alignment.Start,
-            verticalArrangement = Arrangement.spacedBy(6.dp, Alignment.CenterVertically),
+            verticalArrangement = Arrangement.spacedBy(6.dp, Alignment.Top),
         ) {
             Text(
                 text = "인증번호",

--- a/feature/signup/src/main/java/com/idle/signup/center/process/IdPasswordScreen.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/process/IdPasswordScreen.kt
@@ -49,7 +49,7 @@ internal fun IdPasswordScreen(
         focusRequester.requestFocus()
     }
 
-    BackHandler { setSignUpProcess(CenterSignUpProcess.BUSINESS_REGISTRAION_NUMBER) }
+    BackHandler { setSignUpProcess(CenterSignUpProcess.BUSINESS_REGISTRATION_NUMBER) }
 
     Column(
         horizontalAlignment = Alignment.Start,

--- a/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpFragment.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpFragment.kt
@@ -1,6 +1,12 @@
 package com.idle.signin.worker
 
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -125,36 +131,50 @@ internal fun WorkerSignUpScreen(
                 modifier = Modifier.fillMaxWidth(),
             )
 
-            when (signUpProcess) {
-                WorkerSignUpProcess.NAME -> WorkerNameScreen(
-                    workerName = workerName,
-                    onWorkerNameChanged = onWorkerNameChanged,
-                    setSignUpProcess = setSignUpProcess
-                )
+            AnimatedContent(
+                targetState = signUpProcess,
+                transitionSpec = {
+                    if (targetState.ordinal > initialState.ordinal) {
+                        slideInHorizontally(initialOffsetX = { it }) + fadeIn() togetherWith
+                                slideOutHorizontally(targetOffsetX = { -it }) + fadeOut()
+                    } else {
+                        slideInHorizontally(initialOffsetX = { -it }) + fadeIn() togetherWith
+                                slideOutHorizontally(targetOffsetX = { it }) + fadeOut()
+                    }
+                },
+                label = "요양 보호사의 회원가입을 관리하는 애니메이션",
+            ) { signUpProcess ->
+                when (signUpProcess) {
+                    WorkerSignUpProcess.NAME -> WorkerNameScreen(
+                        workerName = workerName,
+                        onWorkerNameChanged = onWorkerNameChanged,
+                        setSignUpProcess = setSignUpProcess
+                    )
 
-                WorkerSignUpProcess.GENDER -> GenderScreen(
-                    gender = gender,
-                    onGenderChanged = onGenderChanged,
-                    setSignUpProcess = setSignUpProcess
-                )
+                    WorkerSignUpProcess.GENDER -> GenderScreen(
+                        gender = gender,
+                        onGenderChanged = onGenderChanged,
+                        setSignUpProcess = setSignUpProcess
+                    )
 
-                WorkerSignUpProcess.PHONE_NUMBER -> WorkerPhoneNumberScreen(
-                    workerPhoneNumber = workerPhoneNumber,
-                    workerAuthCode = workerAuthCode,
-                    onWorkerPhoneNumberChanged = onWorkerPhoneNumberChanged,
-                    onWorkerAuthCodeChanged = onWorkerAuthCodeChanged,
-                    setSignUpProcess = setSignUpProcess,
-                    sendPhoneNumber = sendPhoneNumber,
-                    confirmAuthCode = confirmAuthCode,
-                )
+                    WorkerSignUpProcess.PHONE_NUMBER -> WorkerPhoneNumberScreen(
+                        workerPhoneNumber = workerPhoneNumber,
+                        workerAuthCode = workerAuthCode,
+                        onWorkerPhoneNumberChanged = onWorkerPhoneNumberChanged,
+                        onWorkerAuthCodeChanged = onWorkerAuthCodeChanged,
+                        setSignUpProcess = setSignUpProcess,
+                        sendPhoneNumber = sendPhoneNumber,
+                        confirmAuthCode = confirmAuthCode,
+                    )
 
-                WorkerSignUpProcess.ADDRESS -> AddressScreen(
-                    address = address,
-                    addressDetail = addressDetail,
-                    onAddressChanged = onAddressChanged,
-                    onAddressDetailChanged = onAddressDetailChanged,
-                    setSignUpProcess = setSignUpProcess,
-                )
+                    WorkerSignUpProcess.ADDRESS -> AddressScreen(
+                        address = address,
+                        addressDetail = addressDetail,
+                        onAddressChanged = onAddressChanged,
+                        onAddressDetailChanged = onAddressDetailChanged,
+                        setSignUpProcess = setSignUpProcess,
+                    )
+                }
             }
         }
     }

--- a/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpFragment.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpFragment.kt
@@ -16,6 +16,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -51,7 +53,10 @@ internal class WorkerSignUpFragment : BaseComposeFragment() {
             val signUpProcess by signUpProcess.collectAsStateWithLifecycle()
             val workerName by workerName.collectAsStateWithLifecycle()
             val workerPhoneNumber by workerPhoneNumber.collectAsStateWithLifecycle()
+            val workerAuthCodeTimerMinute by workerAuthCodeTimerMinute.collectAsStateWithLifecycle()
+            val workerAuthCodeTimerSeconds by workerAuthCodeTimerSeconds.collectAsStateWithLifecycle()
             val workerAuthCode by workerAuthCode.collectAsStateWithLifecycle()
+            val isConfirmAuthCode by isConfirmAuthCode.collectAsStateWithLifecycle()
             val gender by gender.collectAsStateWithLifecycle()
             val address by address.collectAsStateWithLifecycle()
             val addressDetail by addressDetail.collectAsStateWithLifecycle()
@@ -60,7 +65,10 @@ internal class WorkerSignUpFragment : BaseComposeFragment() {
                 signUpProcess = signUpProcess,
                 workerName = workerName,
                 workerPhoneNumber = workerPhoneNumber,
+                workerAuthCodeTimerMinute = workerAuthCodeTimerMinute,
+                workerAuthCodeTimerSeconds = workerAuthCodeTimerSeconds,
                 workerAuthCode = workerAuthCode,
+                isConfirmAuthCode = isConfirmAuthCode,
                 gender = gender,
                 address = address,
                 addressDetail = addressDetail,
@@ -89,7 +97,10 @@ internal fun WorkerSignUpScreen(
     signUpProcess: WorkerSignUpProcess,
     workerName: String,
     workerPhoneNumber: String,
+    workerAuthCodeTimerMinute: String,
+    workerAuthCodeTimerSeconds: String,
     workerAuthCode: String,
+    isConfirmAuthCode: Boolean,
     gender: Gender,
     address: String,
     addressDetail: String,
@@ -105,6 +116,7 @@ internal fun WorkerSignUpScreen(
 ) {
     val onBackPressedDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
     val focusManager = LocalFocusManager.current
+    val (addressProcessed, setAddressProcessed)     = remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -159,12 +171,17 @@ internal fun WorkerSignUpScreen(
 
                     WorkerSignUpProcess.PHONE_NUMBER -> WorkerPhoneNumberScreen(
                         workerPhoneNumber = workerPhoneNumber,
+                        workerAuthCodeTimerMinute = workerAuthCodeTimerMinute,
+                        workerAuthCodeTimerSeconds = workerAuthCodeTimerSeconds,
                         workerAuthCode = workerAuthCode,
+                        isConfirmAuthCode = isConfirmAuthCode,
+                        addressProcessed = addressProcessed,
                         onWorkerPhoneNumberChanged = onWorkerPhoneNumberChanged,
                         onWorkerAuthCodeChanged = onWorkerAuthCodeChanged,
                         setSignUpProcess = setSignUpProcess,
                         sendPhoneNumber = sendPhoneNumber,
                         confirmAuthCode = confirmAuthCode,
+                        setAddressProcessed = setAddressProcessed,
                     )
 
                     WorkerSignUpProcess.ADDRESS -> AddressScreen(

--- a/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpFragment.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpFragment.kt
@@ -116,6 +116,7 @@ internal fun WorkerSignUpScreen(
 ) {
     val onBackPressedDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
     val focusManager = LocalFocusManager.current
+    val (phoneNumberProcessed, setPhoneNumberProcessed)     = remember { mutableStateOf(false) }
     val (addressProcessed, setAddressProcessed)     = remember { mutableStateOf(false) }
 
     Scaffold(
@@ -165,8 +166,10 @@ internal fun WorkerSignUpScreen(
 
                     WorkerSignUpProcess.GENDER -> GenderScreen(
                         gender = gender,
+                        phoneNumberProcessed = phoneNumberProcessed,
                         onGenderChanged = onGenderChanged,
-                        setSignUpProcess = setSignUpProcess
+                        setSignUpProcess = setSignUpProcess,
+                        setPhoneNumberProcessed = setPhoneNumberProcessed,
                     )
 
                     WorkerSignUpProcess.PHONE_NUMBER -> WorkerPhoneNumberScreen(

--- a/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpViewModel.kt
@@ -8,6 +8,7 @@ import com.idle.domain.usecase.auth.ConfirmAuthCodeUseCase
 import com.idle.domain.usecase.auth.SendPhoneNumberUseCase
 import com.idle.signin.worker.WorkerSignUpProcess.NAME
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow

--- a/feature/signup/src/main/java/com/idle/signup/worker/process/GenderScreen.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/process/GenderScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -21,10 +22,19 @@ import com.idle.signin.worker.WorkerSignUpProcess
 @Composable
 internal fun GenderScreen(
     gender: Gender,
+    phoneNumberProcessed: Boolean,
     onGenderChanged: (Gender) -> Unit,
     setSignUpProcess: (WorkerSignUpProcess) -> Unit,
+    setPhoneNumberProcessed: (Boolean) -> Unit,
 ) {
     BackHandler { setSignUpProcess(WorkerSignUpProcess.NAME) }
+
+    LaunchedEffect(gender) {
+        if (gender != Gender.NONE && !phoneNumberProcessed) {
+            setSignUpProcess(WorkerSignUpProcess.PHONE_NUMBER)
+            setPhoneNumberProcessed(true)
+        }
+    }
 
     Column(
         horizontalAlignment = Alignment.Start,

--- a/feature/signup/src/main/java/com/idle/signup/worker/process/WorkerNameScreen.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/process/WorkerNameScreen.kt
@@ -46,7 +46,7 @@ internal fun WorkerNameScreen(
             value = workerName,
             hint = "성함을 입력해주세요.",
             onValueChanged = onWorkerNameChanged,
-            onDone = { setSignUpProcess(WorkerSignUpProcess.GENDER) },
+            onDone = { if(workerName.isNotBlank()) setSignUpProcess(WorkerSignUpProcess.GENDER) },
             modifier = Modifier.fillMaxWidth()
                 .focusRequester(focusRequester)
         )
@@ -56,7 +56,7 @@ internal fun WorkerNameScreen(
         CareButtonLarge(
             text = "다음",
             enable = workerName.isNotBlank(),
-            onClick = { setSignUpProcess(WorkerSignUpProcess.GENDER) },
+            onClick = { if(workerName.isNotBlank()) setSignUpProcess(WorkerSignUpProcess.GENDER) },
             modifier = Modifier.fillMaxWidth(),
         )
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,6 +74,7 @@ ktlint = "12.1.1"
 googleServices = "4.4.2"
 firebaseBom = "33.1.1"
 material = "1.12.0"
+junitJupiter = "5.8.1"
 
 [libraries]
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
@@ -88,6 +89,7 @@ androidx-lifecycle-viewModel = { group = "androidx.lifecycle", name = "lifecycle
 androidx-navigation-safeArgs = { module = "androidx.navigation:navigation-safe-args-gradle-plugin", version.ref = "androidxNavigation" }
 androidx-navigation-fragment = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "androidxNavigation" }
 androidx-navigation-ui = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "androidxNavigation" }
+androidx-datastore = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "androidxDatastore" }
 
 androidx-lifecycle-runtimeCompose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidxLifecycle" }
 androidx-lifecycle-viewModelCompose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "androidxLifecycle" }
@@ -119,6 +121,7 @@ androidx-test-ext = { group = "androidx.test.ext", name = "junit-ktx", version.r
 androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidxEspresso" }
 kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version.ref = "junitJupiter" }
 
 coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutine" }
 coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutine" }
@@ -128,7 +131,6 @@ firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.r
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
 
 # plugin
-androidx-datastore = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "androidxDatastore" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 
 [bundles]


### PR DESCRIPTION
## 1. 🔥 변경된 내용

- **타이머 구현 및 UI 적용**
- **센터장, 요양보호사 회원가입 UI 완성**

## 2. 📸 스크린샷(선택)

**센터장 회원가입 Flow**

![2024-07-1612 08 29-ezgif com-resize](https://github.com/user-attachments/assets/a5b11869-7164-4f55-a116-fb5a9a40cb59)

<br><br><br>

**요양보호사 회원가입 Flow**
![2024-07-1612 08 29-ezgif com-resize (1)](https://github.com/user-attachments/assets/66d4e1fd-f0cf-4520-b701-f3a531dae437)
## 3. 💡 알게된 부분

### ProxyMan 사용법을 알게되었습니다!

PR에 서술할만큼 따로 스스로 공부해야할 부분이 없고 프록시맨에서 시키는대로 하면 가능했습니다.

또한 오고가는 패킷을 인터셉트하여 `tools -> Map Local`을 이용하여 응답 값을 Mocking 하는 방법을 알게되었습니다.

아래 사진은 400으로 떨어지는 응답을 강제로 204 응답으로 Mocking하는 스크린샷 입니다.

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/63b3a609-524e-4c19-b8b9-5b66eda1879d">

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/e79cbd4e-ba3f-4a7b-b7de-0889322b8c33">

## 4. 🫡 궁금한 부분

## 5. 📌 이 부분은 꼭 봐주세요!