### PR TITLE
[IDLE-92] 요양 보호사 회원가입 및 로그인 기능 연동

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
     id("care.android.application")
     id("care.android.binding")
@@ -9,6 +11,10 @@ android {
     defaultConfig {
         versionCode = 1
         versionName = "1.0"
+
+        val properties = Properties()
+        properties.load(project.rootProject.file("local.properties").bufferedReader())
+        manifestPlaceholders["NAVER_CLIENT_ID"] = properties["NAVER_CLIENT_ID"] as String
     }
 
     packaging {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <meta-data
+            android:name="com.naver.maps.map.CLIENT_ID"
+            android:value="${NAVER_CLIENT_ID}" />
     </application>
 
 </manifest>

--- a/core/common-ui/compose/src/main/java/com/idle/compose/base/BaseComposeFragment.kt
+++ b/core/common-ui/compose/src/main/java/com/idle/compose/base/BaseComposeFragment.kt
@@ -34,7 +34,13 @@ abstract class BaseComposeFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        viewLifecycleOwner.repeatOnStarted { fragmentViewModel.baseEventFlow.collect { handleEvent(it) } }
+        viewLifecycleOwner.repeatOnStarted {
+            fragmentViewModel.baseEventFlow.collect {
+                handleEvent(
+                    it
+                )
+            }
+        }
 
         composeView.setContent {
             ComposeLayout()
@@ -43,6 +49,10 @@ abstract class BaseComposeFragment : Fragment() {
 
     private fun handleEvent(event: CareBaseEvent) = when (event) {
         is CareBaseEvent.NavigateTo -> findNavController()
-            .deepLinkNavigateTo(requireContext(), event.destination)
+            .deepLinkNavigateTo(
+                context = requireContext(),
+                deepLinkDestination = event.destination,
+                popUpTo = event.popUpTo,
+            )
     }
 }

--- a/core/data/src/main/java/com/idle/data/repository/auth/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/idle/data/repository/auth/AuthRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.idle.domain.repositorry.auth.AuthRepository
 import com.idle.network.model.auth.ConfirmAuthCodeRequest
 import com.idle.network.model.auth.SendPhoneRequest
 import com.idle.network.model.auth.SignInCenterRequest
+import com.idle.network.model.auth.SignInWorkerRequest
 import com.idle.network.model.auth.SignUpCenterRequest
 import com.idle.network.model.auth.SignUpWorkerRequest
 import com.idle.network.source.AuthDataSource
@@ -90,5 +91,22 @@ class AuthRepositoryImpl @Inject constructor(
             longitude = longitude,
             latitude = latitude
         )
+    )
+
+    override suspend fun signInWorker(
+        phoneNumber: String,
+        authCode: String,
+    ): Result<Unit> = authDataSource.signInWorker(
+        SignInWorkerRequest(
+            phoneNumber = phoneNumber,
+            authCode = authCode,
+        )
+    ).fold(
+        onSuccess = { tokenResponse ->
+            tokenDataSource.setAccessToken(tokenResponse.accessToken)
+            tokenDataSource.setRefreshToken(tokenResponse.refreshToken)
+            return Result.success(Unit)
+        },
+        onFailure = { Result.failure(it) }
     )
 }

--- a/core/data/src/main/java/com/idle/data/repository/auth/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/idle/data/repository/auth/AuthRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.idle.network.model.auth.ConfirmAuthCodeRequest
 import com.idle.network.model.auth.SendPhoneRequest
 import com.idle.network.model.auth.SignInCenterRequest
 import com.idle.network.model.auth.SignUpCenterRequest
+import com.idle.network.model.auth.SignUpWorkerRequest
 import com.idle.network.source.AuthDataSource
 import javax.inject.Inject
 
@@ -48,7 +49,7 @@ class AuthRepositoryImpl @Inject constructor(
         authDataSource.signInCenter(
             SignInCenterRequest(
                 identifier = identifier,
-                password = password,
+                password = password
             )
         ).fold(
             onSuccess = { tokenResponse ->
@@ -68,4 +69,26 @@ class AuthRepositoryImpl @Inject constructor(
     ): Result<BusinessRegistrationInfo> =
         authDataSource.validateBusinessRegistrationNumber(businessRegistrationNumber)
             .mapCatching { it.toVO() }
+
+    override suspend fun signUpWorker(
+        name: String,
+        birthYear: Int,
+        genderType: String,
+        phoneNumber: String,
+        roadNameAddress: String,
+        lotNumberAddress: String,
+        longitude: String,
+        latitude: String,
+    ): Result<Unit> = authDataSource.signUpWorker(
+        SignUpWorkerRequest(
+            name = name,
+            birthYear = birthYear,
+            genderType = genderType,
+            phoneNumber = phoneNumber,
+            roadNameAddress = roadNameAddress,
+            lotNumberAddress = lotNumberAddress,
+            longitude = longitude,
+            latitude = latitude
+        )
+    )
 }

--- a/core/designsystem/compose/build.gradle.kts
+++ b/core/designsystem/compose/build.gradle.kts
@@ -10,5 +10,7 @@ android {
 dependencies {
     implementation(projects.core.commonUi.compose)
     implementation(projects.core.designresource)
+
     implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.naver.map)
 }

--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/Map.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/Map.kt
@@ -1,0 +1,60 @@
+package com.idle.designsystem.compose.component
+
+import android.os.Bundle
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import com.naver.maps.map.MapView
+import kotlinx.coroutines.launch
+
+
+@Composable
+fun CareMap(modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val coroutineScope = rememberCoroutineScope()
+
+    val mapView = MapView(context).apply {
+        getMapAsync { naverMap ->
+
+        }
+    }
+
+    // LifecycleEventObserver를 구현하고, 각 이벤트에 맞게 MapView의 Lifecycle 메소드를 호출합니다.
+    val lifecycleObserver = remember {
+        LifecycleEventObserver { _, event ->
+            coroutineScope.launch {
+                when (event) {
+                    Lifecycle.Event.ON_CREATE -> mapView.onCreate(Bundle())
+                    Lifecycle.Event.ON_START -> mapView.onStart()
+                    Lifecycle.Event.ON_RESUME -> mapView.onResume()
+                    Lifecycle.Event.ON_PAUSE -> mapView.onPause()
+                    Lifecycle.Event.ON_STOP -> mapView.onStop()
+                    Lifecycle.Event.ON_DESTROY -> mapView.onDestroy()
+                    Lifecycle.Event.ON_ANY -> Unit
+                }
+            }
+        }
+    }
+
+    // 뷰가 해제될 때 이벤트 리스너를 제거합니다.
+    DisposableEffect(true) {
+        lifecycleOwner.lifecycle.addObserver(lifecycleObserver)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(lifecycleObserver)
+        }
+    }
+
+    // 생성된 MapView 객체를 AndroidView로 Wrapping 합니다.
+    AndroidView(
+        factory = { mapView },
+        modifier = modifier,
+    )
+}

--- a/core/domain/src/main/kotlin/com/idle/domain/model/auth/Gender.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/model/auth/Gender.kt
@@ -1,0 +1,5 @@
+package com.idle.domain.model.auth
+
+enum class Gender(val displayName: String) {
+    MAN("남성"), WOMAN("여성"), NONE("")
+}

--- a/core/domain/src/main/kotlin/com/idle/domain/repositorry/auth/AuthRepository.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/repositorry/auth/AuthRepository.kt
@@ -24,4 +24,15 @@ interface AuthRepository {
 
     suspend fun validateBusinessRegistrationNumber(businessRegistrationNumber: String):
             Result<BusinessRegistrationInfo>
+
+    suspend fun signUpWorker(
+        name: String,
+        birthYear: Int,
+        genderType: String,
+        phoneNumber: String,
+        roadNameAddress: String,
+        lotNumberAddress: String,
+        longitude: String,
+        latitude: String,
+    ): Result<Unit>
 }

--- a/core/domain/src/main/kotlin/com/idle/domain/repositorry/auth/AuthRepository.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/repositorry/auth/AuthRepository.kt
@@ -35,4 +35,6 @@ interface AuthRepository {
         longitude: String,
         latitude: String,
     ): Result<Unit>
+
+    suspend fun signInWorker(phoneNumber: String, authCode: String): Result<Unit>
 }

--- a/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/SignInWorkerUseCase.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/SignInWorkerUseCase.kt
@@ -1,0 +1,13 @@
+package com.idle.domain.usecase.auth
+
+import com.idle.domain.repositorry.auth.AuthRepository
+import javax.inject.Inject
+
+class SignInWorkerUseCase @Inject constructor(
+    private val authRepository: AuthRepository,
+) {
+    suspend operator fun invoke(
+        phoneNumber: String,
+        authCode: String,
+    ) = authRepository.signInWorker(phoneNumber = phoneNumber, authCode = authCode)
+}

--- a/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/SignInWorkerUseCase.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/SignInWorkerUseCase.kt
@@ -9,5 +9,21 @@ class SignInWorkerUseCase @Inject constructor(
     suspend operator fun invoke(
         phoneNumber: String,
         authCode: String,
-    ) = authRepository.signInWorker(phoneNumber = phoneNumber, authCode = authCode)
+    ): Result<Unit> {
+        val formattedPhoneNumber = formatPhoneNumber(phoneNumber)
+
+        return authRepository.signInWorker(phoneNumber = formattedPhoneNumber, authCode = authCode)
+    }
+
+    private fun formatPhoneNumber(phoneNumber: String): String {
+        // 입력된 전화번호가 11자리 숫자인 경우에만 포맷팅을 적용
+        return if (phoneNumber.length == 11) {
+            phoneNumber.replaceFirst(
+                Regex("(\\d{3})(\\d{4})(\\d{4})"),
+                "$1-$2-$3"
+            )
+        } else {
+            phoneNumber  // 비정상적인 경우 원본 번호 반환
+        }
+    }
 }

