### PR TITLE
[IDLE-000] DesignSystem Component Default, Flip, Flop별 Preview 추가

### DIFF
--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/Devices.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/Devices.kt
@@ -1,5 +1,3 @@
 package com.idle.designsystem.compose
 
-import androidx.compose.ui.tooling.preview.Devices
-
 const val Flip = "spec:width=480dp,height=320dp,dpi=480,isRound=false,chinSize=0dp"

--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/Devices.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/Devices.kt
@@ -1,0 +1,5 @@
+package com.idle.designsystem.compose
+
+import androidx.compose.ui.tooling.preview.Devices
+
+const val Flip = "spec:width=480dp,height=320dp,dpi=480,isRound=false,chinSize=0dp"

--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/BottomSheet.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/BottomSheet.kt
@@ -1,10 +1,15 @@
 package com.idle.designsystem.compose.component
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ModalBottomSheetLayout
@@ -15,8 +20,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.idle.designsystem.compose.Flip
 import com.idle.designsystem.compose.foundation.CareTheme
 import java.time.LocalDate
 
@@ -49,44 +57,164 @@ fun CareBottomSheetLayout(
 }
 
 @OptIn(ExperimentalMaterialApi::class)
-@Preview(showBackground = true)
 @Composable
-fun PreviewDatePickerBottomSheet() {
+private fun PreviewCalendarBottomSheet() {
     val sheetState = rememberModalBottomSheetState(
         initialValue = ModalBottomSheetValue.Expanded,
-        confirmValueChange = { false },
+        confirmValueChange = { false }
     )
 
     CareBottomSheetLayout(
         sheetState = sheetState,
-        sheetContent = {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text(
-                    text = "접수 마감일",
-                    style = CareTheme.typography.heading3,
-                    color = CareTheme.colors.gray900,
-                )
-
-                CareCalendar(
-                    year = 2024,
-                    month = 8,
-                    startMonth = 7,
-                    selectedDate = LocalDate.of(2024, 8, 6),
-                    onMonthChanged = {},
-                    onDayClick = {},
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 20.dp)
-                )
-            }
-        },
+        sheetContent = { CalendarBottomSheetContent() },
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 20.dp),
+            .padding(horizontal = 20.dp)
     ) {
         Box(modifier = Modifier.fillMaxSize())
     }
+}
+
+@Composable
+private fun CalendarBottomSheetContent() {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Text(
+            text = "접수 마감일",
+            style = CareTheme.typography.heading3,
+            color = CareTheme.colors.gray900
+        )
+
+        CareCalendar(
+            year = 2024,
+            month = 8,
+            startMonth = 7,
+            selectedDate = LocalDate.of(2024, 8, 6),
+            onMonthChanged = {},
+            onDayClick = {},
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+private fun PreviewWheelPickerBottomSheet() {
+    val sheetState = rememberModalBottomSheetState(
+        initialValue = ModalBottomSheetValue.Expanded,
+        confirmValueChange = { false }
+    )
+
+    CareBottomSheetLayout(
+        sheetState = sheetState,
+        sheetContent = { WheelPickerBottomSheetContent() },
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp)
+    ) {
+        Box(modifier = Modifier.fillMaxSize())
+    }
+}
+
+@Composable
+private fun WheelPickerBottomSheetContent() {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Text(
+            text = "근무 시작 시간",
+            style = CareTheme.typography.heading3,
+            color = CareTheme.colors.gray900
+        )
+
+        Spacer(modifier = Modifier.height(80.dp))
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            CareWheelPicker(
+                list = listOf("오전", "오후"),
+                onItemSelected = {},
+                modifier = Modifier.padding(end = 40.dp)
+            )
+
+            CareWheelPicker(
+                list = (1..12).toList(),
+                onItemSelected = {},
+                modifier = Modifier.padding(end = 10.dp)
+            )
+
+            Text(
+                text = ":",
+                style = CareTheme.typography.subtitle2,
+                color = CareTheme.colors.gray900,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.width(20.dp)
+            )
+
+            CareWheelPicker(
+                list = (0..50 step 10).toList(),
+                onItemSelected = {},
+                modifier = Modifier.padding(start = 10.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(80.dp))
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            CareButtonMedium(
+                text = "취소",
+                onClick = {},
+                modifier = Modifier.weight(1f)
+            )
+
+            CareButtonMedium(
+                text = "저장",
+                onClick = {},
+                modifier = Modifier.weight(1f)
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, group = "Default")
+@Composable
+private fun PreviewCalendarBottomSheetDefault() {
+    PreviewCalendarBottomSheet()
+}
+
+@Preview(showBackground = true, device = Flip, group = "Flip")
+@Composable
+private fun PreviewCalendarBottomSheetFlip() {
+    PreviewCalendarBottomSheet()
+}
+
+@Preview(showBackground = true, device = Devices.FOLDABLE, group = "Fold")
+@Composable
+private fun PreviewCalendarBottomSheetFoldable() {
+    PreviewCalendarBottomSheet()
+}
+
+@Preview(showBackground = true, group = "Default")
+@Composable
+private fun PreviewWheelPickerBottomSheetDefault() {
+    PreviewWheelPickerBottomSheet()
+}
+
+@Preview(showBackground = true, device = Flip, group = "Flip")
+@Composable
+private fun PreviewWheelPickerBottomSheetFlip() {
+    PreviewWheelPickerBottomSheet()
+}
+
+@Preview(showBackground = true, device = Devices.FOLDABLE, group = "Fold")
+@Composable
+private fun PreviewWheelPickerBottomSheetFoldable() {
+    PreviewWheelPickerBottomSheet()
 }

--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/Button.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/Button.kt
@@ -250,9 +250,8 @@ internal fun CareDialogButton(
     }
 }
 
-@Preview(name = "Button_Primary_Default_Large", showBackground = true, group = "Default")
 @Composable
-fun PreviewButtonPrimaryDefaultLarge() {
+private fun PreviewButtonLarge() {
     Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
         CareButtonLarge(text = "다음", onClick = {}, modifier = Modifier.fillMaxWidth())
         CareButtonLarge(
@@ -262,314 +261,196 @@ fun PreviewButtonPrimaryDefaultLarge() {
             enable = false
         )
     }
+}
+
+@Composable
+private fun PreviewButtonMedium() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareButtonMedium(text = "확인", onClick = {})
+        CareButtonMedium(text = "확인", onClick = {}, enable = false)
+    }
+}
+
+@Composable
+private fun PreviewButtonCardLarge() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareButtonCardLarge(text = "저장하기", onClick = {}, modifier = Modifier.fillMaxWidth())
+        CareButtonCardLarge(
+            text = "저장하기",
+            onClick = {},
+            modifier = Modifier.fillMaxWidth(),
+            enable = false
+        )
+    }
+}
+
+@Composable
+private fun PreviewButtonCardMedium() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareButtonCardMedium(text = "저장하기", onClick = {})
+        CareButtonCardMedium(text = "저장하기", onClick = {}, enable = false)
+    }
+}
+
+@Composable
+private fun PreviewButtonRound() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareButtonRound(text = "삭제하기", onClick = {})
+        CareButtonRound(text = "삭제하기", onClick = {}, enable = false)
+    }
+}
+
+@Composable
+private fun PreviewButtonLine() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareButtonLine(text = "삭제하기", onClick = {})
+        CareButtonLine(text = "삭제하기", onClick = {}, enable = false)
+    }
+}
+
+@Composable
+private fun PreviewButtonDialog() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareDialogButton(
+            text = "Dialog",
+            onClick = {},
+            containerColor = CareTheme.colors.orange500,
+            textColor = CareTheme.colors.white000
+        )
+        CareDialogButton(
+            text = "Dialog",
+            onClick = {},
+            containerColor = CareTheme.colors.orange500,
+            textColor = CareTheme.colors.white000
+        )
+    }
+}
+
+// Default Group Previews
+@Preview(name = "Button_Primary_Default_Large", showBackground = true, group = "Default")
+@Composable
+private fun PreviewButtonPrimaryDefaultLarge() {
+    PreviewButtonLarge()
 }
 
 @Preview(name = "Button_Primary_Default_Medium", showBackground = true, group = "Default")
 @Composable
