### PR TITLE
[IDLE-252] WheelPicker 성능 개선

### DIFF
--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/WheelPicker.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/WheelPicker.kt
@@ -15,8 +15,12 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -34,6 +38,8 @@ fun <T> CareWheelPicker(
     pickerMaxHeight: Dp = 150.dp,
 ) {
     val listState = rememberLazyListState(initialFirstVisibleItemIndex = initIndex)
+    val firstItemScrollOffset by remember { derivedStateOf { listState.firstVisibleItemScrollOffset } }
+    val firstItemIndex by remember { derivedStateOf { listState.firstVisibleItemIndex } }
     val snapFlingBehavior = rememberSnapFlingBehavior(lazyListState = listState)
 
     // Int 타입이면 padStart 적용, 아니면 기본 toString 사용
@@ -44,8 +50,13 @@ fun <T> CareWheelPicker(
         }
     } + listOf("")
 
+    val density = LocalDensity.current
+    val threshold = with(density) { 30.dp.toPx().toInt() }
+
     LaunchedEffect(listState.isScrollInProgress) {
-        val currentIndex = listState.firstVisibleItemIndex + 1
+        val currentIndex = if (firstItemScrollOffset >= threshold) firstItemIndex + 2
+        else firstItemIndex + 1
+
         onItemSelected(innerList[currentIndex])
     }
 
@@ -60,7 +71,10 @@ fun <T> CareWheelPicker(
                 .height(pickerMaxHeight),
         ) {
             itemsIndexed(items = innerList) { idx, item ->
-                if (idx == listState.firstVisibleItemIndex + 1) {
+                val currentIndex = if (firstItemScrollOffset >= threshold) firstItemIndex + 2
+                else firstItemIndex + 1
+
+                if (idx == currentIndex) {
                     Text(
                         text = item,
                         style = CareTheme.typography.heading2,


### PR DESCRIPTION
## 1. 🔥 변경된 내용

- **WheelPicker 기능적, 성능적 개선**

**firstVisibleItemIndex + 1** 만으로 **중앙 값을 결정**한다면,

아래와 같이 **약간 마음에 안드는 UI**가 완성되는데, *(항상 중앙을 바라보지 않고 조금만 스크롤 해도 하이라이팅이 변경)*

https://github.com/user-attachments/assets/17bd785c-6022-4a87-8257-5ad2421f8fba

<br><br><br>

평상시에는 **firstVisilbieIndex + 1**로 **하이라이팅**을 주다가,

![image](https://github.com/user-attachments/assets/3d16aa04-6f0b-4a77-a394-c0dc0b76be43)

<br><br><br>

아래로 혹은 위로 드래그 하다가 아래와 같이 스크롤이 되었을 때 **firstVisibleItemIndex+2** 로 **중앙값 하이라이팅**을 주면 된다.

![image](https://github.com/user-attachments/assets/72429763-9249-4fcb-a6e4-fb65bbe977f3)

<br><br><br>

로그를 일일이 찍어보니 **아이템의 높이**인 **30.dp**를 넘어서 **스크롤을 해도 보이지 않는 해당 Item의 Index**가 찍히던데,

추측을 하자면 **verticalArranement**가 **30.dp**로 설정되어있어서 **위 아래로 15.dp씩 더 붙어서 총 60.dp**가 **하나의 item 높이가 되는 것 같다.**

그래서 **firstVisibleItemScrollOffset**이 **30.dp**를 넘어가는 순간 **firstVisbleItemIndex + 2를 중앙값으로 인식**시키면 아래와 같은 결과물이 완성된다.

## 2. 📸 스크린샷(선택)

![ezgif com-resize](https://github.com/user-attachments/assets/63ec443a-e6eb-4af7-a880-171f28327a5f)

## 3. 💡 알게된 부분

### derivedStateOf()를 사용하면 불필요한 리컴포지션을 최소화시킬 수 있다.

**derivedStateOf()** 는 **stateFlow**에 **동일한 값이 할당되면 emit을 내뱉지 않는 것** 처럼,

**이전 값과 똑같은 값이 들어오면 계산하지 않는 역할**을 한다.

**ListState**의 **두 프로퍼티**는 **스크롤될때마다 수십 번 호출**되기 때문에 **불필요한 리컴포지션을 야기**하는데

**두 변수**를 **derivedStateOf**로 래핑해주면 최적화를 시켜줄 수 있다.