--- a/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/SignUpCenterUseCase.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/SignUpCenterUseCase.kt
@@ -12,7 +12,7 @@ class SignUpCenterUseCase @Inject constructor(
         phoneNumber: String,
         managerName: String,
         businessRegistrationNumber: String,
-    ): Result<Unit> = runCatching {
+    ): Result<Unit> {
         val formattedPhoneNumber = formatPhoneNumber(phoneNumber)
         val formattedNumber = when (businessRegistrationNumber.length) {
             10 -> formatTenDigitNumber(businessRegistrationNumber)

--- a/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/SignUpWorkerUseCase.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/SignUpWorkerUseCase.kt
@@ -1,0 +1,44 @@
+package com.idle.domain.usecase.auth
+
+import com.idle.domain.repositorry.auth.AuthRepository
+import javax.inject.Inject
+
+class SignUpWorkerUseCase @Inject constructor(
+    private val authRepository: AuthRepository,
+) {
+    suspend operator fun invoke(
+        name: String,
+        birthYear: Int,
+        genderType: String,
+        phoneNumber: String,
+        roadNameAddress: String,
+        lotNumberAddress: String,
+        longitude: String,
+        latitude: String,
+    ): Result<Unit> {
+        val formattedPhoneNumber = formatPhoneNumber(phoneNumber)
+
+        return authRepository.signUpWorker(
+            name = name,
+            birthYear = birthYear,
+            genderType = genderType,
+            phoneNumber = formattedPhoneNumber,
+            roadNameAddress = roadNameAddress,
+            lotNumberAddress = lotNumberAddress,
+            longitude = longitude,
+            latitude = latitude,
+        )
+    }
+
+    private fun formatPhoneNumber(phoneNumber: String): String {
+        // 입력된 전화번호가 11자리 숫자인 경우에만 포맷팅을 적용
+        return if (phoneNumber.length == 11) {
+            phoneNumber.replaceFirst(
+                Regex("(\\d{3})(\\d{4})(\\d{4})"),
+                "$1-$2-$3"
+            )
+        } else {
+            phoneNumber  // 비정상적인 경우 원본 번호 반환
+        }
+    }
+}

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -19,7 +19,7 @@ android {
         buildConfigField(
             "String",
             "CARE_BASE_URL",
-            "\"${properties["care_base_url"]}\"",
+            "\"${properties["CARE_BASE_URL"]}\"",
         )
     }
 }

--- a/core/network/src/main/java/com/idle/network/api/CareNetworkApi.kt
+++ b/core/network/src/main/java/com/idle/network/api/CareNetworkApi.kt
@@ -5,6 +5,7 @@ import com.idle.network.model.auth.ConfirmAuthCodeRequest
 import com.idle.network.model.auth.SendPhoneRequest
 import com.idle.network.model.auth.SignInCenterRequest
 import com.idle.network.model.auth.SignUpCenterRequest
+import com.idle.network.model.auth.SignUpWorkerRequest
 import com.idle.network.model.profile.CallbackImageUploadRequest
 import com.idle.network.model.profile.CenterProfileRequest
 import com.idle.network.model.profile.CenterProfileResponse
@@ -67,4 +68,7 @@ interface CareNetworkApi {
         @Path("user-type") userType: String,
         @Body callbackImageUploadRequest: CallbackImageUploadRequest,
     ): Response<Unit>
+
+    @POST("/api/v1/auth/carer/join")
+    suspend fun signUpWorker(@Body signUpWorkerRequset: SignUpWorkerRequest): Response<Unit>
 }

