### PR TITLE
[IDLE-335] 구인 공고 채용 종료 및 삭제 API 연결

### DIFF
--- a/core/data/src/main/java/com/idle/data/repository/jobposting/JobPostingRepositoryImpl.kt
+++ b/core/data/src/main/java/com/idle/data/repository/jobposting/JobPostingRepositoryImpl.kt
@@ -186,4 +186,10 @@ class JobPostingRepositoryImpl @Inject constructor(
 
     override suspend fun getApplicants(jobPostingId: String): Result<Pair<JobPostingSummary, List<Applicant>>> =
         jobPostingDataSource.getApplicants(jobPostingId).mapCatching { it.toVO() }
+
+    override suspend fun endJobPosting(jobPostingId: String): Result<Unit> =
+        jobPostingDataSource.endJobPosting(jobPostingId)
+
+    override suspend fun deleteJobPosting(jobPostingId: String): Result<Unit> =
+        jobPostingDataSource.deleteJobPosting(jobPostingId)
 }

--- a/core/designresource/src/main/res/drawable/ic_3dots_horizontal.xml
+++ b/core/designresource/src/main/res/drawable/ic_3dots_horizontal.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M4,12m0,2a2,2 0,1 1,0 -4a2,2 0,1 1,0 4"
+      android:fillColor="#7E848F"/>
+  <path
+      android:pathData="M12,12m0,2a2,2 0,1 1,0 -4a2,2 0,1 1,0 4"
+      android:fillColor="#7E848F"/>
+  <path
+      android:pathData="M20,12m0,2a2,2 0,1 1,0 -4a2,2 0,1 1,0 4"
+      android:fillColor="#7E848F"/>
+</vector>

--- a/core/designresource/src/main/res/drawable/ic_red_check.xml
+++ b/core/designresource/src/main/res/drawable/ic_red_check.xml
@@ -1,0 +1,17 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="25dp"
+    android:viewportWidth="24"
+    android:viewportHeight="25">
+  <group>
+    <clip-path
+        android:pathData="M0,0.5h24v24h-24z"/>
+    <path
+        android:pathData="M6,12L10.5,16.5L18,7.5"
+        android:strokeLineJoin="round"
+        android:strokeWidth="3"
+        android:fillColor="#00000000"
+        android:strokeColor="#FD4F43"
+        android:strokeLineCap="round"/>
+  </group>
+</vector>

--- a/core/designresource/src/main/res/values/strings.xml
+++ b/core/designresource/src/main/res/values/strings.xml
@@ -71,6 +71,7 @@
     <string name="applicant_inquiry">지원자 확인</string>
     <string name="job_posting_complete_message">요양보호사 구인 공고를\n등록했어요!</string>
     <string name="job_posting_detail">공고 정보</string>
+    <string name="job_posting_edit">공고 편집</string>
     <string name="experience_preferred">경력자 우대</string>
     <string name="beginner_possible">초보 가능</string>
     <string name="view_as_caregiver">보호사 측 화면으로 보기</string>

--- a/core/designresource/src/main/res/values/strings.xml
+++ b/core/designresource/src/main/res/values/strings.xml
@@ -67,6 +67,7 @@
     <string name="ongoing_job_posting">진행중인 공고</string>
     <string name="previous_job_posting">이전 공고</string>
     <string name="end_recruiting">채용 종료</string>
+    <string name="end">종료하기</string>
     <string name="recruiting">채용하기</string>
     <string name="applicant_inquiry">지원자 확인</string>
     <string name="job_posting_complete_message">요양보호사 구인 공고를\n등록했어요!</string>

