### PR TITLE
[IDLE-268] 우편 주소 창 사이즈 조절

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,3 @@
-import java.util.Properties
-
 plugins {
     id("care.android.application")
     id("care.android.binding")
@@ -12,10 +10,6 @@ android {
         versionCode = 1
         versionName = "1.0"
         targetSdk = 34
-
-        val properties = Properties()
-        properties.load(project.rootProject.file("local.properties").bufferedReader())
-        manifestPlaceholders["NAVER_CLIENT_ID"] = properties["NAVER_CLIENT_ID"] as String
     }
 
     packaging {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,8 +27,5 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <meta-data
-            android:name="com.naver.maps.map.CLIENT_ID"
-            android:value="${NAVER_CLIENT_ID}" />
     </application>
 </manifest>

--- a/feature/postcode/src/main/java/com/idle/post/code/PostCodeFragment.kt
+++ b/feature/postcode/src/main/java/com/idle/post/code/PostCodeFragment.kt
@@ -1,7 +1,10 @@
 package com.idle.post.code
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.content.DialogInterface
+import android.graphics.Point
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -44,15 +47,37 @@ class PostCodeFragment : DialogFragment() {
 
     override fun onStart() {
         super.onStart()
-        dialog?.window?.setLayout(
-            WindowManager.LayoutParams.MATCH_PARENT,
-            WindowManager.LayoutParams.MATCH_PARENT
-        )
+        resizeDialog(1f, 0.6f)
     }
 
     override fun onDismiss(dialog: DialogInterface) {
         onDismissCallback?.invoke()
         super.onDismiss(dialog)
+    }
+
+    private fun resizeDialog(width: Float, height: Float) {
+        val windowManager =
+            requireContext().getSystemService(Context.WINDOW_SERVICE) as WindowManager
+
+        if (Build.VERSION.SDK_INT < 30) {
+            val display = windowManager.defaultDisplay
+            val size = Point()
+            display.getSize(size)
+
+            val window = this.dialog?.window
+
+            val x = (size.x * width).toInt()
+            val y = (size.y * height).toInt()
+            window?.setLayout(x, y)
+        } else {
+            val rect = windowManager.currentWindowMetrics.bounds
+
+            val window = this.dialog?.window
+
+            val x = (rect.width() * width).toInt()
+            val y = (rect.height() * height).toInt()
+            window?.setLayout(x, y)
+        }
     }
 
     override fun onDestroyView() {

--- a/feature/postcode/src/main/res/layout/fragment_post_code.xml
+++ b/feature/postcode/src/main/res/layout/fragment_post_code.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <androidx.constraintlayout.widget.ConstraintLayout


### PR DESCRIPTION
## 1. 🔥 변경된 내용
- **우편 주소 Dialog Size 변경**

## 2. 📸 스크린샷(선택)

<img width="312" alt="image" src="https://github.com/user-attachments/assets/944d8480-d0a7-46aa-af0d-4af054398bbd">

## 3. 💡 알게된 부분

<img width="647" alt="image" src="https://github.com/user-attachments/assets/dc3c4198-2932-41d6-bcaa-f3a8cc73b962">

왜 다이얼로그의 resize를 `onStart()` 혹은 `onResume()`에서만 먹히는 지 너무 궁금했다.

대부분의 View는 `onViewCreated()` 혹은 `onCreateView()`에서 관련된 속성을 변경시켜서 적용을 하는데,

왜 Dialog는 저 두개의 lifecycle에서만 먹히는 것일까..

```kotlin
override fun onStart() {
    super.onStart()
    resizeDialog(1f, 0.6f)
}

private fun resizeDialog(width: Float, height: Float) {
    val windowManager =
        requireContext().getSystemService(Context.WINDOW_SERVICE) as WindowManager

    if (Build.VERSION.SDK_INT < 30) {
        val display = windowManager.defaultDisplay
        val size = Point()
        display.getSize(size)

        val window = this.dialog?.window

        val x = (size.x * width).toInt()
        val y = (size.y * height).toInt()
        window?.setLayout(x, y)
    } else {
        val rect = windowManager.currentWindowMetrics.bounds

        val window = this.dialog?.window

        val x = (rect.width() * width).toInt()
        val y = (rect.height() * height).toInt()
        window?.setLayout(x, y)
    }
}
```


<br><br><br>

두둥탁....

```
Dialog는 RootView부터 타고타고 내려와서 그려지는 View가 아니라,

다이얼로그가 onStart() 이후에 그려지는 이유는 다이얼로그가 독립적인 윈도우로 처리되기 때문입니다. 

일반적인 뷰는 onViewCreated()에서 그려지기 시작하지만, 

다이얼로그는 WindowManager에 의해 관리되며, 

WindowManager가 다이얼로그를 윈도우로 등록하고 배치 작업을 수행하는 시점이 onStart() 이후입니다.

 이 때문에, 다이얼로그의 크기와 위치를 조정하거나, 다이얼로그를 그리기 위해서는 onStart() 이후에 작업을 수행하는 것이 적절합니다.
```

또 이렇게 광명을....