--- a/core/network/src/main/java/com/idle/network/api/CareNetworkApi.kt
+++ b/core/network/src/main/java/com/idle/network/api/CareNetworkApi.kt
@@ -4,6 +4,7 @@ import com.idle.network.model.auth.BusinessRegistrationResponse
 import com.idle.network.model.auth.ConfirmAuthCodeRequest
 import com.idle.network.model.auth.SendPhoneRequest
 import com.idle.network.model.auth.SignInCenterRequest
+import com.idle.network.model.auth.SignInWorkerRequest
 import com.idle.network.model.auth.SignUpCenterRequest
 import com.idle.network.model.auth.SignUpWorkerRequest
 import com.idle.network.model.profile.CallbackImageUploadRequest
@@ -34,6 +35,12 @@ interface CareNetworkApi {
 
     @POST("/api/v1/auth/center/login")
     suspend fun signInCenter(@Body signInCenterRequest: SignInCenterRequest): Response<TokenResponse>
+
+    @POST("/api/v1/auth/carer/join")
+    suspend fun signUpWorker(@Body signUpWorkerRequest: SignUpWorkerRequest): Response<Unit>
+
+    @POST("/api/v1/auth/carer/login")
+    suspend fun signInWorker(@Body signInWorkerRequest: SignInWorkerRequest): Response<TokenResponse>
 
     @GET("/api/v1/auth/center/validation/{identifier}")
     suspend fun validateIdentifier(@Path("identifier") identifier: String): Response<Unit>
@@ -68,7 +75,4 @@ interface CareNetworkApi {
         @Path("user-type") userType: String,
         @Body callbackImageUploadRequest: CallbackImageUploadRequest,
     ): Response<Unit>
-
-    @POST("/api/v1/auth/carer/join")
-    suspend fun signUpWorker(@Body signUpWorkerRequset: SignUpWorkerRequest): Response<Unit>
 }