--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/Card.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/Card.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
@@ -26,8 +27,8 @@ import com.idle.designsystem.compose.foundation.CareTheme
 @Composable
 fun CareCard(
     title: String,
-    description: String,
     modifier: Modifier = Modifier,
+    description: String? = null,
     titleLeftComponent: @Composable () -> Unit = {},
     descriptionLeftComponent: @Composable () -> Unit = {},
     showRightArrow: Boolean = true,
@@ -64,17 +65,19 @@ fun CareCard(
                     )
                 }
 
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(2.dp)
-                ) {
-                    descriptionLeftComponent()
+                if (description != null) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(2.dp)
+                    ) {
+                        descriptionLeftComponent()
 
-                    Text(
-                        text = description,
-                        style = CareTheme.typography.body3,
-                        color = CareTheme.colors.gray500,
-                    )
+                        Text(
+                            text = description,
+                            style = CareTheme.typography.body3,
+                            color = CareTheme.colors.gray500,
+                        )
+                    }
                 }
             }
 
@@ -147,7 +150,6 @@ private fun CareContactCardPreviewContent(modifier: Modifier = Modifier) {
     )
 }
 
-
 @Preview(name = "CareContactCard_Default", showBackground = true, group = "Default")
 @Composable
 private fun PreviewCareContactCardDefault() {
@@ -169,4 +171,45 @@ private fun PreviewCareContactCardFlip() {
 @Composable
 private fun PreviewCareContactCardFoldable() {
     CareContactCardPreviewContent()
+}
+
+@Composable
+private fun CareCenterEditCardPreviewContent(modifier: Modifier = Modifier) {
+    CareCard(
+        title = "공고 수정하기",
+        titleLeftComponent = {
+            Image(
+                painter = painterResource(id = com.idle.designresource.R.drawable.ic_edit_pencil_non_background),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(CareTheme.colors.gray500),
+            )
+        },
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    )
+}
+
+
+@Preview(name = "CareCenterEditCard_Default", showBackground = true, group = "Default")
+@Composable
+private fun PreviewCareCenterCardDefault() {
+    CareCenterEditCardPreviewContent()
+}
+
+@Preview(name = "CareCenterEditCard_Flip", showBackground = true, device = FLIP, group = "Flip")
+@Composable
+private fun PreviewCareCenterCardFlip() {
+    CareCenterEditCardPreviewContent()
+}
+
+@Preview(
+    name = "CareCenterEditCard_Fold",
+    showBackground = true,
+    device = Devices.FOLDABLE,
+    group = "Fold"
+)
+@Composable
+private fun PreviewCareCenterCardFoldable() {
+    CareCenterEditCardPreviewContent()
 }

--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/Card.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/Card.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Devices
@@ -28,6 +29,7 @@ import com.idle.designsystem.compose.foundation.CareTheme
 fun CareCard(
     title: String,
     modifier: Modifier = Modifier,
+    titleTextColor: Color = CareTheme.colors.gray900,
     description: String? = null,
     titleLeftComponent: @Composable () -> Unit = {},
     descriptionLeftComponent: @Composable () -> Unit = {},
@@ -61,7 +63,7 @@ fun CareCard(
                     Text(
                         text = title,
                         style = CareTheme.typography.subtitle3,
-                        color = CareTheme.colors.gray900,
+                        color = titleTextColor,
                     )
                 }
 

--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/Dialog.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/Dialog.kt
@@ -61,15 +61,11 @@ fun CareDialog(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = Modifier.padding(12.dp),
             ) {
-                val titleModifier =
-                    if (description != null) Modifier.padding(top = 12.dp, bottom = 16.dp)
-                    else Modifier.padding(top = 8.dp)
-
                 Text(
                     text = title,
                     style = CareTheme.typography.subtitle1,
                     color = titleColor,
-                    modifier = titleModifier,
+                    modifier = Modifier.padding(top = 8.dp),
                 )
 
                 if (description != null) {

--- a/core/domain/src/main/kotlin/com/idle/domain/repositorry/jobposting/JobPostingRepository.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/repositorry/jobposting/JobPostingRepository.kt
@@ -100,4 +100,8 @@ interface JobPostingRepository {
     suspend fun removeFavoriteJobPosting(jobPostingId: String): Result<Unit>
 
     suspend fun getApplicants(jobPostingId: String): Result<Pair<JobPostingSummary, List<Applicant>>>
+
+    suspend fun endJobPosting(jobPostingId: String): Result<Unit>
+
+    suspend fun deleteJobPosting(jobPostingId: String): Result<Unit>
 }

--- a/core/domain/src/main/kotlin/com/idle/domain/usecase/jobposting/DeleteJobPostingUseCase.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/usecase/jobposting/DeleteJobPostingUseCase.kt
@@ -1,0 +1,11 @@
+package com.idle.domain.usecase.jobposting
+
+import com.idle.domain.repositorry.jobposting.JobPostingRepository
+import javax.inject.Inject
+
+class DeleteJobPostingUseCase @Inject constructor(
+    private val jobPostingRepository: JobPostingRepository,
+) {
+    suspend operator fun invoke(jobPostingId: String) =
+        jobPostingRepository.deleteJobPosting(jobPostingId)
+}

--- a/core/domain/src/main/kotlin/com/idle/domain/usecase/jobposting/EndJobPostingUseCase.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/usecase/jobposting/EndJobPostingUseCase.kt
@@ -1,0 +1,11 @@
+package com.idle.domain.usecase.jobposting
+
+import com.idle.domain.repositorry.jobposting.JobPostingRepository
+import javax.inject.Inject
+
+class EndJobPostingUseCase @Inject constructor(
+    private val jobPostingRepository: JobPostingRepository,
+) {
+    suspend operator fun invoke(jobPostingId: String) =
+        jobPostingRepository.endJobPosting(jobPostingId)
+}

--- a/core/network/src/main/java/com/idle/network/api/JobPostingApi.kt
+++ b/core/network/src/main/java/com/idle/network/api/JobPostingApi.kt
@@ -10,6 +10,7 @@ import com.idle.network.model.jobposting.GetWorkerJobPostingDetailResponse
 import com.idle.network.model.jobposting.JobPostingRequest
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
@@ -78,4 +79,11 @@ interface JobPostingApi {
 
     @POST("/api/v1/job-postings/{job-posting-id}/remove-favorites")
     suspend fun removeFavoriteJobPosting(@Path("job-posting-id") jobPostingId: String): Response<Unit>
+
+    @PATCH("/api/v1/job-postings/{job-posting-id}/end")
+    suspend fun endJobPosting(@Path("job-posting-id") jobPostingId: String): Response<Unit>
+
+    @DELETE("/api/v1/job-postings/{job-posting-id}")
+    suspend fun deleteJobPosting(@Path("job-posting-id") jobPostingId: String): Response<Unit>
+
 }

--- a/core/network/src/main/java/com/idle/network/source/jobposting/JobPostingDataSource.kt
+++ b/core/network/src/main/java/com/idle/network/source/jobposting/JobPostingDataSource.kt
@@ -66,4 +66,10 @@ class JobPostingDataSource @Inject constructor(
 
     suspend fun getApplicants(jobPostingId: String): Result<GetApplicantsResponse> =
         jobPostingApi.getApplicants(jobPostingId).onResponse()
+
+    suspend fun endJobPosting(jobPostingId: String): Result<Unit> =
+        jobPostingApi.endJobPosting(jobPostingId).onResponse()
+
+    suspend fun deleteJobPosting(jobPostingId: String): Result<Unit> =
+        jobPostingApi.deleteJobPosting(jobPostingId).onResponse()
 }

--- a/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/center/CenterJobPostingDetailFragement.kt
+++ b/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/center/CenterJobPostingDetailFragement.kt
@@ -15,9 +15,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -28,10 +30,10 @@ import com.idle.binding.DeepLinkDestination
 import com.idle.binding.base.CareBaseEvent
 import com.idle.center.job.edit.JobEditScreen
 import com.idle.compose.base.BaseComposeFragment
+import com.idle.compose.clickable
 import com.idle.designresource.R
 import com.idle.designsystem.compose.component.CareBottomSheetLayout
 import com.idle.designsystem.compose.component.CareButtonLarge
-import com.idle.designsystem.compose.component.CareButtonRound
 import com.idle.designsystem.compose.component.CareCard
 import com.idle.designsystem.compose.component.CareStateAnimator
 import com.idle.designsystem.compose.component.CareSubtitleTopBar
@@ -125,6 +127,7 @@ internal fun CenterJobPostingDetailScreen(
         initialValue = ModalBottomSheetValue.Hidden,
         skipHalfExpanded = true,
     )
+    val coroutineScope = rememberCoroutineScope()
 
     jobPostingDetail?.let {
         CareBottomSheetLayout(
@@ -136,23 +139,45 @@ internal fun CenterJobPostingDetailScreen(
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     Text(
-                        text = stringResource(id = R.string.inquiry),
+                        text = stringResource(id = R.string.job_posting_edit),
                         style = CareTheme.typography.heading3,
                         color = CareTheme.colors.gray900,
                         modifier = Modifier.padding(bottom = 20.dp),
                     )
 
-
                     CareCard(
-                        title = stringResource(id = R.string.inquiry_by_call),
-                        description = "010-1234-5678",
+                        title = stringResource(id = R.string.edit_job_posting_button),
                         titleLeftComponent = {
                             Image(
-                                painter = painterResource(R.drawable.ic_call),
+                                painter = painterResource(id = R.drawable.ic_edit_pencil_non_background),
+                                contentDescription = null,
+                                colorFilter = ColorFilter.tint(CareTheme.colors.gray500),
+                            )
+                        },
+                        onClick = {
+                            coroutineScope.launch {
+                                sheetState.hide()
+                                setEditState(true)
+                            }
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 8.dp)
+                    )
+
+                    CareCard(
+                        title = stringResource(id = R.string.end_recruiting),
+                        titleLeftComponent = {
+                            Image(
+                                painter = painterResource(id = R.drawable.ic_red_check),
                                 contentDescription = null,
                             )
                         },
-                        onClick = {},
+                        onClick = {
+                            coroutineScope.launch {
+                                sheetState.hide()
+                            }
+                        },
                         modifier = Modifier.fillMaxWidth(),
                     )
                 }
@@ -164,9 +189,12 @@ internal fun CenterJobPostingDetailScreen(
                         title = stringResource(id = R.string.manage_job_posting),
                         onNavigationClick = { onBackPressedDispatcher?.onBackPressed() },
                         leftComponent = {
-                            CareButtonRound(
-                                text = stringResource(id = R.string.edit_job_posting_button),
-                                onClick = { setEditState(true) },
+                            Image(
+                                painter = painterResource(id = R.drawable.ic_3dots_horizontal),
+                                contentDescription = null,
+                                modifier = Modifier.clickable {
+                                    coroutineScope.launch { sheetState.show() }
+                                }
                             )
                         },
                         modifier = Modifier

--- a/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/center/CenterJobPostingDetailFragement.kt
+++ b/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/center/CenterJobPostingDetailFragement.kt
@@ -1,15 +1,24 @@
 package com.idle.worker.job.posting.detail.center
 
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
@@ -20,8 +29,10 @@ import com.idle.binding.base.CareBaseEvent
 import com.idle.center.job.edit.JobEditScreen
 import com.idle.compose.base.BaseComposeFragment
 import com.idle.designresource.R
+import com.idle.designsystem.compose.component.CareBottomSheetLayout
 import com.idle.designsystem.compose.component.CareButtonLarge
 import com.idle.designsystem.compose.component.CareButtonRound
+import com.idle.designsystem.compose.component.CareCard
 import com.idle.designsystem.compose.component.CareStateAnimator
 import com.idle.designsystem.compose.component.CareSubtitleTopBar
 import com.idle.designsystem.compose.foundation.CareTheme
@@ -99,6 +110,7 @@ internal class CenterJobPostingDetailFragment : BaseComposeFragment() {
     }
 }
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 internal fun CenterJobPostingDetailScreen(
     jobPostingId: String,
@@ -109,72 +121,108 @@ internal fun CenterJobPostingDetailScreen(
 ) {
     val onBackPressedDispatcher =
         LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+    val sheetState = rememberModalBottomSheetState(
+        initialValue = ModalBottomSheetValue.Hidden,
+        skipHalfExpanded = true,
+    )
 
     jobPostingDetail?.let {
-        Scaffold(
-            topBar = {
-                CareSubtitleTopBar(
-                    title = stringResource(id = R.string.manage_job_posting),
-                    onNavigationClick = { onBackPressedDispatcher?.onBackPressed() },
-                    leftComponent = {
-                        CareButtonRound(
-                            text = stringResource(id = R.string.edit_job_posting_button),
-                            onClick = { setEditState(true) },
-                        )
-                    },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(
-                            start = 12.dp,
-                            top = 48.dp,
-                            end = 20.dp,
-                            bottom = 12.dp
-                        ),
-                )
+        CareBottomSheetLayout(
+            sheetState = sheetState,
+            sheetContent = {
+                Column(
+                    verticalArrangement = Arrangement.Top,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.inquiry),
+                        style = CareTheme.typography.heading3,
+                        color = CareTheme.colors.gray900,
+                        modifier = Modifier.padding(bottom = 20.dp),
+                    )
+
+
+                    CareCard(
+                        title = stringResource(id = R.string.inquiry_by_call),
+                        description = "010-1234-5678",
+                        titleLeftComponent = {
+                            Image(
+                                painter = painterResource(R.drawable.ic_call),
+                                contentDescription = null,
+                            )
+                        },
+                        onClick = {},
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
             },
-            containerColor = CareTheme.colors.white000,
-        ) { paddingValue ->
-            SummaryScreen(
-                weekDays = it.weekdays,
-                workStartTime = it.startTime,
-                workEndTime = it.endTime,
-                payType = it.payType,
-                payAmount = it.payAmount.toString(),
-                roadNameAddress = it.roadNameAddress,
-                lotNumberAddress = it.lotNumberAddress,
-                clientName = it.clientName,
-                gender = it.gender,
-                birthYear = (LocalDate.now(ZoneId.of("Asia/Seoul")).year - it.age).toString(),
-                weight = it.weight.toString(),
-                careLevel = it.careLevel.toString(),
-                mentalStatus = it.mentalStatus,
-                disease = it.disease ?: "",
-                isMealAssistance = it.isMealAssistance,
-                isBowelAssistance = it.isBowelAssistance,
-                isWalkingAssistance = it.isWalkingAssistance,
-                lifeAssistance = it.lifeAssistance,
-                extraRequirement = it.extraRequirement,
-                isExperiencePreferred = it.isExperiencePreferred,
-                applyMethod = it.applyMethod,
-                applyDeadline = it.applyDeadline,
-                bottomComponent = {
-                    CareButtonLarge(
-                        text = "지원자 ${applicantsCount}명 조회",
-                        enable = applicantsCount != 0,
-                        onClick = {
-                            navigateTo(
-                                DeepLinkDestination.CenterApplicantInquiry(jobPostingId)
+        ) {
+            Scaffold(
+                topBar = {
+                    CareSubtitleTopBar(
+                        title = stringResource(id = R.string.manage_job_posting),
+                        onNavigationClick = { onBackPressedDispatcher?.onBackPressed() },
+                        leftComponent = {
+                            CareButtonRound(
+                                text = stringResource(id = R.string.edit_job_posting_button),
+                                onClick = { setEditState(true) },
                             )
                         },
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(start = 20.dp, end = 20.dp, bottom = 32.dp),
+                            .padding(
+                                start = 12.dp,
+                                top = 48.dp,
+                                end = 20.dp,
+                                bottom = 12.dp
+                            ),
                     )
                 },
-                modifier = Modifier
-                    .padding(paddingValue)
-                    .padding(top = 24.dp),
-            )
+                containerColor = CareTheme.colors.white000,
+            ) { paddingValue ->
+                SummaryScreen(
+                    weekDays = it.weekdays,
+                    workStartTime = it.startTime,
+                    workEndTime = it.endTime,
+                    payType = it.payType,
+                    payAmount = it.payAmount.toString(),
+                    roadNameAddress = it.roadNameAddress,
+                    lotNumberAddress = it.lotNumberAddress,
+                    clientName = it.clientName,
+                    gender = it.gender,
+                    birthYear = (LocalDate.now(ZoneId.of("Asia/Seoul")).year - it.age).toString(),
+                    weight = it.weight.toString(),
+                    careLevel = it.careLevel.toString(),
+                    mentalStatus = it.mentalStatus,
+                    disease = it.disease ?: "",
+                    isMealAssistance = it.isMealAssistance,
+                    isBowelAssistance = it.isBowelAssistance,
+                    isWalkingAssistance = it.isWalkingAssistance,
+                    lifeAssistance = it.lifeAssistance,
+                    extraRequirement = it.extraRequirement,
+                    isExperiencePreferred = it.isExperiencePreferred,
+                    applyMethod = it.applyMethod,
+                    applyDeadline = it.applyDeadline,
+                    bottomComponent = {
+                        CareButtonLarge(
+                            text = "지원자 ${applicantsCount}명 조회",
+                            enable = applicantsCount != 0,
+                            onClick = {
+                                navigateTo(
+                                    DeepLinkDestination.CenterApplicantInquiry(jobPostingId)
+                                )
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(start = 20.dp, end = 20.dp, bottom = 32.dp),
+                        )
+                    },
+                    modifier = Modifier
+                        .padding(paddingValue)
+                        .padding(top = 24.dp),
+                )
+            }
         }
     }
 }

--- a/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/center/CenterJobPostingDetailFragement.kt
+++ b/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/center/CenterJobPostingDetailFragement.kt
@@ -1,6 +1,7 @@
 package com.idle.worker.job.posting.detail.center
 
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -15,8 +16,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
@@ -35,6 +38,7 @@ import com.idle.designresource.R
 import com.idle.designsystem.compose.component.CareBottomSheetLayout
 import com.idle.designsystem.compose.component.CareButtonLarge
 import com.idle.designsystem.compose.component.CareCard
+import com.idle.designsystem.compose.component.CareDialog
 import com.idle.designsystem.compose.component.CareStateAnimator
 import com.idle.designsystem.compose.component.CareSubtitleTopBar
 import com.idle.designsystem.compose.foundation.CareTheme
@@ -103,6 +107,7 @@ internal class CenterJobPostingDetailFragment : BaseComposeFragment() {
                         jobPostingId = jobPostingId,
                         jobPostingDetail = jobPostingDetail,
                         applicantsCount = applicantsCount,
+                        endJobPosting = ::endJobPosting,
                         navigateTo = { baseEvent(CareBaseEvent.NavigateTo(it)) },
                         setEditState = ::setEditState,
                     )
@@ -118,6 +123,7 @@ internal fun CenterJobPostingDetailScreen(
     jobPostingId: String,
     jobPostingDetail: CenterJobPostingDetail?,
     applicantsCount: Int,
+    endJobPosting: (String) -> Unit,
     navigateTo: (DeepLinkDestination) -> Unit,
     setEditState: (Boolean) -> Unit,
 ) {
@@ -128,6 +134,27 @@ internal fun CenterJobPostingDetailScreen(
         skipHalfExpanded = true,
     )
     val coroutineScope = rememberCoroutineScope()
+    var showEndJobPostingDialog by remember { mutableStateOf(false) }
+
+    if (showEndJobPostingDialog) {
+        CareDialog(
+            title = "채용을 종료하시겠습니까?",
+            description = "채용 종료 시 지원자 정보는 초기화됩니다.",
+            leftButtonText = stringResource(id = R.string.cancel),
+            rightButtonText = stringResource(id = R.string.end),
+            leftButtonTextColor = CareTheme.colors.gray300,
+            leftButtonColor = CareTheme.colors.white000,
+            leftButtonBorder = BorderStroke(1.dp, CareTheme.colors.gray100),
+            rightButtonTextColor = CareTheme.colors.white000,
+            rightButtonColor = CareTheme.colors.red,
+            onDismissRequest = { showEndJobPostingDialog = false },
+            onLeftButtonClick = { showEndJobPostingDialog = false },
+            onRightButtonClick = { endJobPosting(jobPostingId) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp),
+        )
+    }
 
     jobPostingDetail?.let {
         CareBottomSheetLayout(
@@ -167,17 +194,14 @@ internal fun CenterJobPostingDetailScreen(
 
                     CareCard(
                         title = stringResource(id = R.string.end_recruiting),
+                        titleTextColor = CareTheme.colors.red,
                         titleLeftComponent = {
                             Image(
                                 painter = painterResource(id = R.drawable.ic_red_check),
                                 contentDescription = null,
                             )
                         },
-                        onClick = {
-                            coroutineScope.launch {
-                                sheetState.hide()
-                            }
-                        },
+                        onClick = { showEndJobPostingDialog = true },
                         modifier = Modifier.fillMaxWidth(),
                     )
                 }

--- a/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/center/CenterJobPostingDetailViewModel.kt
+++ b/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/center/CenterJobPostingDetailViewModel.kt
@@ -1,14 +1,17 @@
 package com.idle.worker.job.posting.detail.center
 
 import androidx.lifecycle.viewModelScope
+import com.idle.binding.DeepLinkDestination
 import com.idle.binding.base.BaseViewModel
 import com.idle.binding.base.CareBaseEvent
 import com.idle.domain.model.job.LifeAssistance
 import com.idle.domain.model.jobposting.CenterJobPostingDetail
 import com.idle.domain.model.jobposting.EditJobPostingDetail
+import com.idle.domain.usecase.jobposting.EndJobPostingUseCase
 import com.idle.domain.usecase.jobposting.GetApplicantsCountUseCase
 import com.idle.domain.usecase.jobposting.GetCenterJobPostingDetailUseCase
 import com.idle.domain.usecase.jobposting.UpdateJobPostingUseCase
+import com.idle.job.posting.detail.R
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -20,6 +23,7 @@ class CenterJobPostingDetailViewModel @Inject constructor(
     private val getCenterJobPostingDetailUseCase: GetCenterJobPostingDetailUseCase,
     private val getApplicantsCountUseCase: GetApplicantsCountUseCase,
     private val updateJobPostingUseCase: UpdateJobPostingUseCase,
+    private val endJobPostingUseCase: EndJobPostingUseCase,
 ) : BaseViewModel() {
     private val _jobPostingDetail = MutableStateFlow<CenterJobPostingDetail?>(null)
     val jobPostingDetail = _jobPostingDetail.asStateFlow()
@@ -105,6 +109,17 @@ class CenterJobPostingDetailViewModel @Inject constructor(
             )
 
             _isEditState.value = false
+        }.onFailure { baseEvent(CareBaseEvent.Error(it.message.toString())) }
+    }
+
+    fun endJobPosting(jobPostingId: String) = viewModelScope.launch {
+        endJobPostingUseCase(jobPostingId).onSuccess {
+            baseEvent(
+                CareBaseEvent.NavigateTo(
+                    DeepLinkDestination.CenterHome,
+                    R.id.centerJobPostingDetailFragment
+                )
+            )
         }.onFailure { baseEvent(CareBaseEvent.Error(it.message.toString())) }
     }
 }


### PR DESCRIPTION
## 1. 🔥 변경된 내용

- **구인 공고 채용 종료 및 삭제 API 연결**
- **센터장 공고 상세화면에서 더 보기 옵션 추가**
- **더 보기 버튼을 누를 경우 바텀시트가 나오도록 변경**

## 2. 📸 스크린샷(선택)

https://github.com/user-attachments/assets/9cb945c7-7e09-4709-985f-585cbbd718ad