-fun PreviewButtonPrimaryDefaultMedium() {
-    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-        CareButtonMedium(text = "확인", onClick = {})
-        CareButtonMedium(text = "확인", onClick = {}, enable = false)
-    }
+private fun PreviewButtonPrimaryDefaultMedium() {
+    PreviewButtonMedium()
 }
 
 @Preview(name = "Button_Primary_Default_CardLarge", showBackground = true, group = "Default")
 @Composable
-fun PreviewButtonPrimaryDefaultCardLarge() {
-    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-        CareButtonCardLarge(text = "저장하기", onClick = {}, modifier = Modifier.fillMaxWidth())
-        CareButtonCardLarge(
-            text = "저장하기",
-            onClick = {},
-            modifier = Modifier.fillMaxWidth(),
-            enable = false
-        )
-    }
+private fun PreviewButtonPrimaryDefaultCardLarge() {
+    PreviewButtonCardLarge()
 }
 
-@Preview(
-    name = "Button_Primary_Default_CardMedium",
-    showBackground = true,
-    group = "Default"
-)
+@Preview(name = "Button_Primary_Default_CardMedium", showBackground = true, group = "Default")
 @Composable
-fun PreviewButtonPrimaryDefaultCardMedium() {
-    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-        CareButtonCardMedium(text = "저장하기", onClick = {})
-        CareButtonCardMedium(text = "저장하기", onClick = {}, enable = false)
-    }
+private fun PreviewButtonPrimaryDefaultCardMedium() {
+    PreviewButtonCardMedium()
 }
 
 @Preview(name = "Button_Primary_Default_Round", showBackground = true, group = "Default")
 @Composable
-fun PreviewButtonPrimaryDefaultRound() {
-    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-        CareButtonRound(text = "삭제하기", onClick = {})
-        CareButtonRound(text = "삭제하기", onClick = {}, enable = false)
-    }
+private fun PreviewButtonPrimaryDefaultRound() {
+    PreviewButtonRound()
 }
 
 @Preview(name = "Button_Primary_Default_Line", showBackground = true, group = "Default")
 @Composable
-fun PreviewButtonPrimaryDefaultLine() {
-    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-        CareButtonLine(text = "삭제하기", onClick = {})
-        CareButtonLine(text = "삭제하기", onClick = {}, enable = false)
-    }
+private fun PreviewButtonPrimaryDefaultLine() {
+    PreviewButtonLine()
 }
 
 @Preview(name = "Button_Primary_Default_Dialog", showBackground = true, group = "Default")
 @Composable
-fun PreviewButtonPrimaryDefaultDialog() {
-    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-        CareDialogButton(
-            text = "Dialog",
-            onClick = {},
-            containerColor = CareTheme.colors.orange500,
-            textColor = CareTheme.colors.white000
-        )
-        CareDialogButton(
-            text = "Dialog",
-            onClick = {},
-            containerColor = CareTheme.colors.orange500,
-            textColor = CareTheme.colors.white000
-        )
-    }
+private fun PreviewButtonPrimaryDefaultDialog() {
+    PreviewButtonDialog()
 }
 
-@Preview(
-    name = "Button_Primary_Flip_Large",
-    showBackground = true,
-    device = Flip,
-    group = "Flip"
-)
+// Flip Group Previews
+@Preview(name = "Button_Primary_Flip_Large", showBackground = true, device = Flip, group = "Flip")
 @Composable
-fun PreviewButtonPrimaryFlipLarge() {
-    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-        CareButtonLarge(text = "다음", onClick = {}, modifier = Modifier.fillMaxWidth())
-        CareButtonLarge(
-            text = "다음",
-            onClick = {},
-            modifier = Modifier.fillMaxWidth(),
-            enable = false
-        )
-    }
+private fun PreviewButtonPrimaryFlipLarge() {
+    PreviewButtonLarge()
 }
 
-@Preview(
-    name = "Button_Primary_Flip_Medium",
-    showBackground = true,
-    device = Flip,
-    group = "Flip"
-
-)
+@Preview(name = "Button_Primary_Flip_Medium", showBackground = true, device = Flip, group = "Flip")
 @Composable
-fun PreviewButtonPrimaryFlipMedium() {
-    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-        CareButtonMedium(text = "확인", onClick = {})
-        CareButtonMedium(text = "확인", onClick = {}, enable = false)
-    }
+private fun PreviewButtonPrimaryFlipMedium() {
+    PreviewButtonMedium()
 }
 
-@Preview(
-    name = "Button_Primary_Flip_CardLarge",
-    showBackground = true,
-    device = Flip,
-    group = "Flip"
-)
+@Preview(name = "Button_Primary_Flip_CardLarge", showBackground = true, device = Flip, group = "Flip")
 @Composable
-fun PreviewButtonPrimaryFlipCardLarge() {
-    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-        CareButtonCardLarge(text = "저장하기", onClick = {}, modifier = Modifier.fillMaxWidth())
-        CareButtonCardLarge(
-            text = "저장하기",
-            onClick = {},
-            modifier = Modifier.fillMaxWidth(),
-            enable = false
-        )
-    }
+private fun PreviewButtonPrimaryFlipCardLarge() {
+    PreviewButtonCardLarge()
 }
 
-@Preview(
-    name = "Button_Primary_Flip_CardMedium",
-    showBackground = true,
-    device = Flip,
-    group = "Flip"
-)
+@Preview(name = "Button_Primary_Flip_CardMedium", showBackground = true, device = Flip, group = "Flip")
 @Composable
-fun PreviewButtonPrimaryFlipCardMedium() {
-    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-        CareButtonCardMedium(text = "저장하기", onClick = {})
-        CareButtonCardMedium(text = "저장하기", onClick = {}, enable = false)
-    }
+private fun PreviewButtonPrimaryFlipCardMedium() {
+    PreviewButtonCardMedium()
 }
 
-@Preview(
-    name = "Button_Primary_Flip_Round",
-    showBackground = true,
-    device = Flip,
-    group = "Flip"
-)
+@Preview(name = "Button_Primary_Flip_Round", showBackground = true, device = Flip, group = "Flip")
 @Composable
-fun PreviewButtonPrimaryFlipRound() {
-    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-        CareButtonRound(text = "삭제하기", onClick = {})
-        CareButtonRound(text = "삭제하기", onClick = {}, enable = false)
-    }
+private fun PreviewButtonPrimaryFlipRound() {
+    PreviewButtonRound()
 }
 
-@Preview(
-    name = "Button_Primary_Flip_Line",
-    showBackground = true,
-    device = Flip,
-    group = "Flip"
-)
+@Preview(name = "Button_Primary_Flip_Line", showBackground = true, device = Flip, group = "Flip")
 @Composable
-fun PreviewButtonPrimaryFlipLine() {
-    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-        CareButtonLine(text = "삭제하기", onClick = {})
-        CareButtonLine(text = "삭제하기", onClick = {}, enable = false)
-    }
+private fun PreviewButtonPrimaryFlipLine() {
+    PreviewButtonLine()
 }
 
-@Preview(
-    name = "Button_Primary_Flip_Dialog",
-    showBackground = true,
-    device = Flip,
-    group = "Flip"
-)
+@Preview(name = "Button_Primary_Flip_Dialog", showBackground = true, device = Flip, group = "Flip")
 @Composable