--- a/core/network/src/main/java/com/idle/network/api/NaverNetworkApi.kt
+++ b/core/network/src/main/java/com/idle/network/api/NaverNetworkApi.kt
@@ -1,0 +1,4 @@
+package com.idle.network.api
+
+interface NaverNetworkApi {
+}

--- a/core/network/src/main/java/com/idle/network/di/RetrofitModule.kt
+++ b/core/network/src/main/java/com/idle/network/di/RetrofitModule.kt
@@ -2,6 +2,7 @@ package com.idle.network.di
 
 import com.idle.network.BuildConfig
 import com.idle.network.api.CareNetworkApi
+import com.idle.network.api.NaverNetworkApi
 import com.idle.network.api.TokenNetworkApi
 import com.idle.network.token.TokenAuthenticator
 import com.idle.network.token.TokenInterceptor
@@ -83,4 +84,15 @@ object RetrofitModule {
         .baseUrl(BuildConfig.CARE_BASE_URL)
         .build()
         .create(TokenNetworkApi::class.java)
+
+    @Singleton
+    @Provides
+    fun providesNaverNetworkApi(
+        @Named("common") okHttpClient: OkHttpClient,
+    ): NaverNetworkApi = Retrofit.Builder()
+        .client(okHttpClient)
+        .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+        .baseUrl(BuildConfig.NAVER_BASE_URL)
+        .build()
+        .create(NaverNetworkApi::class.java)
 }

--- a/core/network/src/main/java/com/idle/network/di/RetrofitModule.kt
+++ b/core/network/src/main/java/com/idle/network/di/RetrofitModule.kt
@@ -2,7 +2,6 @@ package com.idle.network.di
 
 import com.idle.network.BuildConfig
 import com.idle.network.api.CareNetworkApi
-import com.idle.network.api.NaverNetworkApi
 import com.idle.network.api.TokenNetworkApi
 import com.idle.network.token.TokenAuthenticator
 import com.idle.network.token.TokenInterceptor
@@ -84,15 +83,4 @@ object RetrofitModule {
         .baseUrl(BuildConfig.CARE_BASE_URL)
         .build()
         .create(TokenNetworkApi::class.java)
-
-    @Singleton
-    @Provides
-    fun providesNaverNetworkApi(
-        @Named("common") okHttpClient: OkHttpClient,
-    ): NaverNetworkApi = Retrofit.Builder()
-        .client(okHttpClient)
-        .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
-        .baseUrl(BuildConfig.NAVER_BASE_URL)
-        .build()
-        .create(NaverNetworkApi::class.java)
 }

--- a/core/network/src/main/java/com/idle/network/model/auth/SignInWorkerRequest.kt
+++ b/core/network/src/main/java/com/idle/network/model/auth/SignInWorkerRequest.kt
@@ -1,0 +1,10 @@
+package com.idle.network.model.auth
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SignInWorkerRequest(
+    val phoneNumber: String,
+    @SerialName("verificationNumber") val authCode: String,
+)

--- a/core/network/src/main/java/com/idle/network/model/auth/SignUpWorkerRequest.kt
+++ b/core/network/src/main/java/com/idle/network/model/auth/SignUpWorkerRequest.kt
@@ -1,0 +1,16 @@
+package com.idle.network.model.auth
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SignUpWorkerRequest(
+    @SerialName("carerName") val name: String,
+    val birthYear: Int,
+    val genderType: String,
+    val phoneNumber: String,
+    val roadNameAddress: String,
+    val lotNumberAddress: String,
+    val longitude: String,
+    val latitude: String,
+)

--- a/core/network/src/main/java/com/idle/network/source/AuthDataSource.kt
+++ b/core/network/src/main/java/com/idle/network/source/AuthDataSource.kt
@@ -5,6 +5,7 @@ import com.idle.network.model.auth.BusinessRegistrationResponse
 import com.idle.network.model.auth.ConfirmAuthCodeRequest
 import com.idle.network.model.auth.SendPhoneRequest
 import com.idle.network.model.auth.SignInCenterRequest
