### PR TITLE
[IDLE-312] 로그아웃, 회원탈퇴 API 연결 및 네비게이션 관리

### DIFF
--- a/core/datastore/src/main/java/com/idle/datastore/datasource/TokenDataSource.kt
+++ b/core/datastore/src/main/java/com/idle/datastore/datasource/TokenDataSource.kt
@@ -3,9 +3,12 @@ package com.idle.datastore.datasource
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.stringPreferencesKey
+import com.idle.datastore.util.clear
 import com.idle.datastore.util.getValue
 import com.idle.datastore.util.setValue
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -21,6 +24,11 @@ class TokenDataSource @Inject constructor(
 
     suspend fun setRefreshToken(refreshToken: String) {
         dataStore.setValue(REFRESH_TOKEN, refreshToken)
+    }
+
+    suspend fun clearToken() = coroutineScope {
+        dataStore.clear(ACCESS_TOKEN)
+        launch { dataStore.clear(REFRESH_TOKEN) }
     }
 
     companion object {

--- a/core/datastore/src/main/java/com/idle/datastore/util/DataStoreUtil.kt
+++ b/core/datastore/src/main/java/com/idle/datastore/util/DataStoreUtil.kt
@@ -26,6 +26,11 @@ internal suspend fun <T> DataStore<Preferences>.setValue(
     preferences[key] = value
 }
 
+internal suspend fun <T> DataStore<Preferences>.clear(
+    key: Preferences.Key<T>
+) = edit { preferences ->
+    preferences.remove(key)
+}
 
 private fun Flow<Preferences>.handleException(): Flow<Preferences> =
     this.catch { exception ->

--- a/core/domain/src/main/kotlin/com/idle/domain/repositorry/auth/AuthRepository.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/repositorry/auth/AuthRepository.kt
@@ -35,4 +35,12 @@ interface AuthRepository {
     ): Result<Unit>
 
     suspend fun signInWorker(phoneNumber: String, authCode: String): Result<Unit>
+
+    suspend fun logoutWorker(): Result<Unit>
+
+    suspend fun logoutCenter(): Result<Unit>
+
+    suspend fun withdrawalCenter(reason: String, password: String): Result<Unit>
+
+    suspend fun withdrawalWorker(reason: String): Result<Unit>
 }

--- a/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/LogoutCenterUseCase.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/LogoutCenterUseCase.kt
@@ -1,0 +1,10 @@
+package com.idle.domain.usecase.auth
+
+import com.idle.domain.repositorry.auth.AuthRepository
+import javax.inject.Inject
+
+class LogoutCenterUseCase @Inject constructor(
+    private val authRepository: AuthRepository,
+) {
+    suspend operator fun invoke() = authRepository.logoutCenter()
+}

--- a/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/LogoutWorkerUseCase.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/LogoutWorkerUseCase.kt
@@ -1,0 +1,10 @@
+package com.idle.domain.usecase.auth
+
+import com.idle.domain.repositorry.auth.AuthRepository
+import javax.inject.Inject
+
+class LogoutWorkerUseCase @Inject constructor(
+    private val authRepository: AuthRepository,
+) {
+    suspend operator fun invoke() = authRepository.logoutWorker()
+}

--- a/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/WithdrawalCenterUseCase.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/WithdrawalCenterUseCase.kt
@@ -1,0 +1,11 @@
+package com.idle.domain.usecase.auth
+
+import com.idle.domain.repositorry.auth.AuthRepository
+import javax.inject.Inject
+
+class WithdrawalCenterUseCase @Inject constructor(
+    private val authRepository: AuthRepository,
+) {
+    suspend operator fun invoke(reason: String, password: String) =
+        authRepository.withdrawalCenter(reason = reason, password = password)
+}

--- a/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/WithdrawalWorkerUseCase.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/WithdrawalWorkerUseCase.kt
@@ -1,0 +1,10 @@
+package com.idle.domain.usecase.auth
+
+import com.idle.domain.repositorry.auth.AuthRepository
+import javax.inject.Inject
+
+class WithdrawalWorkerUseCase @Inject constructor(
+    private val authRepository: AuthRepository,
+) {
+    suspend operator fun invoke(reason: String) = authRepository.withdrawalWorker(reason = reason)
+}

--- a/core/network/src/main/java/com/idle/network/api/CareApi.kt
+++ b/core/network/src/main/java/com/idle/network/api/CareApi.kt
@@ -7,6 +7,8 @@ import com.idle.network.model.auth.SignInCenterRequest
 import com.idle.network.model.auth.SignInWorkerRequest
 import com.idle.network.model.auth.SignUpCenterRequest
 import com.idle.network.model.auth.SignUpWorkerRequest
+import com.idle.network.model.auth.WithdrawalCenterRequest
+import com.idle.network.model.auth.WithdrawalWorkerRequest
 import com.idle.network.model.jobposting.JobPostingRequest
 import com.idle.network.model.profile.CallbackImageUploadRequest
 import com.idle.network.model.profile.GetCenterProfileResponse
@@ -49,6 +51,22 @@ interface CareApi {
 
     @POST("/api/v1/auth/carer/login")
     suspend fun signInWorker(@Body signInWorkerRequest: SignInWorkerRequest): Response<Unit>
+
+    @POST("/api/v1/auth/center/logout")
+    suspend fun logoutCenter(): Response<Unit>
+
+    @POST("/api/v1/auth/worker/logout")
+    suspend fun logoutWorker(): Response<Unit>
+
+    @POST("/api/v1/auth/worker/withdraw")
+    suspend fun withdrawalCenter(
+        @Body withdrawalCenterResponse: WithdrawalCenterRequest
+    ): Response<Unit>
+
+    @POST("/api/v1/auth/worker/withdraw")
+    suspend fun withdrawalWorker(
+        @Body withdrawalWorkerResponse: WithdrawalWorkerRequest
+    ): Response<Unit>
 
     @GET("/api/v1/auth/center/validation/{identifier}")
     suspend fun validateIdentifier(@Path("identifier") identifier: String): Response<Unit>

--- a/core/network/src/main/java/com/idle/network/api/CareApi.kt
+++ b/core/network/src/main/java/com/idle/network/api/CareApi.kt
@@ -58,7 +58,7 @@ interface CareApi {
     @POST("/api/v1/auth/worker/logout")
     suspend fun logoutWorker(): Response<Unit>
 
-    @POST("/api/v1/auth/worker/withdraw")
+    @POST("/api/v1/auth/center/withdraw")
     suspend fun withdrawalCenter(
         @Body withdrawalCenterResponse: WithdrawalCenterRequest
     ): Response<Unit>

--- a/core/network/src/main/java/com/idle/network/model/auth/WithdrawalCenterRequest.kt
+++ b/core/network/src/main/java/com/idle/network/model/auth/WithdrawalCenterRequest.kt
@@ -1,0 +1,9 @@
+package com.idle.network.model.auth
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WithdrawalCenterRequest(
+    val reason: String,
+    val password: String,
+)

--- a/core/network/src/main/java/com/idle/network/model/auth/WithdrawalWorkerRequest.kt
+++ b/core/network/src/main/java/com/idle/network/model/auth/WithdrawalWorkerRequest.kt
@@ -1,0 +1,8 @@
+package com.idle.network.model.auth
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WithdrawalWorkerRequest(
+    val reason: String,
+)

--- a/core/network/src/main/java/com/idle/network/source/auth/AuthDataSource.kt
+++ b/core/network/src/main/java/com/idle/network/source/auth/AuthDataSource.kt
@@ -8,6 +8,8 @@ import com.idle.network.model.auth.SignInCenterRequest
 import com.idle.network.model.auth.SignInWorkerRequest
 import com.idle.network.model.auth.SignUpCenterRequest
 import com.idle.network.model.auth.SignUpWorkerRequest
+import com.idle.network.model.auth.WithdrawalCenterRequest
+import com.idle.network.model.auth.WithdrawalWorkerRequest
 import com.idle.network.model.token.TokenResponse
 import com.idle.network.util.onResponse
 import javax.inject.Inject
@@ -32,6 +34,16 @@ class AuthDataSource @Inject constructor(
 
     suspend fun signInWorker(signInWorkerRequest: SignInWorkerRequest): Result<Unit> =
         careApi.signInWorker(signInWorkerRequest).onResponse()
+
+    suspend fun logoutWorker(): Result<Unit> = careApi.logoutWorker().onResponse()
+
+    suspend fun logoutCenter(): Result<Unit> = careApi.logoutCenter().onResponse()
+
+    suspend fun withdrawalCenter(withdrawalCenterRequest: WithdrawalCenterRequest): Result<Unit> =
+        careApi.withdrawalCenter(withdrawalCenterRequest).onResponse()
+
+    suspend fun withdrawalWorker(withdrawalWorkerRequest: WithdrawalWorkerRequest): Result<Unit> =
+        careApi.withdrawalWorker(withdrawalWorkerRequest).onResponse()
 
     suspend fun validateIdentifier(identifier: String): Result<Unit> =
         careApi.validateIdentifier(identifier).onResponse()

--- a/feature/auth/src/main/java/com/idle/auth/AuthFragment.kt
+++ b/feature/auth/src/main/java/com/idle/auth/AuthFragment.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.fragment.findNavController
 import com.idle.binding.DeepLinkDestination
 import com.idle.binding.DeepLinkDestination.CenterSignIn
 import com.idle.binding.DeepLinkDestination.CenterSignUp

--- a/feature/setting/src/main/java/com/idle/setting/SettingEvent.kt
+++ b/feature/setting/src/main/java/com/idle/setting/SettingEvent.kt
@@ -8,4 +8,5 @@ sealed class SettingEvent {
     data object PrivacyPolicy : SettingEvent()
     data object Logout : SettingEvent()
     data object Withdrawal : SettingEvent()
+    data object LogoutSuccess : SettingEvent()
 }

--- a/feature/setting/src/main/java/com/idle/setting/center/CenterSettingFragment.kt
+++ b/feature/setting/src/main/java/com/idle/setting/center/CenterSettingFragment.kt
@@ -14,11 +14,14 @@ import com.idle.binding.repeatOnStarted
 import com.idle.domain.model.auth.UserRole
 import com.idle.setting.FAQ_URL
 import com.idle.setting.PRIVACY_POLICY_URL
+import com.idle.setting.R
 import com.idle.setting.SettingEvent
+import com.idle.setting.navigation.SettingNavigation
 import com.idle.setting.TERMS_AND_POLICES_URL
 import com.idle.setting.databinding.FragmentCenterSettingBinding
 import com.idle.setting.dialog.LogoutDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 internal class CenterSettingFragment :
@@ -26,6 +29,10 @@ internal class CenterSettingFragment :
         FragmentCenterSettingBinding::inflate
     ) {
     override val fragmentViewModel: CenterSettingViewModel by viewModels()
+
+    @Inject
+    lateinit var settingNavigation : SettingNavigation
+
     private val logoutDialog: LogoutDialogFragment? by lazy {
         LogoutDialogFragment().apply {
             onDismissCallback = {
@@ -57,12 +64,20 @@ internal class CenterSettingFragment :
             SettingEvent.PrivacyPolicy -> navigateToUri(PRIVACY_POLICY_URL)
             SettingEvent.TermsAndPolicies -> navigateToUri(TERMS_AND_POLICES_URL)
             SettingEvent.Inquiry -> {}
-            SettingEvent.Withdrawal -> fragmentViewModel.baseEvent(NavigateTo(Withdrawal(UserRole.CENTER)))
+            SettingEvent.Withdrawal -> fragmentViewModel.baseEvent(
+                NavigateTo(
+                    destination = Withdrawal(UserRole.CENTER),
+                    popUpTo = R.id.centerSettingFragment
+                )
+            )
+
             SettingEvent.Logout -> {
                 if (!(logoutDialog?.isAdded == true || logoutDialog?.isVisible == true)) {
                     logoutDialog?.show(parentFragmentManager, "LogoutDialogFragment")
                 }
             }
+
+            SettingEvent.LogoutSuccess -> settingNavigation.navigateToAuth()
         }
     }
 

--- a/feature/setting/src/main/java/com/idle/setting/center/CenterSettingViewModel.kt
+++ b/feature/setting/src/main/java/com/idle/setting/center/CenterSettingViewModel.kt
@@ -1,8 +1,11 @@
 package com.idle.setting.center
 
-import android.util.Log
 import androidx.lifecycle.viewModelScope
+import com.idle.binding.DeepLinkDestination
 import com.idle.binding.base.BaseViewModel
+import com.idle.binding.base.CareBaseEvent
+import com.idle.domain.usecase.auth.LogoutCenterUseCase
+import com.idle.setting.R
 import com.idle.setting.SettingEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -11,12 +14,16 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class CenterSettingViewModel @Inject constructor() : BaseViewModel() {
+class CenterSettingViewModel @Inject constructor(
+    private val logoutCenterUseCase: LogoutCenterUseCase,
+) : BaseViewModel() {
     private val _centerSettingEvent = MutableSharedFlow<SettingEvent>()
     val centerSettingEvent = _centerSettingEvent.asSharedFlow()
 
-    fun logout() {
-        Log.d("test", "로그아웃")
+    fun logout() = viewModelScope.launch {
+        logoutCenterUseCase().onSuccess {
+            centerSettingEvent(SettingEvent.LogoutSuccess)
+        }.onFailure { }
     }
 
     fun clickLogout() = centerSettingEvent(SettingEvent.Logout)

--- a/feature/setting/src/main/java/com/idle/setting/navigation/SettingNavigation.kt
+++ b/feature/setting/src/main/java/com/idle/setting/navigation/SettingNavigation.kt
@@ -1,0 +1,5 @@
+package com.idle.setting.navigation
+
+interface SettingNavigation {
+    fun navigateToAuth()
+}

--- a/feature/setting/src/main/java/com/idle/setting/worker/WorkerSettingFragment.kt
+++ b/feature/setting/src/main/java/com/idle/setting/worker/WorkerSettingFragment.kt
@@ -14,11 +14,14 @@ import com.idle.binding.repeatOnStarted
 import com.idle.domain.model.auth.UserRole
 import com.idle.setting.FAQ_URL
 import com.idle.setting.PRIVACY_POLICY_URL
+import com.idle.setting.R
 import com.idle.setting.SettingEvent
+import com.idle.setting.navigation.SettingNavigation
 import com.idle.setting.TERMS_AND_POLICES_URL
 import com.idle.setting.databinding.FragmentWorkerSettingBinding
 import com.idle.setting.dialog.LogoutDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 internal class WorkerSettingFragment :
@@ -26,6 +29,10 @@ internal class WorkerSettingFragment :
         FragmentWorkerSettingBinding::inflate
     ) {
     override val fragmentViewModel: WorkerSettingViewModel by viewModels()
+
+    @Inject
+    lateinit var settingNavigation : SettingNavigation
+
     private val logoutDialog: LogoutDialogFragment? by lazy {
         LogoutDialogFragment().apply {
             onDismissCallback = {
@@ -57,12 +64,20 @@ internal class WorkerSettingFragment :
             SettingEvent.PrivacyPolicy -> navigateToUri(PRIVACY_POLICY_URL)
             SettingEvent.TermsAndPolicies -> navigateToUri(TERMS_AND_POLICES_URL)
             SettingEvent.Inquiry -> {}
-            SettingEvent.Withdrawal -> fragmentViewModel.baseEvent(NavigateTo(Withdrawal(UserRole.WORKER)))
+            SettingEvent.Withdrawal -> fragmentViewModel.baseEvent(
+                NavigateTo(
+                    destination = Withdrawal(UserRole.WORKER),
+                    popUpTo = R.id.workerSettingFragment
+                )
+            )
+
             SettingEvent.Logout -> {
                 if (!(logoutDialog?.isAdded == true || logoutDialog?.isVisible == true)) {
                     logoutDialog?.show(parentFragmentManager, "LogoutDialogFragment")
                 }
             }
+
+            SettingEvent.LogoutSuccess -> settingNavigation.navigateToAuth()
         }
     }
 

--- a/feature/setting/src/main/java/com/idle/setting/worker/WorkerSettingViewModel.kt
+++ b/feature/setting/src/main/java/com/idle/setting/worker/WorkerSettingViewModel.kt
@@ -1,8 +1,11 @@
 package com.idle.setting.worker
 
-import android.util.Log
 import androidx.lifecycle.viewModelScope
+import com.idle.binding.DeepLinkDestination
 import com.idle.binding.base.BaseViewModel
+import com.idle.binding.base.CareBaseEvent
+import com.idle.domain.usecase.auth.LogoutWorkerUseCase
+import com.idle.setting.R
 import com.idle.setting.SettingEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -11,11 +14,16 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class WorkerSettingViewModel @Inject constructor() : BaseViewModel() {
+class WorkerSettingViewModel @Inject constructor(
+    private val logoutWorkerUseCase: LogoutWorkerUseCase,
+) : BaseViewModel() {
     private val _workerSettingEvent = MutableSharedFlow<SettingEvent>()
     val workerSettingEvent = _workerSettingEvent.asSharedFlow()
-    fun logout() {
-        Log.d("test", "로그아웃 호출")
+
+    fun logout() = viewModelScope.launch {
+        logoutWorkerUseCase().onSuccess {
+            workerSettingEvent(SettingEvent.LogoutSuccess)
+        }.onFailure { }
     }
 
     fun clickLogout() = workerSettingEvent(SettingEvent.Logout)

--- a/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpViewModel.kt
@@ -87,7 +87,9 @@ class WorkerSignUpViewModel @Inject constructor(
     }
 
     internal fun setBirthYear(birthYear: String) {
-        _birthYear.value = birthYear
+        if (birthYear.length <= 4) {
+            _birthYear.value = birthYear
+        }
     }
 
     internal fun setGender(gender: Gender) {

--- a/feature/withdrawal/src/main/java/com/idle/withdrawal/navigation/WithdrawalNavigation.kt
+++ b/feature/withdrawal/src/main/java/com/idle/withdrawal/navigation/WithdrawalNavigation.kt
@@ -1,0 +1,5 @@
+package com.idle.withdrawal.navigation
+
+interface WithdrawalNavigation {
+    fun navigateToAuth()
+}

--- a/feature/withdrawal/src/main/java/com/idle/withdrawal/step/SettingEvent.kt
+++ b/feature/withdrawal/src/main/java/com/idle/withdrawal/step/SettingEvent.kt
@@ -1,0 +1,5 @@
+package com.idle.withdrawal.step
+
+sealed class WithdrawalEvent {
+    data object WithdrawalSuccess : WithdrawalEvent()
+}

--- a/presentation/src/main/java/com/idle/presentation/navigation/NavigationModule.kt
+++ b/presentation/src/main/java/com/idle/presentation/navigation/NavigationModule.kt
@@ -1,0 +1,31 @@
+package com.idle.presentation.navigation
+
+import androidx.fragment.app.Fragment
+import com.idle.setting.navigation.SettingNavigation
+import com.idle.withdrawal.navigation.WithdrawalNavigation
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.FragmentComponent
+import dagger.hilt.android.scopes.FragmentScoped
+
+@Module
+@InstallIn(FragmentComponent::class)
+object NavigationModule {
+
+    @Provides
+    @FragmentScoped
+    fun provideWithdrawalNavigation(
+        fragment: Fragment
+    ): WithdrawalNavigation {
+        return WithdrawalNavigationImpl(fragment)
+    }
+
+    @Provides
+    @FragmentScoped
+    fun provideSettingNavigation(
+        fragment: Fragment
+    ): SettingNavigation {
+        return SettingNavigationImpl(fragment)
+    }
+}

--- a/presentation/src/main/java/com/idle/presentation/navigation/SettingNavigationImpl.kt
+++ b/presentation/src/main/java/com/idle/presentation/navigation/SettingNavigationImpl.kt
@@ -1,0 +1,15 @@
+package com.idle.presentation.navigation
+
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import com.idle.presentation.R
+import com.idle.setting.navigation.SettingNavigation
+import javax.inject.Inject
+
+class SettingNavigationImpl @Inject constructor(
+    private val fragment: Fragment
+) : SettingNavigation {
+    override fun navigateToAuth() {
+        fragment.findNavController().navigate(R.id.action_global_nav_auth)
+    }
+}

--- a/presentation/src/main/java/com/idle/presentation/navigation/WithdrawalNavigationImpl.kt
+++ b/presentation/src/main/java/com/idle/presentation/navigation/WithdrawalNavigationImpl.kt
@@ -1,0 +1,15 @@
+package com.idle.presentation.navigation
+
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import com.idle.presentation.R
+import com.idle.withdrawal.navigation.WithdrawalNavigation
+import javax.inject.Inject
+
+class WithdrawalNavigationImpl @Inject constructor(
+    private val fragment: Fragment
+) : WithdrawalNavigation {
+    override fun navigateToAuth() {
+        fragment.findNavController().navigate(R.id.action_global_nav_auth)
+    }
+}

--- a/presentation/src/main/res/navigation/nav_main.xml
+++ b/presentation/src/main/res/navigation/nav_main.xml
@@ -22,4 +22,12 @@
     <include app:graph="@navigation/nav_worker_setting" />
     <include app:graph="@navigation/nav_worker_recruitment_detail" />
     <include app:graph="@navigation/nav_worker_job_posting" />
+
+    <action
+        android:id="@+id/action_global_nav_auth"
+        app:destination="@id/nav_auth"
+        app:popUpTo="@id/nav_main"
+        app:enterAnim="@anim/anim_pop_slide_in_horizontally"
+        app:exitAnim="@anim/anim_pop_slide_out_horizontally"
+        app:popUpToInclusive="true" />
 </navigation>


### PR DESCRIPTION
## 1. 🔥 변경된 내용

- **센터 로그아웃, 회원탈퇴 API 연결**
- **요양 보호사 로그아웃, 회원탈퇴 API 연결**

## 2. 📸 스크린샷(선택)

https://github.com/user-attachments/assets/7daf054b-def5-4609-9eaa-db6b36e71b55

## 3. 💡 알게된 부분

### 다중 모듈 프로젝트에서 xml Navigation을 사용할 때 서로 모르는 Destination으로의 BackStack 관리

로그아웃, 회원탈퇴를 진행하면 앱 초기 화면으로 돌아가는데,

이 때 BackStack에 BottomNavigation의 Route 인 Home이 남아있는 이슈가 발생.

https://github.com/user-attachments/assets/274e8bb9-41e5-4e7d-a045-25b62c88d454

<br><br><br><br><br><br>

다중 모듈 프로젝트이기 때문에,

feature는 아래와 같은 모듈 구조로 이루어져 있음.

![image](https://github.com/user-attachments/assets/493de5f8-491d-4c59-9b6c-571f079ae57d)

즉, 로그아웃, 회원탈퇴까지 가는 시나리오는 아래와 같음

`auth` → `signin` → `home` → `setting` → `withdrawal`

<br><br><br><br><br><br>

이 때 딥링크로 하는 다중 모듈 프로젝트의 네비게이션 특성상 백스택에 관여하는 방법은 

자신이 속해있는 모듈에 있는 다른 Fragment를 popUpTo로 설정한 뒤 inclusive를 True로 설정하여 모듈 내에서만 영향을 끼칠 수 있음.

![image](https://github.com/user-attachments/assets/17f99e55-1b79-440a-9c7c-a8859e2c0c3e)

<br><br><br><br><br><br>

거기에 더해서 BottomNavigation을 사용할경우 어떤 화면에서 뒤로가기를 누르던 Route화면으로 돌아감.

*(어떤 속성을 주어도 항상 Home 화면을 백스택에서 지울 수 없음.)*

```kotlin
mainBNVWorker.setupWithNavController(navController)   // <--- 기본값이 Route 화면으로 가는것.
NavigationUI.setupWithNavController(mainBNVWorker, navController, false) // <------ 이렇게 설정하면 바텀 네비게이션 내부에서도 백스택 설정 가능
```

즉, 회원탈퇴, 로그아웃 까지 도달하기위해 화면을 이동할 때 마다 자기 자신을 백스택에서 제거하더라도 아래와 같이 BottomNaivgation의 Route인 `home` 은 남게 될 것임.

`home`  → `withdrawal`

<br><br><br>

---

## 그래서 어떻게 해결했는데요 ?

열심히 3시간동안 구글링 했다…

진짜… 공식문서에서 빠트린 부분도 있나 체크했고…

https://github.com/user-attachments/assets/5e21425a-1963-4cae-bac6-1152befe2821

<br><br><br><br><br><br>

결국… 찾아낸 광명..

![image](https://github.com/user-attachments/assets/681b991c-4af2-4b14-b90e-0cb0be77066b)

로그인, 로그아웃, 회원탈퇴와 같이 특정한 상황에서는 Action을 사용해서 추가 목적지를 pop 할 수 있다.

<br><br><br><br><br><br>

즉, 컴포즈에서 루트에서 모든 라우팅을 관리했던 것 처럼

우리는 nav_auth로 가는 Gobal_Action을 아래와 같이 정의하고,

```xml
    <action
        android:id="@+id/action_global_nav_auth"
        app:destination="@id/nav_auth"
        app:popUpTo="@id/nav_main"
        app:enterAnim="@anim/anim_pop_slide_in_horizontally"
        app:exitAnim="@anim/anim_pop_slide_out_horizontally"
        app:popUpToInclusive="true" />
```

![image](https://github.com/user-attachments/assets/057041f2-b4e0-460c-95ce-ce589eda22a1)

<br><br><br>

회원탈퇴 모듈에 아래와 같은 interface를 정의한 뒤,

```kotlin
interface WithdrawalNavigation {
    fun navigateToAuth()
}
```

<br><br><br>

presentation에서 GlobalAction을 넣어준다!

```kotlin
class WithdrawalNavigationImpl @Inject constructor(
    private val fragment: Fragment
) : WithdrawalNavigation {
    override fun navigateToAuth() {
        fragment.findNavController().navigate(R.id.action_global_nav_auth)
    }
}
```

<br><br><br>

그리고 주입해주면!

![image](https://github.com/user-attachments/assets/d768c191-783d-4fc7-bfad-2cba7d54dc13)

아래와 같이 뙇!! 사용가능 !!!!

https://github.com/user-attachments/assets/93a835a0-a9f5-4054-bf42-b7ddc1177bf4