-fun PreviewButtonPrimaryFlipDialog() {
-    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-        CareDialogButton(
-            text = "Dialog",
-            onClick = {},
-            containerColor = CareTheme.colors.orange500,
-            textColor = CareTheme.colors.white000
-        )
-        CareDialogButton(
-            text = "Dialog",
-            onClick = {},
-            containerColor = CareTheme.colors.orange500,
-            textColor = CareTheme.colors.white000
-        )
-    }
+private fun PreviewButtonPrimaryFlipDialog() {
+    PreviewButtonDialog()
 }
 
-@Preview(
-    name = "Button_Primary_Foldable_Large",
-    showBackground = true,
-    device = Devices.FOLDABLE,
-    group = "Fold"
-)
+// Fold Group Previews
+@Preview(name = "Button_Primary_Foldable_Large", showBackground = true, device = Devices.FOLDABLE, group = "Fold")
 @Composable
-fun PreviewButtonPrimaryFoldableLarge() {
-    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-        CareButtonLarge(text = "다음", onClick = {}, modifier = Modifier.fillMaxWidth())
-        CareButtonLarge(
-            text = "다음",
-            onClick = {},
-            modifier = Modifier.fillMaxWidth(),
-            enable = false
-        )
-    }
+private fun PreviewButtonPrimaryFoldableLarge() {
+    PreviewButtonLarge()
 }
 
-@Preview(
-    name = "Button_Primary_Foldable_Medium",
-    showBackground = true,
-    device = Devices.FOLDABLE,
-    group = "Fold"
-)
+@Preview(name = "Button_Primary_Foldable_Medium", showBackground = true, device = Devices.FOLDABLE, group = "Fold")
 @Composable
-fun PreviewButtonPrimaryFoldableMedium() {
-    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-        CareButtonMedium(text = "확인", onClick = {})
-        CareButtonMedium(text = "확인", onClick = {}, enable = false)
-    }
+private fun PreviewButtonPrimaryFoldableMedium() {
+    PreviewButtonMedium()
 }
 
-@Preview(
-    name = "Button_Primary_Foldable_CardLarge",
-    showBackground = true,
-    device = Devices.FOLDABLE,
-    group = "Fold"
-)
+@Preview(name = "Button_Primary_Foldable_CardLarge", showBackground = true, device = Devices.FOLDABLE, group = "Fold")
 @Composable
-fun PreviewButtonPrimaryFoldableCardLarge() {
-    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-        CareButtonCardLarge(text = "저장하기", onClick = {}, modifier = Modifier.fillMaxWidth())
-        CareButtonCardLarge(
-            text = "저장하기",
-            onClick = {},
-            modifier = Modifier.fillMaxWidth(),
-            enable = false
-        )
-    }
+private fun PreviewButtonPrimaryFoldableCardLarge() {
+    PreviewButtonCardLarge()
 }
 
-@Preview(
-    name = "Button_Primary_Foldable_CardMedium",
-    showBackground = true,
-    device = Devices.FOLDABLE,
-    group = "Fold"
-)
+@Preview(name = "Button_Primary_Foldable_CardMedium", showBackground = true, device = Devices.FOLDABLE, group = "Fold")
 @Composable
-fun PreviewButtonPrimaryFoldableCardMedium() {
-    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-        CareButtonCardMedium(text = "저장하기", onClick = {})
-        CareButtonCardMedium(text = "저장하기", onClick = {}, enable = false)
-    }
+private fun PreviewButtonPrimaryFoldableCardMedium() {
+    PreviewButtonCardMedium()
 }
 
-@Preview(
-    name = "Button_Primary_Foldable_Round",
-    showBackground = true,
-    device = Devices.FOLDABLE,
-    group = "Fold"
-)
+@Preview(name = "Button_Primary_Foldable_Round", showBackground = true, device = Devices.FOLDABLE, group = "Fold")
 @Composable
-fun PreviewButtonPrimaryFoldableRound() {
-    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-        CareButtonRound(text = "삭제하기", onClick = {})
-        CareButtonRound(text = "삭제하기", onClick = {}, enable = false)
-    }
+private fun PreviewButtonPrimaryFoldableRound() {
+    PreviewButtonRound()
 }
 
-@Preview(
-    name = "Button_Primary_Foldable_Line",
-    showBackground = true,
-    device = Devices.FOLDABLE,
-    group = "Fold"
-)
+@Preview(name = "Button_Primary_Foldable_Line", showBackground = true, device = Devices.FOLDABLE, group = "Fold")
 @Composable
-fun PreviewButtonPrimaryFoldableLine() {
-    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-        CareButtonLine(text = "삭제하기", onClick = {})
-        CareButtonLine(text = "삭제하기", onClick = {}, enable = false)
-    }
+private fun PreviewButtonPrimaryFoldableLine() {
+    PreviewButtonLine()
 }
 
-@Preview(
-    name = "Button_Primary_Foldable_Dialog",
-    showBackground = true,
-    device = Devices.FOLDABLE,
-    group = "Fold"
-)
+@Preview(name = "Button_Primary_Foldable_Dialog", showBackground = true, device = Devices.FOLDABLE, group = "Fold")
 @Composable
-fun PreviewButtonPrimaryFoldableDialog() {
-    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-        CareDialogButton(
-            text = "Dialog",
-            onClick = {},
-            containerColor = CareTheme.colors.orange500,
-            textColor = CareTheme.colors.white000
-        )
-        CareDialogButton(
-            text = "Dialog",
-            onClick = {},
-            containerColor = CareTheme.colors.orange500,
-            textColor = CareTheme.colors.white000
-        )
-    }
+private fun PreviewButtonPrimaryFoldableDialog() {
+    PreviewButtonDialog()
 }

--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/Button.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/Button.kt
@@ -1,7 +1,10 @@
 package com.idle.designsystem.compose.component
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -11,7 +14,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.idle.designsystem.compose.Flip
 import com.idle.designsystem.compose.foundation.CareTheme
 
 @Composable
@@ -150,7 +156,7 @@ fun CareButtonCardMedium(
 }
 
 @Composable