+import com.idle.network.model.auth.SignInWorkerRequest
 import com.idle.network.model.auth.SignUpCenterRequest
 import com.idle.network.model.auth.SignUpWorkerRequest
 import com.idle.network.model.token.TokenResponse
@@ -26,6 +27,12 @@ class AuthDataSource @Inject constructor(
     suspend fun signInCenter(signInCenterRequest: SignInCenterRequest): Result<TokenResponse> =
         careNetworkApi.signInCenter(signInCenterRequest).onResponse()
 
+    suspend fun signUpWorker(signUpWorkerRequest: SignUpWorkerRequest): Result<Unit> =
+        careNetworkApi.signUpWorker(signUpWorkerRequest).onResponse()
+
+    suspend fun signInWorker(signInWorkerRequest: SignInWorkerRequest): Result<TokenResponse> =
+        careNetworkApi.signInWorker(signInWorkerRequest).onResponse()
+
     suspend fun validateIdentifier(identifier: String): Result<Unit> =
         careNetworkApi.validateIdentifier(identifier).onResponse()
 
@@ -33,7 +40,4 @@ class AuthDataSource @Inject constructor(
         businessRegistrationNumber: String
     ): Result<BusinessRegistrationResponse> =
         careNetworkApi.validateBusinessRegistrationNumber(businessRegistrationNumber).onResponse()
-
-    suspend fun signUpWorker(signUpWorkerRequest: SignUpWorkerRequest): Result<Unit> =
-        careNetworkApi.signUpWorker(signUpWorkerRequest).onResponse()
 }

--- a/core/network/src/main/java/com/idle/network/source/AuthDataSource.kt
+++ b/core/network/src/main/java/com/idle/network/source/AuthDataSource.kt
@@ -6,6 +6,7 @@ import com.idle.network.model.auth.ConfirmAuthCodeRequest
 import com.idle.network.model.auth.SendPhoneRequest
 import com.idle.network.model.auth.SignInCenterRequest
 import com.idle.network.model.auth.SignUpCenterRequest
+import com.idle.network.model.auth.SignUpWorkerRequest
 import com.idle.network.model.token.TokenResponse
 import com.idle.network.util.onResponse
 import javax.inject.Inject
@@ -32,4 +33,7 @@ class AuthDataSource @Inject constructor(
         businessRegistrationNumber: String
     ): Result<BusinessRegistrationResponse> =
         careNetworkApi.validateBusinessRegistrationNumber(businessRegistrationNumber).onResponse()
+
+    suspend fun signUpWorker(signUpWorkerRequest: SignUpWorkerRequest): Result<Unit> =
+        careNetworkApi.signUpWorker(signUpWorkerRequest).onResponse()
 }

--- a/core/network/src/main/java/com/idle/network/token/TokenInterceptor.kt
+++ b/core/network/src/main/java/com/idle/network/token/TokenInterceptor.kt
@@ -38,6 +38,7 @@ class TokenInterceptor @Inject constructor(
             "/api/v1/auth/common/confirm" -> false
             "/api/v1/auth/center/join" -> false
             "/api/v1/auth/center/login" -> false
+            "/api/v1/auth/carer/join" -> false
             else -> true
         }
     }

--- a/feature/signup/build.gradle.kts
+++ b/feature/signup/build.gradle.kts
@@ -5,7 +5,3 @@ plugins {
 android {
     namespace = "com.idle.signup"
 }
-
-dependencies {
-    implementation(libs.naver.map)
-}

--- a/feature/signup/build.gradle.kts
+++ b/feature/signup/build.gradle.kts
@@ -6,4 +6,6 @@ android {
     namespace = "com.idle.signup"
 }
 
-dependencies {}
+dependencies {
+    implementation(libs.naver.map)
+}

--- a/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpFragment.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpFragment.kt
@@ -29,6 +29,7 @@ import com.idle.compose.addFocusCleaner
 import com.idle.compose.base.BaseComposeFragment
 import com.idle.designsystem.compose.component.CareProgressBar
 import com.idle.designsystem.compose.component.CareSubtitleTopAppBar
+import com.idle.domain.model.auth.Gender
 import com.idle.signin.center.CenterSignUpProcess
 import com.idle.signup.worker.process.AddressScreen
 import com.idle.signup.worker.process.GenderScreen

--- a/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpFragment.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpFragment.kt
@@ -75,6 +75,7 @@ internal class WorkerSignUpFragment : BaseComposeFragment() {
                 setSignUpProcess = ::setWorkerSignUpProcess,
                 sendPhoneNumber = ::sendPhoneNumber,
                 confirmAuthCode = ::confirmAuthCode,
+                signUpWorker = ::signUpWorker,
             )
         }
     }
