### PR TITLE
[IDLE-225] Fragment에서 Context를 사용하던 것 data레이어에서 처리하도록 변경

### DIFF
--- a/core/data/src/main/java/com/idle/data/di/DataModule.kt
+++ b/core/data/src/main/java/com/idle/data/di/DataModule.kt
@@ -31,8 +31,8 @@ abstract class DataModule {
 
     @Binds
     @Singleton
-    abstract fun bindsCenterProfileRepository(
-        centerProfileRepositoryImpl: ProfileRepositoryImpl
+    abstract fun bindsProfileRepository(
+        profileRepositoryImpl: ProfileRepositoryImpl
     ): ProfileRepository
 
     @Binds

--- a/core/domain/src/main/kotlin/com/idle/domain/model/profile/ImageFileInfo.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/model/profile/ImageFileInfo.kt
@@ -1,11 +1,8 @@
 package com.idle.domain.model.profile
 
-import java.io.InputStream
-
 data class ImageFileInfo(
     val imageUrl: String,
     val imageFileExtension: MIMEType,
-    val imageInputStream: InputStream,
 )
 
 enum class MIMEType(val value: String) {

--- a/core/domain/src/main/kotlin/com/idle/domain/model/profile/MIMEType.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/model/profile/MIMEType.kt
@@ -1,10 +1,5 @@
 package com.idle.domain.model.profile
 
-data class ImageFileInfo(
-    val imageUrl: String,
-    val imageFileExtension: MIMEType,
-)
-
 enum class MIMEType(val value: String) {
     JPG("image/jpeg"),
     PNG("image/png"),

--- a/core/domain/src/main/kotlin/com/idle/domain/repositorry/profile/ProfileRepository.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/repositorry/profile/ProfileRepository.kt
@@ -1,7 +1,6 @@
 package com.idle.domain.repositorry.profile
 
 import com.idle.domain.model.profile.CenterProfile
-import com.idle.domain.model.profile.ImageFileInfo
 
 interface ProfileRepository {
     suspend fun getMyCenterProfile(): Result<CenterProfile>
@@ -10,6 +9,6 @@ interface ProfileRepository {
 
     suspend fun updateProfileImage(
         userType: String,
-        imageFileInfo: ImageFileInfo,
+        imageFileUri: String,
     ): Result<Unit>
 }

--- a/core/domain/src/main/kotlin/com/idle/domain/usecase/profile/UpdateCenterProfileUseCase.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/usecase/profile/UpdateCenterProfileUseCase.kt
@@ -1,7 +1,6 @@
 package com.idle.domain.usecase.profile
 
 import com.idle.domain.model.auth.UserRole
-import com.idle.domain.model.profile.ImageFileInfo
 import com.idle.domain.repositorry.profile.ProfileRepository
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -13,7 +12,7 @@ class UpdateCenterProfileUseCase @Inject constructor(
     suspend operator fun invoke(
         officeNumber: String,
         introduce: String?,
-        imageFileInfo: ImageFileInfo?,
+        imageFileUri: String?,
     ): Result<Unit> = runCatching {
         coroutineScope {
             val updateProfileDeferred = async {
@@ -23,11 +22,11 @@ class UpdateCenterProfileUseCase @Inject constructor(
                 ).getOrThrow()
             }
 
-            val updateProfileImageDeferred = imageFileInfo?.let {
+            val updateProfileImageDeferred = imageFileUri?.let {
                 async {
                     profileRepository.updateProfileImage(
                         userType = UserRole.CENTER.apiValue,
-                        imageFileInfo = it,
+                        imageFileUri = imageFileUri,
                     ).getOrThrow()
                 }
             }

--- a/core/network/src/main/java/com/idle/network/source/CenterProfileDataSource.kt
+++ b/core/network/src/main/java/com/idle/network/source/CenterProfileDataSource.kt
@@ -1,6 +1,5 @@
 package com.idle.network.source
 
-import com.idle.domain.model.profile.ImageFileInfo
 import com.idle.network.api.CareNetworkApi
 import com.idle.network.model.profile.CallbackImageUploadRequest
 import com.idle.network.model.profile.CenterProfileRequest
@@ -9,6 +8,7 @@ import com.idle.network.model.profile.ProfileImageUploadUrlResponse
 import com.idle.network.util.onResponse
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.InputStream
 import javax.inject.Inject
 
 class CenterProfileDataSource @Inject constructor(
@@ -30,12 +30,11 @@ class CenterProfileDataSource @Inject constructor(
 
     suspend fun uploadProfileImage(
         uploadUrl: String,
-        imageFileInfo: ImageFileInfo,
+        imageFileExtension: String,
+        imageInputStream: InputStream,
     ): Result<Unit> {
-        val requestImage = imageFileInfo.run {
-            imageInputStream.readBytes()
-                .toRequestBody(imageFileExtension.value.toMediaTypeOrNull())
-        }
+        val requestImage = imageInputStream.readBytes()
+            .toRequestBody(imageFileExtension.toMediaTypeOrNull())
 
         return careNetworkApi.uploadProfileImage(
             uploadUrl = uploadUrl,

--- a/feature/auth/src/main/java/com/idle/auth/AuthViewModel.kt
+++ b/feature/auth/src/main/java/com/idle/auth/AuthViewModel.kt
@@ -1,9 +1,7 @@
 package com.idle.auth
 
-import android.util.Log
 import androidx.lifecycle.viewModelScope
 import com.idle.binding.base.BaseViewModel
-import com.idle.binding.base.CareBaseEvent
 import com.idle.binding.base.CareBaseEvent.NavigateTo
 import com.idle.domain.usecase.auth.GetAccessTokenUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -19,15 +17,14 @@ class AuthViewModel @Inject constructor(
     fun handleTokenNavigation(
         defaultDestination: NavigateTo,
         authenticatedDestination: NavigateTo
-    ) =
-        viewModelScope.launch(Dispatchers.IO) {
-            val accessToken = getAccessTokenUseCase()
+    ) = viewModelScope.launch(Dispatchers.IO) {
+        val accessToken = getAccessTokenUseCase()
 
-            if (accessToken.isNotBlank()) {
-                baseEvent(authenticatedDestination)
-                return@launch
-            }
-
-            baseEvent(defaultDestination)
+        if (accessToken.isNotBlank()) {
+            baseEvent(authenticatedDestination)
+            return@launch
         }
+
+        baseEvent(defaultDestination)
+    }
 }

--- a/feature/center/profile/src/main/java/com/idle/center/profile/CenterProfileViewModel.kt
+++ b/feature/center/profile/src/main/java/com/idle/center/profile/CenterProfileViewModel.kt
@@ -1,10 +1,10 @@
 package com.idle.center.profile
 
+import android.net.Uri
 import android.util.Log
 import androidx.lifecycle.viewModelScope
 import com.idle.binding.base.BaseViewModel
 import com.idle.domain.model.profile.CenterProfile
-import com.idle.domain.model.profile.ImageFileInfo
 import com.idle.domain.usecase.profile.GetMyCenterProfileUseCase
 import com.idle.domain.usecase.profile.UpdateCenterProfileUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -30,8 +30,8 @@ class CenterProfileViewModel @Inject constructor(
     private val _isEditState = MutableStateFlow(false)
     val isEditState = _isEditState.asStateFlow()
 
-    private val _profileImageFileInfo = MutableStateFlow<ImageFileInfo?>(null)
-    val profileImageFileInfo = _profileImageFileInfo.asStateFlow()
+    private val _profileImageUri = MutableStateFlow<Uri?>(null)
+    val profileImageUri = _profileImageUri.asStateFlow()
 
     init {
         getMyCenterProfile()
@@ -60,19 +60,19 @@ class CenterProfileViewModel @Inject constructor(
         updateCenterProfileUseCase(
             officeNumber = _centerOfficeNumber.value,
             introduce = _centerIntroduce.value.ifBlank { null },
-            imageFileInfo = _profileImageFileInfo.value,
+            imageFileUri = _profileImageUri.value.toString(),
         ).onSuccess {
             setEditState(false)
             Log.d("test", "업데이트 성공!")
         }.onFailure {
             Log.d("test", "업데이트 실패!")
-        }.also { _profileImageFileInfo.value?.imageInputStream?.close() }
+        }
     }
 
     private fun isCenterProfileUnchanged(): Boolean {
         return _centerOfficeNumber.value == _centerProfile.value.officeNumber &&
                 _centerIntroduce.value == _centerProfile.value.introduce &&
-                profileImageFileInfo.value == null
+                profileImageUri.value == null
     }
 
     fun setCenterOfficeNumber(number: String) {
@@ -87,7 +87,7 @@ class CenterProfileViewModel @Inject constructor(
         _isEditState.value = state
     }
 
-    fun setProfileImageUrl(imageFileInfo: ImageFileInfo) {
-        _profileImageFileInfo.value = imageFileInfo
+    fun setProfileImageUrl(uri: Uri?) {
+        _profileImageUri.value = uri
     }
 }


### PR DESCRIPTION
## 1. 🔥 변경된 내용
- **Fragment에서 이미지가 선택되자 마자 InputStream이 열리고, 수정 버튼을 누르기 전 까지 Stream이 닫히지 않던 것을,**
**data 레이어에서 실제로 이미지 파일을 업로드 할 때에만 Stream이 열리고 닫히도록 리팩토링 합니다.**

<br><br><br>

갤러리에서 이미지가 선택됨과 동시에 InputStream이 열리고,

수정 버튼을 누르기 전 까지 닫히지 않는 것이 너무나도 냄새가 나서,

**data 레이어**에서 **Application Context를 주입**받고 실제로 Stream을 사용할 때에만 `use{ }`를 사용하도록 변경합니다.

https://github.com/3IDLES/idle-android/pull/15