-fun CareButtonStrokeSmall(
+fun CareButtonRound(
     text: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -192,19 +198,22 @@ fun CareButtonLine(
         onClick = onClick,
         enabled = enable,
         shape = RoundedCornerShape(6.dp),
-        border = BorderStroke(width = 1.dp, color = borderColor),
+        border = BorderStroke(
+            width = 1.dp,
+            color = if (!enable) CareTheme.colors.gray300 else borderColor
+        ),
         colors = ButtonColors(
             containerColor = containerColor,
             contentColor = CareTheme.colors.white000,
-            disabledContentColor = CareTheme.colors.gray300,
-            disabledContainerColor = CareTheme.colors.gray200,
+            disabledContentColor = CareTheme.colors.gray050,
+            disabledContainerColor = CareTheme.colors.gray050,
         ),
         modifier = modifier.height(56.dp),
     ) {
         Text(
             text = text,
             style = CareTheme.typography.heading4,
-            color = textColor,
+            color = if (!enable) CareTheme.colors.gray300 else textColor,
         )
     }
 }
@@ -237,6 +246,330 @@ internal fun CareDialogButton(
             text = text,
             style = CareTheme.typography.heading4,
             color = textColor,
+        )
+    }
+}
+
+@Preview(name = "Button_Primary_Default_Large", showBackground = true, group = "Default")
+@Composable
+fun PreviewButtonPrimaryDefaultLarge() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareButtonLarge(text = "다음", onClick = {}, modifier = Modifier.fillMaxWidth())
+        CareButtonLarge(
+            text = "다음",
+            onClick = {},
+            modifier = Modifier.fillMaxWidth(),
+            enable = false
+        )
+    }
+}
+
+@Preview(name = "Button_Primary_Default_Medium", showBackground = true, group = "Default")
+@Composable
+fun PreviewButtonPrimaryDefaultMedium() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareButtonMedium(text = "확인", onClick = {})
+        CareButtonMedium(text = "확인", onClick = {}, enable = false)
+    }
+}
+
+@Preview(name = "Button_Primary_Default_CardLarge", showBackground = true, group = "Default")
+@Composable
+fun PreviewButtonPrimaryDefaultCardLarge() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareButtonCardLarge(text = "저장하기", onClick = {}, modifier = Modifier.fillMaxWidth())
+        CareButtonCardLarge(
+            text = "저장하기",
+            onClick = {},
+            modifier = Modifier.fillMaxWidth(),
+            enable = false
+        )
+    }
+}
+
+@Preview(
+    name = "Button_Primary_Default_CardMedium",
+    showBackground = true,
+    group = "Default"
+)
+@Composable
+fun PreviewButtonPrimaryDefaultCardMedium() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareButtonCardMedium(text = "저장하기", onClick = {})
+        CareButtonCardMedium(text = "저장하기", onClick = {}, enable = false)
+    }
+}
+
+@Preview(name = "Button_Primary_Default_Round", showBackground = true, group = "Default")
+@Composable
+fun PreviewButtonPrimaryDefaultRound() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareButtonRound(text = "삭제하기", onClick = {})
+        CareButtonRound(text = "삭제하기", onClick = {}, enable = false)
+    }
+}
+
+@Preview(name = "Button_Primary_Default_Line", showBackground = true, group = "Default")
+@Composable
+fun PreviewButtonPrimaryDefaultLine() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareButtonLine(text = "삭제하기", onClick = {})
+        CareButtonLine(text = "삭제하기", onClick = {}, enable = false)
+    }
+}
+
+@Preview(name = "Button_Primary_Default_Dialog", showBackground = true, group = "Default")
+@Composable
+fun PreviewButtonPrimaryDefaultDialog() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareDialogButton(
+            text = "Dialog",
+            onClick = {},
+            containerColor = CareTheme.colors.orange500,
+            textColor = CareTheme.colors.white000
+        )
+        CareDialogButton(
+            text = "Dialog",
+            onClick = {},
+            containerColor = CareTheme.colors.orange500,
+            textColor = CareTheme.colors.white000
+        )
+    }
+}
+
+@Preview(
+    name = "Button_Primary_Flip_Large",
+    showBackground = true,
+    device = Flip,
+    group = "Flip"
+)
+@Composable
+fun PreviewButtonPrimaryFlipLarge() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareButtonLarge(text = "다음", onClick = {}, modifier = Modifier.fillMaxWidth())
+        CareButtonLarge(
+            text = "다음",
+            onClick = {},
+            modifier = Modifier.fillMaxWidth(),
+            enable = false
+        )
+    }
+}
+
+@Preview(
+    name = "Button_Primary_Flip_Medium",
+    showBackground = true,
+    device = Flip,
+    group = "Flip"
+
+)
+@Composable
+fun PreviewButtonPrimaryFlipMedium() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareButtonMedium(text = "확인", onClick = {})
+        CareButtonMedium(text = "확인", onClick = {}, enable = false)
+    }
+}
+
+@Preview(
+    name = "Button_Primary_Flip_CardLarge",
+    showBackground = true,
+    device = Flip,
+    group = "Flip"
+)
+@Composable
+fun PreviewButtonPrimaryFlipCardLarge() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareButtonCardLarge(text = "저장하기", onClick = {}, modifier = Modifier.fillMaxWidth())
+        CareButtonCardLarge(
+            text = "저장하기",
+            onClick = {},
+            modifier = Modifier.fillMaxWidth(),
+            enable = false
+        )
+    }
+}
+
+@Preview(
+    name = "Button_Primary_Flip_CardMedium",
+    showBackground = true,
+    device = Flip,
+    group = "Flip"
+)
+@Composable
+fun PreviewButtonPrimaryFlipCardMedium() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareButtonCardMedium(text = "저장하기", onClick = {})
+        CareButtonCardMedium(text = "저장하기", onClick = {}, enable = false)
+    }
+}
+
+@Preview(
+    name = "Button_Primary_Flip_Round",
+    showBackground = true,
+    device = Flip,
+    group = "Flip"
+)
+@Composable
+fun PreviewButtonPrimaryFlipRound() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareButtonRound(text = "삭제하기", onClick = {})
+        CareButtonRound(text = "삭제하기", onClick = {}, enable = false)
+    }
+}
+
+@Preview(
+    name = "Button_Primary_Flip_Line",
+    showBackground = true,
+    device = Flip,
+    group = "Flip"
+)
+@Composable
+fun PreviewButtonPrimaryFlipLine() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareButtonLine(text = "삭제하기", onClick = {})
+        CareButtonLine(text = "삭제하기", onClick = {}, enable = false)
+    }
+}
+
+@Preview(
+    name = "Button_Primary_Flip_Dialog",
+    showBackground = true,
+    device = Flip,
+    group = "Flip"
+)
+@Composable
+fun PreviewButtonPrimaryFlipDialog() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareDialogButton(
+            text = "Dialog",
+            onClick = {},
+            containerColor = CareTheme.colors.orange500,
+            textColor = CareTheme.colors.white000
+        )
+        CareDialogButton(
+            text = "Dialog",
+            onClick = {},
+            containerColor = CareTheme.colors.orange500,
+            textColor = CareTheme.colors.white000
+        )
+    }
+}
+
+@Preview(
+    name = "Button_Primary_Foldable_Large",
+    showBackground = true,
+    device = Devices.FOLDABLE,
+    group = "Fold"
+)
+@Composable
+fun PreviewButtonPrimaryFoldableLarge() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareButtonLarge(text = "다음", onClick = {}, modifier = Modifier.fillMaxWidth())
+        CareButtonLarge(
+            text = "다음",
+            onClick = {},
+            modifier = Modifier.fillMaxWidth(),
+            enable = false
+        )
+    }
+}
+
+@Preview(
+    name = "Button_Primary_Foldable_Medium",
+    showBackground = true,
+    device = Devices.FOLDABLE,
+    group = "Fold"
+)
+@Composable
+fun PreviewButtonPrimaryFoldableMedium() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareButtonMedium(text = "확인", onClick = {})
+        CareButtonMedium(text = "확인", onClick = {}, enable = false)
+    }
+}
+
+@Preview(
+    name = "Button_Primary_Foldable_CardLarge",
+    showBackground = true,
+    device = Devices.FOLDABLE,
+    group = "Fold"
+)
+@Composable
+fun PreviewButtonPrimaryFoldableCardLarge() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareButtonCardLarge(text = "저장하기", onClick = {}, modifier = Modifier.fillMaxWidth())
+        CareButtonCardLarge(
+            text = "저장하기",
+            onClick = {},
+            modifier = Modifier.fillMaxWidth(),
+            enable = false
+        )
+    }
+}
+
+@Preview(
+    name = "Button_Primary_Foldable_CardMedium",
+    showBackground = true,
+    device = Devices.FOLDABLE,
+    group = "Fold"
+)
+@Composable
+fun PreviewButtonPrimaryFoldableCardMedium() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareButtonCardMedium(text = "저장하기", onClick = {})
+        CareButtonCardMedium(text = "저장하기", onClick = {}, enable = false)
+    }
+}
+
+@Preview(
+    name = "Button_Primary_Foldable_Round",
+    showBackground = true,
+    device = Devices.FOLDABLE,
+    group = "Fold"
+)
+@Composable
+fun PreviewButtonPrimaryFoldableRound() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareButtonRound(text = "삭제하기", onClick = {})
+        CareButtonRound(text = "삭제하기", onClick = {}, enable = false)
+    }
+}
+
+@Preview(
+    name = "Button_Primary_Foldable_Line",
+    showBackground = true,
+    device = Devices.FOLDABLE,
+    group = "Fold"
+)
+@Composable
+fun PreviewButtonPrimaryFoldableLine() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareButtonLine(text = "삭제하기", onClick = {})
+        CareButtonLine(text = "삭제하기", onClick = {}, enable = false)
+    }
+}
+
+@Preview(
+    name = "Button_Primary_Foldable_Dialog",
+    showBackground = true,
+    device = Devices.FOLDABLE,
+    group = "Fold"
+)
+@Composable
+fun PreviewButtonPrimaryFoldableDialog() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareDialogButton(
+            text = "Dialog",
+            onClick = {},
+            containerColor = CareTheme.colors.orange500,
+            textColor = CareTheme.colors.white000
+        )
+        CareDialogButton(
+            text = "Dialog",
+            onClick = {},
+            containerColor = CareTheme.colors.orange500,
+            textColor = CareTheme.colors.white000
         )
     }
 }