@@ -102,6 +103,7 @@ internal fun WorkerSignUpScreen(
     setSignUpProcess: (WorkerSignUpProcess) -> Unit,
     sendPhoneNumber: () -> Unit,
     confirmAuthCode: () -> Unit,
+    signUpWorker: () -> Unit,
 ) {
     val onBackPressedDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
     val focusManager = LocalFocusManager.current
@@ -182,6 +184,7 @@ internal fun WorkerSignUpScreen(
                         onAddressChanged = onAddressChanged,
                         onAddressDetailChanged = onAddressDetailChanged,
                         setSignUpProcess = setSignUpProcess,
+                        signUpWorker = signUpWorker,
                     )
                 }
             }

--- a/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpViewModel.kt
@@ -6,6 +6,7 @@ import com.idle.binding.base.BaseViewModel
 import com.idle.domain.model.CountDownTimer
 import com.idle.domain.model.CountDownTimer.Companion.SECONDS_PER_MINUTE
 import com.idle.domain.model.CountDownTimer.Companion.TICK_INTERVAL
+import com.idle.domain.model.auth.Gender
 import com.idle.domain.usecase.auth.ConfirmAuthCodeUseCase
 import com.idle.domain.usecase.auth.SendPhoneNumberUseCase
 import com.idle.signin.worker.WorkerSignUpProcess.NAME
@@ -128,8 +129,4 @@ class WorkerSignUpViewModel @Inject constructor(
 
 enum class WorkerSignUpProcess(val step: Int) {
     NAME(1), GENDER(2), PHONE_NUMBER(3), ADDRESS(4)
-}
-
-enum class Gender(val displayName: String) {
-    MALE("남성"), FEMALE("여성"), NONE("")
 }

--- a/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpViewModel.kt
@@ -2,7 +2,9 @@ package com.idle.signin.worker
 
 import android.util.Log
 import androidx.lifecycle.viewModelScope
+import com.idle.binding.DeepLinkDestination.WorkerAuth
 import com.idle.binding.base.BaseViewModel
+import com.idle.binding.base.CareBaseEvent
 import com.idle.domain.model.CountDownTimer
 import com.idle.domain.model.CountDownTimer.Companion.SECONDS_PER_MINUTE
 import com.idle.domain.model.CountDownTimer.Companion.TICK_INTERVAL
@@ -139,7 +141,7 @@ class WorkerSignUpViewModel @Inject constructor(
             longitude = "127.0276",
             latitude = "37.4979",
         )
-            .onSuccess { Log.d("test", "회원가입 성공!") }
+            .onSuccess { baseEvent(CareBaseEvent.NavigateTo(WorkerAuth, true)) }
             .onFailure { Log.d("test", "실패! ${it}") }
     }
 }

--- a/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpViewModel.kt
@@ -9,6 +9,7 @@ import com.idle.domain.model.CountDownTimer.Companion.TICK_INTERVAL
 import com.idle.domain.model.auth.Gender
 import com.idle.domain.usecase.auth.ConfirmAuthCodeUseCase
 import com.idle.domain.usecase.auth.SendPhoneNumberUseCase
+import com.idle.domain.usecase.auth.SignUpWorkerUseCase
 import com.idle.signin.worker.WorkerSignUpProcess.NAME
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
@@ -19,6 +20,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class WorkerSignUpViewModel @Inject constructor(
+    private val signUpWorkerUseCase: SignUpWorkerUseCase,
     private val sendPhoneNumberUseCase: SendPhoneNumberUseCase,
     private val confirmAuthCodeUseCase: ConfirmAuthCodeUseCase,
     private val countDownTimer: CountDownTimer,
@@ -123,6 +125,21 @@ class WorkerSignUpViewModel @Inject constructor(
                 cancelTimer()
                 _isConfirmAuthCode.value = true
             }
+            .onFailure { Log.d("test", "실패! ${it}") }
+    }
+
+    internal fun signUpWorker() = viewModelScope.launch {
+        signUpWorkerUseCase(
+            name = _workerName.value,
+            birthYear = 2000,
+            genderType = _gender.value.name,
+            phoneNumber = _workerPhoneNumber.value,
+            roadNameAddress = "서울특별시 강남구 테헤란로 123",
+            lotNumberAddress = "서울특별시 강남구 역삼동 456-78",
+            longitude = "127.0276",
+            latitude = "37.4979",
+        )
+            .onSuccess { Log.d("test", "회원가입 성공!") }
             .onFailure { Log.d("test", "실패! ${it}") }
     }
 }

