### PR TITLE
[IDLE-226] 공고 상세화면 UI 놓친 부분 적용

### DIFF
--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/Button.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/Button.kt
@@ -149,7 +149,7 @@ fun CareButtonLine(
     ) {
         Text(
             text = text,
-            style = CareTheme.typography.body3,
+            style = CareTheme.typography.heading4,
             color = textColor,
         )
     }


### PR DESCRIPTION
## 1. 🔥 변경된 내용

- **추가 지원 정보와 경력 우대사항 간격 40px 였던 거 20px로 수정**
- **가장 위쪽 부분 양끝 맞춤 -> 간격 8px 으로 수정**
- **기관 정보 안에 위치 아이콘 변경**
- **지원하기, 문의하기 버튼 폰트 body3으로 되어있던거 heading4로 변경**
 
## 2. 📸 스크린샷(선택)

![image](https://github.com/user-attachments/assets/2b313899-6b57-4571-ba46-ad3f139be7e2)

![image](https://github.com/user-attachments/assets/1321f991-0e88-4252-a5e1-2cc899fa2a86)

![image](https://github.com/user-attachments/assets/d667411c-4406-49e9-9b9b-c39f301ba8b2)

![image](https://github.com/user-attachments/assets/d9736c60-ef07-4f2b-af8a-412b57d6fbf3)