--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/Calendar.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/Calendar.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.idle.compose.clickable
+import com.idle.designsystem.compose.Flip
 import com.idle.designsystem.compose.foundation.CareTheme
 import java.time.LocalDate
 import java.time.format.TextStyle
@@ -276,11 +277,12 @@ enum class DayOfWeek(val displayName: String) {
 }
 
 @Preview(
-    name = "withOutSelect",
+    name = "Calendar_Default_WithOutSelect",
     showBackground = true,
+    group = "Default"
 )
 @Composable
-fun PreviewCareCalendarWithoutSelect() {
+private fun PreviewCareCalendarDefaultWithoutSelect() {
     CareCalendar(
         year = 2024,
         month = 7,
@@ -294,11 +296,12 @@ fun PreviewCareCalendarWithoutSelect() {
 }
 
 @Preview(
-    name = "withSelect",
+    name = "Calendar_Default_WithSelect",
     showBackground = true,
+    group = "Default"
 )
 @Composable
-fun PreviewCareCalendarWithSelect() {
+private fun PreviewCareCalendarDefaultWithSelect() {
     CareCalendar(
         year = 2024,
         month = 8,
@@ -313,12 +316,33 @@ fun PreviewCareCalendarWithSelect() {
 }
 
 @Preview(
-    name = "Foldable",
+    name = "Calendar_Foldable_WithOutSelect",
     showBackground = true,
-    device = Devices.FOLDABLE
+    device = Devices.FOLDABLE,
+    group = "Fold"
 )
 @Composable
-fun PreviewCareCalendarFoldable() {
+private fun PreviewCareCalendarFoldableWithoutSelect() {
+    CareCalendar(
+        year = 2024,
+        month = 7,
+        startMonth = 7,
+        onMonthChanged = {},
+        onDayClick = {},
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp)
+    )
+}
+
+@Preview(
+    name = "Calendar_Foldable_WithSelect",
+    showBackground = true,
+    device = Devices.FOLDABLE,
+    group = "Fold"
+)
+@Composable
+private fun PreviewCareCalendarFoldableWithSelect() {
     CareCalendar(
         year = 2024,
         month = 7,
@@ -333,12 +357,33 @@ fun PreviewCareCalendarFoldable() {
 }
 
 @Preview(
-    name = "Flip",
+    name = "Calendar_Flip_WithOutSelect",
     showBackground = true,
-    device = "spec:width=480dp,height=320dp,dpi=480,isRound=false,chinSize=0dp"
+    device = Flip,
+    group = "Flip"
 )
 @Composable
-fun PreviewCareCalendarFlip() {
+private fun PreviewCareCalendarFlipWithoutSelect() {
+    CareCalendar(
+        year = 2024,
+        month = 8,
+        startMonth = 7,
+        onMonthChanged = {},
+        onDayClick = {},
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp)
+    )
+}
+
+@Preview(
+    name = "Calendar_Flip_WithSelect",
+    showBackground = true,
+    device = Flip,
+    group = "Flip"
+)
+@Composable
+private fun PreviewCareCalendarFlipWithSelect() {
     CareCalendar(
         year = 2024,
         month = 8,

--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/Card.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/Card.kt
@@ -16,8 +16,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.idle.compose.clickable
+import com.idle.designsystem.compose.Flip
 import com.idle.designsystem.compose.foundation.CareTheme
 
 @Composable
@@ -40,7 +43,8 @@ fun CareCard(
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
                 .padding(horizontal = 20.dp, vertical = 16.dp)
         ) {
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
@@ -72,4 +76,40 @@ fun CareCard(
             )
         }
     }
+}
+
+@Preview(name = "CareCard_Default", showBackground = true, group = "Default")
+@Composable
+private fun PreviewCareCardDefault() {
+    CareCard(
+        name = "John Doe",
+        address = "1234 Elm Street",
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    )
+}
+
+@Preview(name = "CareCard_Flip", showBackground = true, device = Flip, group = "Flip")
+@Composable
+private fun PreviewCareCardFlip() {
+    CareCard(
+        name = "John Doe",
+        address = "1234 Elm Street",
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    )
+}
+
+@Preview(name = "CareCard_Fold", showBackground = true, device = Devices.FOLDABLE, group = "Fold")
+@Composable
+private fun PreviewCareCardFoldable() {
+    CareCard(
+        name = "John Doe",
+        address = "1234 Elm Street",
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    )
 }

--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/Chip.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/Chip.kt
@@ -2,14 +2,18 @@ package com.idle.designsystem.compose.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.idle.compose.clickable
 import com.idle.designsystem.compose.foundation.CareTheme
@@ -53,7 +57,8 @@ fun CareChipShort(
 ) {
     Box(
         contentAlignment = Alignment.Center,
-        modifier = Modifier.size(40.dp)
+        modifier = modifier
+            .size(40.dp)
             .background(
                 color = if (enable) CareTheme.colors.orange100 else CareTheme.colors.white000,
                 shape = RoundedCornerShape(6.dp)
@@ -69,6 +74,40 @@ fun CareChipShort(
             text = text,
             style = CareTheme.typography.body2,
             color = if (enable) CareTheme.colors.orange400 else CareTheme.colors.gray400,
+        )
+    }
+}
+
+@Preview(name = "CareChipBasic_Default", showBackground = true, group = "Default")
+@Composable
+private fun PreviewCareChipBasicDefault() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareChipBasic(
+            text = "Basic",
+            enable = true,
+            modifier = Modifier.width(104.dp),
+        )
+        CareChipBasic(
+            text = "Basic",
+            enable = false,
+            modifier = Modifier.width(104.dp),
+        )
+    }
+}
+
+@Preview(name = "CareChipShort_Default", showBackground = true, group = "Default")
+@Composable
+private fun PreviewCareChipShortDefault() {
+    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+        CareChipShort(
+            text = "S",
+            enable = true,
+            modifier = Modifier
+        )
+        CareChipShort(
+            text = "S",
+            enable = false,
+            modifier = Modifier
         )
     }
 }

--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/Dialog.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/Dialog.kt
@@ -1,5 +1,6 @@
 package com.idle.designsystem.compose.component
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -10,17 +11,16 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import com.idle.designsystem.compose.Flip
 import com.idle.designsystem.compose.foundation.CareTheme
-import com.idle.designsystem.compose.foundation.Gray500
-import com.idle.designsystem.compose.foundation.Gray900
-import com.idle.designsystem.compose.foundation.Orange500
-import com.idle.designsystem.compose.foundation.White000
 
 @Composable
 fun CareDialog(
@@ -35,8 +35,10 @@ fun CareDialog(
     descriptionColor: Color = CareTheme.colors.gray500,
     leftButtonTextColor: Color = CareTheme.colors.white000,
     leftButtonColor: Color = CareTheme.colors.white000,
+    leftButtonBorder: BorderStroke? = null,
     rightButtonTextColor: Color = CareTheme.colors.orange500,
     rightButtonColor: Color = CareTheme.colors.white000,
+    rightButtonBorder: BorderStroke? = null,
     onDismissRequest: () -> Unit = {},
 ) {
     Dialog(onDismissRequest = onDismissRequest) {
@@ -71,6 +73,7 @@ fun CareDialog(
                         text = description,
                         style = CareTheme.typography.body3,
                         color = descriptionColor,
+                        textAlign = TextAlign.Center,
                         modifier = Modifier.padding(bottom = 16.dp),
                     )
                 }
@@ -83,6 +86,7 @@ fun CareDialog(
                         text = leftButtonText,
                         textColor = leftButtonTextColor,
                         containerColor = leftButtonColor,
+                        border = leftButtonBorder,
                         onClick = onLeftButtonClick,
                         modifier = Modifier.weight(1f),
                     )
@@ -91,6 +95,7 @@ fun CareDialog(
                         text = rightButtonText,
                         textColor = rightButtonTextColor,
                         containerColor = rightButtonColor,
+                        border = rightButtonBorder,
                         onClick = onRightButtonClick,
                         modifier = Modifier.weight(1f),
                     )
@@ -98,4 +103,157 @@ fun CareDialog(
             }
         }
     }
+}
+
+@Composable
+private fun PreviewCareDialogBigContent() {
+    CareDialog(
+        title = "정말 탈퇴하시겠어요?",
+        description = "탈퇴 버튼 선택 시 모든 정보가 삭제되며, 되돌릴 수 없습니다.",
+        leftButtonText = "취소하기",
+        rightButtonText = "탈퇴하기",
+        onLeftButtonClick = {},
+        onRightButtonClick = {},
+        modifier = Modifier.fillMaxWidth(),
+        leftButtonTextColor = CareTheme.colors.gray300,
+        leftButtonColor = CareTheme.colors.white000,
+        leftButtonBorder = BorderStroke(1.dp, CareTheme.colors.gray100),
+        rightButtonTextColor = CareTheme.colors.white000,
+        rightButtonColor = CareTheme.colors.orange500,
+    )
+
+}
+
+@Composable
+private fun PreviewCareDialogBigContent2() {
+    CareDialog(
+        title = "정말 탈퇴하시겠어요?",
+        description = "탈퇴 버튼 선택 시 모든 정보가 삭제되며, 되돌릴 수 없습니다.",
+        leftButtonText = "취소하기",
+        rightButtonText = "탈퇴하기",
+        onLeftButtonClick = {},
+        onRightButtonClick = {},
+        modifier = Modifier.fillMaxWidth(),
+        leftButtonTextColor = CareTheme.colors.gray300,
+        leftButtonColor = CareTheme.colors.white000,
+        leftButtonBorder = BorderStroke(1.dp, CareTheme.colors.gray100),
+        rightButtonTextColor = CareTheme.colors.white000,
+        rightButtonColor = CareTheme.colors.red,
+    )
+}
+
+@Composable
+private fun PreviewCareDialogSmallContent() {
+    CareDialog(
+        title = "로그아웃하시겠어요?",
+        leftButtonText = "취소하기",
+        rightButtonText = "로그아웃",
+        onLeftButtonClick = {},
+        onRightButtonClick = {},
+        modifier = Modifier.fillMaxWidth(),
+        leftButtonTextColor = CareTheme.colors.gray300,
+        leftButtonColor = CareTheme.colors.white000,
+        leftButtonBorder = BorderStroke(1.dp, CareTheme.colors.gray100),
+        rightButtonTextColor = CareTheme.colors.white000,
+        rightButtonColor = CareTheme.colors.orange500,
+    )
+}
+
+@Composable
+private fun PreviewCareDialogSmallContent2() {
+    CareDialog(
+        title = "'홍길동'님을 채용할까요?",
+        leftButtonText = "취소하기",
+        rightButtonText = "채용하기",
+        onLeftButtonClick = {},
+        onRightButtonClick = {},
+        modifier = Modifier.fillMaxWidth(),
+        leftButtonTextColor = CareTheme.colors.gray300,
+        leftButtonColor = CareTheme.colors.white000,
+        leftButtonBorder = BorderStroke(1.dp, CareTheme.colors.gray100),
+        rightButtonTextColor = CareTheme.colors.white000,
+        rightButtonColor = CareTheme.colors.red,
+    )
+}
+
+@Preview(name = "Modal_big_Default", showBackground = true, group = "Default")
+@Composable
+private fun PreviewCareDialogBigDefault() {
+    PreviewCareDialogBigContent()
+}
+
+@Preview(name = "Modal_big_Default2", showBackground = true, group = "Default")
+@Composable
+private fun PreviewCareDialogBigDefault2() {
+    PreviewCareDialogBigContent2()
+}
+
+@Preview(name = "Modal_small_Default", showBackground = true, group = "Default")
+@Composable
+private fun PreviewCareDialogSmallDefault() {
+    PreviewCareDialogSmallContent()
+}
+
+@Preview(name = "Modal_small_Default2", showBackground = true, group = "Default")
+@Composable
+private fun PreviewCareDialogSmallDefault2() {
+    PreviewCareDialogSmallContent2()
+}
+
+@Preview(name = "Modal_big_Flip", showBackground = true, device = Flip, group = "Flip")
+@Composable
+private fun PreviewCareDialogBigFlip() {
+    PreviewCareDialogBigContent()
+}
+
+@Preview(name = "Modal_big_Flip2", showBackground = true, device = Flip, group = "Flip")
+@Composable
+private fun PreviewCareDialogBigFlip2() {
+    PreviewCareDialogBigContent2()
+}
+
+@Preview(name = "Modal_small_Flip", showBackground = true, device = Flip, group = "Flip")
+@Composable
+private fun PreviewCareDialogSmallFlip() {
+    PreviewCareDialogSmallContent()
+}
+
+@Preview(name = "Modal_small_Flip2", showBackground = true, device = Flip, group = "Flip")
+@Composable
+private fun PreviewCareDialogSmallFlip2() {
+    PreviewCareDialogSmallContent2()
+}
+
+@Preview(name = "Modal_big_Fold", showBackground = true, device = Devices.FOLDABLE, group = "Fold")
+@Composable
+private fun PreviewCareDialogBigFold() {
+    PreviewCareDialogBigContent()
+}
+
+@Preview(name = "Modal_big_Fold2", showBackground = true, device = Devices.FOLDABLE, group = "Fold")
+@Composable
+private fun PreviewCareDialogBigFold2() {
+    PreviewCareDialogBigContent2()
+}
+
+@Preview(
+    name = "Modal_small_Fold",
+    showBackground = true,
+    device = Devices.FOLDABLE,
+    group = "Fold"
+)
+@Composable
+private fun PreviewCareDialogSmallFold() {
+    PreviewCareDialogSmallContent()
+}
+
+@Preview(
+    name = "Modal_small_Fold2",
+    showBackground = true,
+    device = Devices.FOLDABLE,
+    group = "Fold"
+)
+@Composable
+private fun PreviewCareDialogSmallFold2() {
+    PreviewCareDialogSmallContent2()
 }

--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/ProgressBar.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/ProgressBar.kt
@@ -3,6 +3,7 @@ package com.idle.designsystem.compose.component
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.LinearProgressIndicator
@@ -16,8 +17,11 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.idle.designsystem.compose.Flip
 import com.idle.designsystem.compose.foundation.CareTheme
 
 @Composable
@@ -60,7 +64,7 @@ private fun formatProgressText(
     totalSteps: Int,
 ) = buildAnnotatedString {
     withStyle(
-        style = SpanStyle(color = CareTheme.colors.orange500,)
+        style = SpanStyle(color = CareTheme.colors.orange500)
     ) {
         append("$currentStep ")
     }
@@ -72,4 +76,36 @@ private fun formatProgressText(
     ) {
         append("/ $totalSteps")
     }
+}
+
+@Composable
+private fun CareProgressBarContent() {
+    CareProgressBar(
+        currentStep = 3,
+        totalSteps = 5,
+        modifier = Modifier.fillMaxWidth()
+    )
+}
+
+@Preview(name = "Progress_Default", showBackground = true, group = "Default")
+@Composable
+private fun PreviewCareProgressBarDefault() {
+    CareProgressBarContent()
+}
+
+@Preview(name = "Progress_Flip", showBackground = true, device = Flip, group = "Flip")
+@Composable
+private fun PreviewCareProgressBarFlip() {
+    CareProgressBarContent()
+}
+
+@Preview(
+    name = "Progress_Foldable",
+    showBackground = true,
+    device = Devices.FOLDABLE,
+    group = "Fold"
+)
+@Composable
+private fun PreviewCareProgressBarFoldable() {
+    CareProgressBarContent()
 }

--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/Tag.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/Tag.kt
@@ -11,7 +11,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.idle.designsystem.compose.Flip
 import com.idle.designsystem.compose.foundation.CareTheme
 
 @Composable
@@ -36,4 +39,20 @@ fun CareTag(
             modifier = Modifier.padding(horizontal = 4.dp, vertical = 0.5.dp),
         )
     }
+}
+
+@Composable
+private fun CareTagContent() {
+    CareTag(
+        text = "Sample Tag",
+        textColor = CareTheme.colors.white000,
+        backgroundColor = CareTheme.colors.orange500,
+        modifier = Modifier.wrapContentSize()
+    )
+}
+
+@Preview(name = "Tag_Default", showBackground = true, group = "Default")
+@Composable
+private fun PreviewCareTagDefault() {
+    CareTagContent()
 }

--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/TextField.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/TextField.kt
@@ -1,6 +1,7 @@
 package com.idle.designsystem.compose.component
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -24,12 +25,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.idle.compose.clickable
+import com.idle.designresource.R
+import com.idle.designsystem.compose.Flip
 import com.idle.designsystem.compose.foundation.CareTheme
 
 @Composable
@@ -344,4 +350,95 @@ fun CareClickableTextField(
 
         leftComponent()
     }
+}
+
+@Composable
+private fun CareTextFieldDefaultContent() {
+    CareTextField(
+        value = "Sample Text",
+        onValueChanged = {},
+        supportingText = "Supporting text",
+        hint = "Hint",
+        modifier = Modifier.fillMaxWidth()
+    )
+}
+
+@Composable
+private fun CareTextFieldLongDefaultContent() {
+    CareTextFieldLong(
+        value = "Sample Long Text",
+        hint = "Long Hint",
+        onValueChanged = {},
+        modifier = Modifier.fillMaxWidth()
+    )
+}
+
+@Composable
+private fun CareClickableTextFieldDefaultContent() {
+    CareClickableTextField(
+        value = "Clickable Text",
+        onClick = {},
+        leftComponent = {
+            Image(
+                painter = painterResource(R.drawable.ic_arrow_down),
+                contentDescription = null,
+            )
+        },
+        hint = "Hint",
+        modifier = Modifier.fillMaxWidth()
+    )
+}
+
+@Preview(name = "TextField_Default", showBackground = true, group = "Default")
+@Composable
+private fun PreviewCareTextFieldDefault() {
+    CareTextFieldDefaultContent()
+}
+
+@Preview(name = "TextField_Flip", showBackground = true, device = Flip, group = "Flip")
+@Composable
+private fun PreviewCareTextFieldFlip() {
+    CareTextFieldDefaultContent()
+}
+
+@Preview(name = "TextField_Foldable", showBackground = true, device = Devices.FOLDABLE, group = "Fold")
+@Composable
+private fun PreviewCareTextFieldFoldable() {
+    CareTextFieldDefaultContent()
+}
+
+@Preview(name = "TextFieldLong_Default", showBackground = true, group = "Default")
+@Composable
+private fun PreviewCareTextFieldLongDefault() {
+    CareTextFieldLongDefaultContent()
+}
+
+@Preview(name = "TextFieldLong_Flip", showBackground = true, device = Flip, group = "Flip")
+@Composable
+private fun PreviewCareTextFieldLongFlip() {
+    CareTextFieldLongDefaultContent()
+}
+
+@Preview(name = "TextFieldLong_Foldable", showBackground = true, device = Devices.FOLDABLE, group = "Fold")
+@Composable
+private fun PreviewCareTextFieldLongFoldable() {
+    CareTextFieldLongDefaultContent()
+}
+
+@Preview(name = "ClickableTextField_Default", showBackground = true, group = "Default")
+@Composable
+private fun PreviewCareClickableTextFieldDefault() {
+    CareClickableTextFieldDefaultContent()
+}
+
+@Preview(name = "ClickableTextField_Flip", showBackground = true, device = Flip, group = "Flip")
+@Composable
+private fun PreviewCareClickableTextFieldFlip() {
+    CareClickableTextFieldDefaultContent()
+}
+
+@Preview(name = "ClickableTextField_Foldable", showBackground = true, device = Devices.FOLDABLE, group = "Fold")
+@Composable
+private fun PreviewCareClickableTextFieldFoldable() {
+    CareClickableTextFieldDefaultContent()
 }

--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/TopAppBar.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/TopAppBar.kt
@@ -4,13 +4,18 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.idle.compose.clickable
+import com.idle.designsystem.compose.Flip
 import com.idle.designsystem.compose.foundation.CareTheme
 
 @Composable
@@ -65,4 +70,66 @@ fun CareHeadingTopAppBar(
 
         leftComponent()
     }
+}
+
+@Composable
+private fun CareSubtitleTopAppBarContent() {
+    CareSubtitleTopAppBar(
+        title = "Subtitle AppBar",
+        onNavigationClick = {},
+        leftComponent = {
+            Text(text = "Left Action", style = CareTheme.typography.body3)
+        },
+        modifier = Modifier.fillMaxWidth().padding(16.dp)
+    )
+}
+
+@Composable
+private fun CareHeadingTopAppBarContent() {
+    CareHeadingTopAppBar(
+        title = "Heading AppBar",
+        rightComponent = {
+            Text(text = "Right Action", style = CareTheme.typography.body3)
+        },
+        leftComponent = {
+            Text(text = "Left Action", style = CareTheme.typography.body3)
+        },
+        modifier = Modifier.fillMaxWidth().padding(16.dp)
+    )
+}
+
+@Preview(name = "SubtitleTopAppBar_Default", showBackground = true, group = "Default")
+@Composable
+private fun PreviewCareSubtitleTopAppBarDefault() {
+    CareSubtitleTopAppBarContent()
+}
+
+@Preview(name = "SubtitleTopAppBar_Flip", showBackground = true, device = Flip, group = "Flip")
+@Composable
+private fun PreviewCareSubtitleTopAppBarFlip() {
+    CareSubtitleTopAppBarContent()
+}
+
+@Preview(name = "SubtitleTopAppBar_Foldable", showBackground = true, device = Devices.FOLDABLE, group = "Fold")
+@Composable
+private fun PreviewCareSubtitleTopAppBarFoldable() {
+    CareSubtitleTopAppBarContent()
+}
+
+@Preview(name = "HeadingTopAppBar_Default", showBackground = true, group = "Default")
+@Composable
+private fun PreviewCareHeadingTopAppBarDefault() {
+    CareHeadingTopAppBarContent()
+}
+
+@Preview(name = "HeadingTopAppBar_Flip", showBackground = true, device = Flip, group = "Flip")
+@Composable
+private fun PreviewCareHeadingTopAppBarFlip() {
+    CareHeadingTopAppBarContent()
+}
+
+@Preview(name = "HeadingTopAppBar_Foldable", showBackground = true, device = Devices.FOLDABLE, group = "Fold")
+@Composable
+private fun PreviewCareHeadingTopAppBarFoldable() {
+    CareHeadingTopAppBarContent()
 }

--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/WheelPicker.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/WheelPicker.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.idle.designsystem.compose.Flip
 import com.idle.designsystem.compose.foundation.CareTheme
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -91,58 +92,81 @@ fun <T> CareWheelPicker(
     }
 }
 