--- a/feature/signup/src/main/java/com/idle/signup/worker/process/AddressScreen.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/process/AddressScreen.kt
@@ -23,6 +23,7 @@ internal fun AddressScreen(
     onAddressChanged: (String) -> Unit,
     onAddressDetailChanged: (String) -> Unit,
     setSignUpProcess: (WorkerSignUpProcess) -> Unit,
+    signUpWorker: () -> Unit,
 ) {
     BackHandler { setSignUpProcess(WorkerSignUpProcess.PHONE_NUMBER) }
 
@@ -78,9 +79,9 @@ internal fun AddressScreen(
         Spacer(modifier = Modifier.weight(1f))
 
         CareButtonLarge(
-            text = "다음",
+            text = "완료",
             enable = addressDetail.isNotBlank(),
-            onClick = { },
+            onClick = signUpWorker,
             modifier = Modifier.fillMaxWidth(),
         )
     }

--- a/feature/signup/src/main/java/com/idle/signup/worker/process/GenderScreen.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/process/GenderScreen.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.unit.dp
 import com.idle.designsystem.compose.component.CareButtonLarge
 import com.idle.designsystem.compose.component.CareChip
 import com.idle.designsystem.compose.foundation.CareTheme
-import com.idle.signin.worker.Gender
+import com.idle.domain.model.auth.Gender
 import com.idle.signin.worker.WorkerSignUpProcess
 
 @Composable

--- a/feature/signup/src/main/java/com/idle/signup/worker/process/GenderScreen.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/process/GenderScreen.kt
@@ -53,16 +53,16 @@ internal fun GenderScreen(
             modifier = Modifier.fillMaxWidth()
         ) {
             CareChip(
-                text = Gender.FEMALE.displayName,
-                onClick = { onGenderChanged(Gender.FEMALE) },
-                enable = gender == Gender.FEMALE,
+                text = Gender.WOMAN.displayName,
+                onClick = { onGenderChanged(Gender.WOMAN) },
+                enable = gender == Gender.WOMAN,
                 modifier = Modifier.weight(1f),
             )
 
             CareChip(
-                text = Gender.MALE.displayName,
-                onClick = { onGenderChanged(Gender.MALE) },
-                enable = gender == Gender.MALE,
+                text = Gender.MAN.displayName,
+                onClick = { onGenderChanged(Gender.MAN) },
+                enable = gender == Gender.MAN,
                 modifier = Modifier.weight(1f),
             )
         }

--- a/feature/worker/job-detail/src/main/java/com/idle/worker/job/detail/WorkerJobDetailFragment.kt
+++ b/feature/worker/job-detail/src/main/java/com/idle/worker/job/detail/WorkerJobDetailFragment.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
@@ -20,13 +21,14 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
 import com.idle.compose.base.BaseComposeFragment
 import com.idle.designsystem.compose.component.CareButtonLine
+import com.idle.designsystem.compose.component.CareMap
 import com.idle.designsystem.compose.component.CareSubtitleTopAppBar
 import com.idle.designsystem.compose.component.CareTag
 import com.idle.designsystem.compose.component.CareTextFieldLong
@@ -200,11 +202,10 @@ internal fun WorkerJobDetailScreen(
                     )
                 }
 
-                Image(
-                    painter = painterResource(com.idle.designresource.R.drawable.ic_temp_map),
-                    contentDescription = null,
-                    contentScale = ContentScale.FillWidth,
-                    modifier = Modifier.fillMaxWidth(),
+                CareMap(
+                    modifier = Modifier.fillMaxWidth()
+                        .height(224.dp)
+                        .clip(RoundedCornerShape(8.dp)),
                 )
             }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,6 +82,9 @@ firebaseBom = "33.1.2"
 # https://coil-kt.github.io/coil/#jetpack-compose
 coil = "2.7.0"
 
+# https://navermaps.github.io/android-map-sdk/guide-ko/1.html
+naverMap = "3.18.0"
+
 [libraries]
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -138,6 +141,8 @@ firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.r
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
 
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
+
+naver-map = { module = "com.naver.maps:map-sdk", version.ref = "naverMap" }
 
 [bundles]
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,6 +18,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven("https://repository.map.naver.com/archive/maven")
     }
 }
 


### PR DESCRIPTION
## 1. 🔥 변경된 내용

- **요양보호사 채용 화면에서 사용하는 지도를 Dummy 데이터에서 실제 네이버 지도 뷰로 변경합니다.**
- **요양 보호사 회원가입 및 로그인 API를 구현하고 연결합니다.**


## 3. 💡 알게된 부분

네이버 지도는 기본적으로 Compose를 지원하고 있지 않다.

