### PR TITLE
[IDLE-000] Scroll가능한 View에서 OverScroll 이펙트를 없앰

### DIFF
--- a/core/common-ui/compose/src/main/java/com/idle/compose/base/BaseComposeFragment.kt
+++ b/core/common-ui/compose/src/main/java/com/idle/compose/base/BaseComposeFragment.kt
@@ -4,7 +4,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.LocalOverscrollConfiguration
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
@@ -31,16 +34,20 @@ abstract class BaseComposeFragment : Fragment() {
         }
     }
 
+    @OptIn(ExperimentalFoundationApi::class)
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         viewLifecycleOwner.repeatOnStarted {
-            fragmentViewModel.baseEventFlow.collect { handleEvent(it)
+            fragmentViewModel.baseEventFlow.collect {
+                handleEvent(it)
             }
         }
 
         composeView.setContent {
-            ComposeLayout()
+            CompositionLocalProvider(LocalOverscrollConfiguration provides null) {
+                ComposeLayout()
+            }
         }
     }
 

--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/Card.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/Card.kt
@@ -51,7 +51,10 @@ fun CareCard(
                 .padding(horizontal = 20.dp, vertical = 16.dp)
         ) {
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
                     titleLeftComponent()
 
                     Text(
@@ -61,7 +64,10 @@ fun CareCard(
                     )
                 }
 
-                Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(2.dp)
+                ) {
                     descriptionLeftComponent()
 
                     Text(
@@ -113,7 +119,12 @@ private fun PreviewCareCenterInfoCardFlip() {
     CareCenterInfoCardPreviewContent()
 }
 
-@Preview(name = "CareCenterInfoCard_Fold", showBackground = true, device = Devices.FOLDABLE, group = "Fold")
+@Preview(
+    name = "CareCenterInfoCard_Fold",
+    showBackground = true,
+    device = Devices.FOLDABLE,
+    group = "Fold"
+)
 @Composable
 private fun PreviewCareCenterInfoCardFoldable() {
     CareCenterInfoCardPreviewContent()
@@ -149,7 +160,12 @@ private fun PreviewCareContactCardFlip() {
     CareContactCardPreviewContent()
 }
 
-@Preview(name = "CareContactCard_Fold", showBackground = true, device = Devices.FOLDABLE, group = "Fold")
+@Preview(
+    name = "CareContactCard_Fold",
+    showBackground = true,
+    device = Devices.FOLDABLE,
+    group = "Fold"
+)
 @Composable
 private fun PreviewCareContactCardFoldable() {
     CareContactCardPreviewContent()

--- a/feature/worker/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/WorkerJobPostingDetailFragment.kt
+++ b/feature/worker/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/WorkerJobPostingDetailFragment.kt
@@ -600,9 +600,7 @@ internal fun WorkerJobPostingDetailScreen(
 
                     Row(
                         horizontalArrangement = Arrangement.spacedBy(32.dp),
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 20.dp),
+                        modifier = Modifier.fillMaxWidth(),
                     ) {
                         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                             Text(


### PR DESCRIPTION
## 1. 🔥 변경된 내용

- **Compose를 사용하면 기본적으로 OverScroll시 달려있는 AnimationEffect를 제거하였습니다.**

## 2. 📸 스크린샷(선택)

https://github.com/user-attachments/assets/5bbeba09-eb59-4188-822e-eac6020de4e1

## 3. 💡 알게된 부분

```kotlin
    @OptIn(ExperimentalFoundationApi::class)
    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
        super.onViewCreated(view, savedInstanceState)

        viewLifecycleOwner.repeatOnStarted {
            fragmentViewModel.baseEventFlow.collect {
                handleEvent(it)
            }
        }

        composeView.setContent {
            CompositionLocalProvider(LocalOverscrollConfiguration provides null) {   // <-------- 스크롤을 없애고 싶은 부분에서 CompositionLocalProvider로 값을 넘겨주면 된다!
                ComposeLayout()
            }
        }
    }
```