-@Preview
 @Composable
-fun PreviewCareWheelPickerHour() {
+private fun CareWheelPickerContent(list: List<Any>, initIndex: Int = 0) {
     CareWheelPicker(
-        list = (1..12).toList(),
-        onItemSelected = { },
-    )
-}
-
-@Preview
-@Composable
-fun PreviewCareWheelPickerMinute() {
-    CareWheelPicker(
-        list = (0..50 step 10).toList(),
+        list = list,
         onItemSelected = {},
-    )
-}
-
-@Preview
-@Composable
-fun PreviewCareWheelPickerString() {
-    CareWheelPicker(
-        list = listOf("오전", "오후"),
-        initIndex = 1,
-        onItemSelected = {},
-    )
-}
-
-@Preview(
-    name = "Foldable",
-    showBackground = true,
-    device = Devices.FOLDABLE
-)
-@Composable
-fun PreviewCareWheelPickerFoldable() {
-    CareWheelPicker(
-        list = (1..24).toList(),
-        onItemSelected = { },
+        initIndex = initIndex,
         modifier = Modifier.padding(horizontal = 20.dp)
     )
 }
 
+@Preview(name = "WheelPicker_Default_Hour", showBackground = true, group = "Default")
+@Composable
+private fun PreviewCareWheelPickerHourDefault() {
+    CareWheelPickerContent(list = (1..12).toList())
+}
+
+@Preview(name = "WheelPicker_Default_Minute", showBackground = true, group = "Default")
+@Composable
+private fun PreviewCareWheelPickerMinuteDefault() {
+    CareWheelPickerContent(list = (0..50 step 10).toList())
+}
+
+@Preview(name = "WheelPicker_Default_String", showBackground = true, group = "Default")
+@Composable
+private fun PreviewCareWheelPickerStringDefault() {
+    CareWheelPickerContent(list = listOf("오전", "오후"), initIndex = 1)
+}
+
+@Preview(name = "WheelPicker_Flip_Hour", showBackground = true, device = Flip, group = "Flip")
+@Composable
+private fun PreviewCareWheelPickerHourFlip() {
+    CareWheelPickerContent(list = (1..12).toList())
+}
+
+@Preview(name = "WheelPicker_Flip_Minute", showBackground = true, device = Flip, group = "Flip")
+@Composable
+private fun PreviewCareWheelPickerMinuteFlip() {
+    CareWheelPickerContent(list = (0..50 step 10).toList())
+}
+
+@Preview(name = "WheelPicker_Flip_String", showBackground = true, device = Flip, group = "Flip")
+@Composable
+private fun PreviewCareWheelPickerStringFlip() {
+    CareWheelPickerContent(list = listOf("오전", "오후"), initIndex = 1)
+}
+
 @Preview(
-    name = "Flip",
+    name = "WheelPicker_Foldable_Hour",
     showBackground = true,
-    device = "spec:width=480dp,height=320dp,dpi=480,isRound=false,chinSize=0dp"
+    device = Devices.FOLDABLE,
+    group = "Fold"
 )
 @Composable
-fun PreviewCareWheelPickerFlip() {
-    CareWheelPicker(
-        list = listOf("오전", "오후"),
-        onItemSelected = {},
-        modifier = Modifier.padding(horizontal = 20.dp)
-    )
+private fun PreviewCareWheelPickerHourFoldable() {
+    CareWheelPickerContent(list = (1..12).toList())
+}
+
+@Preview(
+    name = "WheelPicker_Foldable_Minute",
+    showBackground = true,
+    device = Devices.FOLDABLE,
+    group = "Fold"
+)
+@Composable
+private fun PreviewCareWheelPickerMinuteFoldable() {
+    CareWheelPickerContent(list = (0..50 step 10).toList())
+}
+
+@Preview(
+    name = "WheelPicker_Foldable_String",
+    showBackground = true,
+    device = Devices.FOLDABLE,
+    group = "Fold"
+)
+@Composable
+private fun PreviewCareWheelPickerStringFoldable() {
+    CareWheelPickerContent(list = listOf("오전", "오후"), initIndex = 1)
 }

--- a/feature/center/job-posting/src/main/java/com/idle/center/jobposting/JobPostingFragment.kt
+++ b/feature/center/job-posting/src/main/java/com/idle/center/jobposting/JobPostingFragment.kt
@@ -40,7 +40,7 @@ import com.idle.compose.addFocusCleaner
 import com.idle.compose.base.BaseComposeFragment
 import com.idle.designsystem.compose.component.CareBottomSheetLayout
 import com.idle.designsystem.compose.component.CareButtonMedium
-import com.idle.designsystem.compose.component.CareButtonStrokeSmall
+import com.idle.designsystem.compose.component.CareButtonRound
 import com.idle.designsystem.compose.component.CareCalendar
 import com.idle.designsystem.compose.component.CareProgressBar
 import com.idle.designsystem.compose.component.CareStateAnimator
@@ -522,7 +522,7 @@ internal fun JobPostingScreen(
                     onNavigationClick = { onBackPressedDispatcher?.onBackPressed() },
                     leftComponent = {
                         if (jobPostingStep == JobPostingStep.SUMMARY) {
-                            CareButtonStrokeSmall(
+                            CareButtonRound(
                                 text = "공고 수정하기",
                                 onClick = { setEditState(true) },
                             )

--- a/feature/center/profile/src/main/java/com/idle/center/profile/CenterProfileFragment.kt
+++ b/feature/center/profile/src/main/java/com/idle/center/profile/CenterProfileFragment.kt
@@ -39,7 +39,7 @@ import com.idle.compose.addFocusCleaner
 import com.idle.compose.base.BaseComposeFragment
 import com.idle.compose.clickable
 import com.idle.designresource.R
-import com.idle.designsystem.compose.component.CareButtonStrokeSmall
+import com.idle.designsystem.compose.component.CareButtonRound
 import com.idle.designsystem.compose.component.CareSubtitleTopAppBar
 import com.idle.designsystem.compose.component.CareTextField
 import com.idle.designsystem.compose.component.CareTextFieldLong
@@ -173,7 +173,7 @@ internal fun CenterProfileScreen(
                     )
 
                     if (!isEditState) {
-                        CareButtonStrokeSmall(
+                        CareButtonRound(
                             text = "수정하기",
                             onClick = { setEditState(true) }
                         )

--- a/feature/worker/profile/src/main/java/com/idle/worker/profile/WorkerProfileFragment.kt
+++ b/feature/worker/profile/src/main/java/com/idle/worker/profile/WorkerProfileFragment.kt
@@ -39,7 +39,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.idle.compose.addFocusCleaner
 import com.idle.compose.base.BaseComposeFragment
 import com.idle.compose.clickable
-import com.idle.designsystem.compose.component.CareButtonStrokeSmall
+import com.idle.designsystem.compose.component.CareButtonRound
 import com.idle.designsystem.compose.component.CareChipBasic
 import com.idle.designsystem.compose.component.CareSubtitleTopAppBar
 import com.idle.designsystem.compose.component.CareTag
@@ -132,7 +132,7 @@ internal fun WorkerProfileScreen(
                                 }
                             )
                         } else {
-                            CareButtonStrokeSmall(
+                            CareButtonRound(
                                 text = "수정하기",
                                 onClick = { setEditState(true) },
                             )


### PR DESCRIPTION
## 1. 🔥 변경된 내용
- **DesignSystem Component Default, Flip, Flop별 Preview 추가**

## 2. 📸 스크린샷(선택)

디바이스별로 group하여 Preview를 보여줍니다.

<img width="410" alt="image" src="https://github.com/user-attachments/assets/de593a8c-4ce8-40e0-b57c-b32ee16f8ba0">

## 3. 💡 알게된 부분

Preview에서 디바이스, 언어, fontScale도 줄 수 있다....!

무엇보다 group대박...!

[[Compose] @Preview 분석](https://jjunsu.tistory.com/385)