![image](https://github.com/user-attachments/assets/e40d12c0-b51e-40b7-a541-e35bac2437b8)


하지만 네이버 지도를 Compose로 구현하고 있는 화면에서 사용해야했고,

이를 위해 자료를 찾아보던 도중 완전 짱 유명한 안성용 개발자님이 컴포즈로 네이버 지도를 사용하게 할 수 있는 라이브러리를 발견했다.

[GitHub - fornewid/naver-map-compose: NAVER Map Android SDK for Jetpack Compose 🗺](https://github.com/fornewid/naver-map-compose)

<br><br><br>

위 라이브러리를 써서 편하게 개발 할까? 하다가 ..

이슈에서 아래와 같은 코멘트를 발견하였다.

![image](https://github.com/user-attachments/assets/1378a328-0962-416f-956a-838a17b4283b)

거의 대부분의 기능은 구현이 되어있어서 상관없겠지만, 만약 지원되고 있지 않는 기능이 생기면 이슈에서 성용님의 개발을 기다려야만 하는 상황이었기에,

그냥 네이버에서 지원하고 있는 공식 API를 사용하기로 하였다.

<br><br><br>

## How to Use?

---

```kotlin
@Composable
fun CareMap(modifier: Modifier = Modifier) {
    val context = LocalContext.current
    val lifecycleOwner = LocalLifecycleOwner.current
    val coroutineScope = rememberCoroutineScope()

    val mapView = MapView(context).apply {
        getMapAsync { naverMap ->

        }
    }

    // LifecycleEventObserver를 구현하고, 각 이벤트에 맞게 MapView의 Lifecycle 메소드를 호출합니다.
    val lifecycleObserver = remember {
        LifecycleEventObserver { _, event ->
            coroutineScope.launch {
                when (event) {
                    Lifecycle.Event.ON_CREATE -> mapView.onCreate(Bundle())
                    Lifecycle.Event.ON_START -> mapView.onStart()
                    Lifecycle.Event.ON_RESUME -> mapView.onResume()
                    Lifecycle.Event.ON_PAUSE -> mapView.onPause()
                    Lifecycle.Event.ON_STOP -> mapView.onStop()
                    Lifecycle.Event.ON_DESTROY -> mapView.onDestroy()
                    Lifecycle.Event.ON_ANY -> Unit
                }
            }
        }
    }

    // 뷰가 해제될 때 이벤트 리스너를 제거합니다.
    DisposableEffect(true) {
        lifecycleOwner.lifecycle.addObserver(lifecycleObserver)
        onDispose {
            lifecycleOwner.lifecycle.removeObserver(lifecycleObserver)
        }
    }

    // 생성된 MapView 객체를 AndroidView로 Wrapping 합니다.
    AndroidView(
        factory = { mapView },
        modifier = modifier,
    )
}
```

[Jetpack Compose에서 네이버 지도 사용해보기](https://stellapath.tistory.com/7)

<br><br><br>

### Android View

---

**MapView** 나 **AdView** 는 Composable로 아직 제공이 되고있지 않기 때문에 Legacy View로 제공되는 View를 Compose로 끌어와서 사용해야 함.

이 때 사용하는 것이 바로 **Android View.**

이 때 Android View는 아래와 같이 **2개의 람다**를 받는데, 

**factory 람다**에서 사용할 View 객체를 넣어주면 되고,

**update 람다**는 뷰가 그려지면서 데이터 바인딩 처럼 **사용되는 데이터들을 삽입**해주면 됨.

이 때 **update 람다** **내부에서 사용되는 데이터가 업데이트 되면 뷰가 재구성** 됨.

```kotlin
AndroidView(
    modifier = Modifier.fillMaxSize(), // Occupy the max size in the Compose UI tree
    factory = { context ->
        // Creates view
        MyView(context).apply {
            // Sets up listeners for View -> Compose communication
            setOnClickListener {
                selectedItem = 1
            }
        }
    },
    update = { view ->
        // View's been inflated or state read in this block has been updated
        // Add logic here if necessary

        // As selectedItem is read here, AndroidView will recompose
        // whenever the state changes
        // Example of Compose -> View communication
        view.selectedItem = selectedItem
    }
)
```

[Compose에서 뷰 사용  |  Jetpack Compose  |  Android Developers](https://developer.android.com/develop/ui/compose/migrate/interoperability-apis/views-in-compose?hl=ko)

<br><br><br>

### Disposable Effect

---

Dispossable Effect는 Composable이 Dispose될 때 정리되어야 할 side effect가 있을 때 사용하는 Effect임.

주로 Lifecycle에 맞춰서 Observer를 구독하거나 해제하는 작업 등에 사용된다.

```kotlin
DisposableEffect(key) {
    // Dispose될 때 까지 지속되어야 하는 로직 작성
    onDispose {
        // Dispose될 때 지속되던 로직을 제거하는 로직 
    }
}
```

[Compose Side Effect] Disposable Effect 란 무엇인가?](https://kotlinworld.com/257)

Map View에서 Disposable Effect가 사용되는 이유는, 

Map View는 Activity의 Lifecycle을 따르기 때문에 Composable에서 Activity의 Lifecycle을 구독하기 위함임.

<br><br><br>

https://www.notion.so/Compose-0eb3976d1aab4d25b39a8403910b04cc