### PR TITLE
[IDLE-343] 모든 행위에 대해 스낵바 보여주도록 구현

### DIFF
--- a/core/common-ui/binding/src/main/java/com/idle/binding/base/BaseViewModel.kt
+++ b/core/common-ui/binding/src/main/java/com/idle/binding/base/BaseViewModel.kt
@@ -24,11 +24,11 @@ open class BaseViewModel : ViewModel() {
             ApiErrorCode.TokenExpiredException,
             ApiErrorCode.TokenNotFound,
             ApiErrorCode.NotSupportUserTokenType -> {
-                _baseEventFlow.emit(CareBaseEvent.ShowSnackBar(error.apiErrorCode.displayMsg))
+                _baseEventFlow.emit(CareBaseEvent.ShowSnackBar(error.apiErrorCode.displayMsg + "|Error"))
                 _baseEventFlow.emit(CareBaseEvent.NavigateToAuthWithClearBackStack)
             }
 
-            else -> _baseEventFlow.emit(CareBaseEvent.ShowSnackBar(error.apiErrorCode.displayMsg))
+            else -> _baseEventFlow.emit(CareBaseEvent.ShowSnackBar(error.apiErrorCode.displayMsg + "|Error"))
         }
     }
 }

--- a/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/SnackBar.kt
+++ b/core/designsystem/compose/src/main/java/com/idle/designsystem/compose/component/SnackBar.kt
@@ -1,6 +1,5 @@
 package com.idle.designsystem.compose.component
 
-import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
@@ -16,7 +15,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -28,9 +26,27 @@ import com.idle.designsystem.compose.foundation.CareTheme
 fun CareSnackBar(
     data: SnackbarData,
     modifier: Modifier = Modifier,
-    @DrawableRes leftImage: Int = R.drawable.ic_error,
-    backgroundColor: Color = CareTheme.colors.red,
 ) {
+    val (msg, type) = try {
+        data.visuals.message.split("|").let {
+            if (it.size >= 2) {
+                it[0] to it[1]
+            } else {
+                data.visuals.message to SnackBarType.ERROR.name
+            }
+        }
+    } catch (e: Exception) {
+        data.visuals.message to SnackBarType.ERROR.name
+    }
+
+    val snackBarType = SnackBarType.create(type)
+
+    val (backgroundColor, leftImage) = when (snackBarType) {
+        SnackBarType.SUCCESS -> CareTheme.colors.gray500 to R.drawable.ic_check_gray
+        SnackBarType.ERROR -> CareTheme.colors.red to R.drawable.ic_error
+    }
+
+
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
@@ -47,7 +63,7 @@ fun CareSnackBar(
         )
 
         Text(
-            text = data.visuals.message,
+            text = msg,
             style = CareTheme.typography.subtitle4,
             color = CareTheme.colors.white000,
         )
@@ -59,6 +75,16 @@ fun CareSnackBar(
             contentDescription = null,
             modifier = Modifier.clickable { data.dismiss() }
         )
+    }
+}
+
+enum class SnackBarType {
+    ERROR, SUCCESS;
+
+    companion object {
+        fun create(type: String): SnackBarType {
+            return SnackBarType.entries.firstOrNull { it.name == type } ?: ERROR
+        }
     }
 }
 

--- a/core/domain/src/main/kotlin/com/idle/domain/model/jobposting/JobPosting.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/model/jobposting/JobPosting.kt
@@ -3,7 +3,7 @@ package com.idle.domain.model.jobposting
 import java.time.LocalDate
 import java.time.ZoneId
 
-open class JobPosting(
+abstract class JobPosting(
     open val id: String,
     open val distance: Int,
     open val jobPostingType: JobPostingType,

--- a/feature/auth/src/main/java/com/idle/auth/AuthFragment.kt
+++ b/feature/auth/src/main/java/com/idle/auth/AuthFragment.kt
@@ -91,7 +91,7 @@ internal fun AuthScreen(
                 snackbar = { data ->
                     CareSnackBar(
                         data = data,
-                        modifier = Modifier.padding(bottom = 104.dp)
+                        modifier = Modifier.padding(bottom = 138.dp)
                     )
                 }
             )

--- a/feature/center/job-posting-edit/src/main/java/com/idle/center/job/edit/JobEditScreen.kt
+++ b/feature/center/job-posting-edit/src/main/java/com/idle/center/job/edit/JobEditScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -57,6 +59,7 @@ import com.idle.designsystem.compose.component.CareCalendar
 import com.idle.designsystem.compose.component.CareChipBasic
 import com.idle.designsystem.compose.component.CareChipShort
 import com.idle.designsystem.compose.component.CareClickableTextField
+import com.idle.designsystem.compose.component.CareSnackBar
 import com.idle.designsystem.compose.component.CareSubtitleTopBar
 import com.idle.designsystem.compose.component.CareTextField
 import com.idle.designsystem.compose.component.CareTextFieldLong
@@ -80,6 +83,7 @@ import java.time.ZoneId
 @OptIn(ExperimentalLayoutApi::class, ExperimentalMaterialApi::class)
 @Composable
 fun JobEditScreen(
+    snackbarHostState: SnackbarHostState,
     weekDays: Set<DayOfWeek>,
     workStartTime: String,
     workEndTime: String,
@@ -430,6 +434,17 @@ fun JobEditScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(start = 12.dp, top = 48.dp, end = 20.dp, bottom = 12.dp),
+                )
+            },
+            snackbarHost = {
+                SnackbarHost(
+                    hostState = snackbarHostState,
+                    snackbar = { data ->
+                        CareSnackBar(
+                            data = data,
+                            modifier = Modifier.padding(bottom = 138.dp)
+                        )
+                    }
                 )
             },
             containerColor = CareTheme.colors.white000,

--- a/feature/center/job-posting-post/src/main/java/com/idle/center/jobposting/JobPostingFragment.kt
+++ b/feature/center/job-posting-post/src/main/java/com/idle/center/jobposting/JobPostingFragment.kt
@@ -631,7 +631,7 @@ internal fun JobPostingScreen(
                             snackbar = { data ->
                                 CareSnackBar(
                                     data = data,
-                                    modifier = Modifier.padding(bottom = 108.dp)
+                                    modifier = Modifier.padding(bottom = 138.dp)
                                 )
                             }
                         )

--- a/feature/center/job-posting-post/src/main/java/com/idle/center/jobposting/JobPostingFragment.kt
+++ b/feature/center/job-posting-post/src/main/java/com/idle/center/jobposting/JobPostingFragment.kt
@@ -133,6 +133,7 @@ internal class JobPostingFragment : BaseComposeFragment() {
             ) { state ->
                 if (state) {
                     JobEditScreen(
+                        snackbarHostState = snackbarHostState,
                         weekDays = weekDays,
                         workStartTime = workStartTime,
                         workEndTime = workEndTime,

--- a/feature/center/profile/src/main/java/com/idle/center/profile/CenterProfileFragment.kt
+++ b/feature/center/profile/src/main/java/com/idle/center/profile/CenterProfileFragment.kt
@@ -49,6 +49,7 @@ import com.idle.designsystem.compose.component.CareSubtitleTopBar
 import com.idle.designsystem.compose.component.CareTextField
 import com.idle.designsystem.compose.component.CareTextFieldLong
 import com.idle.designsystem.compose.component.LabeledContent
+import com.idle.designsystem.compose.component.SnackBarType
 import com.idle.designsystem.compose.foundation.CareTheme
 import com.idle.domain.model.profile.CenterProfile
 import dagger.hilt.android.AndroidEntryPoint
@@ -132,7 +133,12 @@ internal fun CenterProfileScreen(
         snackbarHost = {
             SnackbarHost(
                 hostState = snackbarHostState,
-                snackbar = { data -> CareSnackBar(data = data) }
+                snackbar = { data ->
+                    CareSnackBar(
+                        data = data,
+                        modifier = Modifier.padding(bottom = 138.dp)
+                    )
+                }
             )
         },
         containerColor = CareTheme.colors.white000,

--- a/feature/center/profile/src/main/java/com/idle/center/profile/CenterProfileViewModel.kt
+++ b/feature/center/profile/src/main/java/com/idle/center/profile/CenterProfileViewModel.kt
@@ -3,6 +3,7 @@ package com.idle.center.profile
 import android.net.Uri
 import androidx.lifecycle.viewModelScope
 import com.idle.binding.base.BaseViewModel
+import com.idle.binding.base.CareBaseEvent
 import com.idle.domain.model.error.HttpResponseException
 import com.idle.domain.model.profile.CenterProfile
 import com.idle.domain.usecase.profile.GetLocalMyCenterProfileUseCase
@@ -60,6 +61,7 @@ class CenterProfileViewModel @Inject constructor(
             introduce = _centerIntroduce.value.ifBlank { null },
             imageFileUri = _profileImageUri.value?.toString(),
         ).onSuccess {
+            baseEvent(CareBaseEvent.ShowSnackBar("정보 수정이 완료되었어요.|ERROR"))
             setEditState(false)
         }.onFailure {
             handleFailure(it as HttpResponseException)

--- a/feature/center/register-info/src/main/java/com/idle/center/register/RegisterCenterInfoFragment.kt
+++ b/feature/center/register-info/src/main/java/com/idle/center/register/RegisterCenterInfoFragment.kt
@@ -22,6 +22,9 @@ import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.fragment.findNavController
+import com.idle.center.register.step.CenterAddressScreen
+import com.idle.center.register.step.CenterInfoScreen
+import com.idle.center.register.step.CenterIntroduceScreen
 import com.idle.compose.addFocusCleaner
 import com.idle.compose.base.BaseComposeFragment
 import com.idle.designresource.R
@@ -30,9 +33,6 @@ import com.idle.designsystem.compose.component.CareSnackBar
 import com.idle.designsystem.compose.component.CareStateAnimator
 import com.idle.designsystem.compose.component.CareSubtitleTopBar
 import com.idle.post.code.PostCodeFragment
-import com.idle.center.register.step.CenterAddressScreen
-import com.idle.center.register.step.CenterInfoScreen
-import com.idle.center.register.step.CenterIntroduceScreen
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -134,7 +134,12 @@ internal fun CenterRegisterScreen(
         snackbarHost = {
             SnackbarHost(
                 hostState = snackbarHostState,
-                snackbar = { data -> CareSnackBar(data = data) }
+                snackbar = { data ->
+                    CareSnackBar(
+                        data = data,
+                        modifier = Modifier.padding(bottom = 138.dp)
+                    )
+                }
             )
         },
         modifier = Modifier.addFocusCleaner(focusManager),

--- a/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/center/CenterJobPostingDetailFragement.kt
+++ b/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/center/CenterJobPostingDetailFragement.kt
@@ -11,6 +11,8 @@ import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -39,6 +41,7 @@ import com.idle.designsystem.compose.component.CareBottomSheetLayout
 import com.idle.designsystem.compose.component.CareButtonLarge
 import com.idle.designsystem.compose.component.CareCard
 import com.idle.designsystem.compose.component.CareDialog
+import com.idle.designsystem.compose.component.CareSnackBar
 import com.idle.designsystem.compose.component.CareStateAnimator
 import com.idle.designsystem.compose.component.CareSubtitleTopBar
 import com.idle.designsystem.compose.foundation.CareTheme
@@ -74,6 +77,7 @@ internal class CenterJobPostingDetailFragment : BaseComposeFragment() {
                 if (state) {
                     jobPostingDetail?.let {
                         JobEditScreen(
+                            snackbarHostState = snackbarHostState,
                             fragmentManager = parentFragmentManager,
                             weekDays = it.weekdays,
                             workStartTime = it.startTime,
@@ -104,6 +108,7 @@ internal class CenterJobPostingDetailFragment : BaseComposeFragment() {
                     }
                 } else {
                     CenterJobPostingDetailScreen(
+                        snackbarHostState = snackbarHostState,
                         jobPostingId = jobPostingId,
                         jobPostingDetail = jobPostingDetail,
                         applicantsCount = applicantsCount,
@@ -120,6 +125,7 @@ internal class CenterJobPostingDetailFragment : BaseComposeFragment() {
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 internal fun CenterJobPostingDetailScreen(
+    snackbarHostState: SnackbarHostState,
     jobPostingId: String,
     jobPostingDetail: CenterJobPostingDetail?,
     applicantsCount: Int,
@@ -229,6 +235,17 @@ internal fun CenterJobPostingDetailScreen(
                                 end = 20.dp,
                                 bottom = 12.dp
                             ),
+                    )
+                },
+                snackbarHost = {
+                    SnackbarHost(
+                        hostState = snackbarHostState,
+                        snackbar = { data ->
+                            CareSnackBar(
+                                data = data,
+                                modifier = Modifier.padding(bottom = 117.dp)
+                            )
+                        }
                     )
                 },
                 containerColor = CareTheme.colors.white000,

--- a/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/center/CenterJobPostingDetailViewModel.kt
+++ b/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/center/CenterJobPostingDetailViewModel.kt
@@ -82,6 +82,8 @@ class CenterJobPostingDetailViewModel @Inject constructor(
             applyDeadlineType = editJobPostingDetail.applyDeadlineType,
             applyDeadline = editJobPostingDetail.applyDeadline.toString().ifBlank { null },
         ).onSuccess {
+            baseEvent(CareBaseEvent.ShowSnackBar("수정이 완료되었어요.|SUCCESS"))
+
             _jobPostingDetail.value = CenterJobPostingDetail(
                 id = _jobPostingDetail.value?.id ?: return@launch,
                 weekdays = editJobPostingDetail.weekdays,
@@ -121,6 +123,7 @@ class CenterJobPostingDetailViewModel @Inject constructor(
                     R.id.centerJobPostingDetailFragment
                 )
             )
+            baseEvent(CareBaseEvent.ShowSnackBar("채용이 종료되었어요.|SUCCESS"))
         }.onFailure { handleFailure(it as HttpResponseException) }
     }
 }

--- a/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/worker/WorkerJobPostingDetailFragment.kt
+++ b/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/worker/WorkerJobPostingDetailFragment.kt
@@ -76,6 +76,7 @@ internal class WorkerJobPostingDetailFragment : BaseComposeFragment() {
                     } else {
                         if (jobPosting.jobPostingType == JobPostingType.CAREMEET) {
                             WorkerJobPostingDetailScreen(
+                                snackbarHostState = snackbarHostState,
                                 profile = profile,
                                 jobPostingDetail = jobPosting as WorkerJobPostingDetail,
                                 showPlaceDetail = setShowPlaceDetail,
@@ -85,6 +86,7 @@ internal class WorkerJobPostingDetailFragment : BaseComposeFragment() {
                             )
                         } else {
                             CrawlingJobPostingDetailScreen(
+                                snackbarHostState = snackbarHostState,
                                 profile = profile,
                                 jobPostingDetail = jobPosting as CrawlingJobPostingDetail,
                                 showPlaceDetail = setShowPlaceDetail,

--- a/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/worker/WorkerJobPostingDetailViewModel.kt
+++ b/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/worker/WorkerJobPostingDetailViewModel.kt
@@ -2,6 +2,7 @@ package com.idle.worker.job.posting.detail.worker
 
 import androidx.lifecycle.viewModelScope
 import com.idle.binding.base.BaseViewModel
+import com.idle.binding.base.CareBaseEvent
 import com.idle.domain.model.error.HttpResponseException
 import com.idle.domain.model.jobposting.ApplyMethod
 import com.idle.domain.model.jobposting.CrawlingJobPostingDetail
@@ -64,6 +65,8 @@ class WorkerJobPostingDetailViewModel @Inject constructor(
                 jobPostingId = jobPostingId,
                 applyMethod = applyMethod,
             ).onSuccess {
+                baseEvent(CareBaseEvent.ShowSnackBar("지원이 완료되었어요.|SUCCESS"))
+
                 if (_workerJobPostingDetail.value?.jobPostingType == JobPostingType.CAREMEET) {
                     _workerJobPostingDetail.value =
                         (_workerJobPostingDetail.value as WorkerJobPostingDetail).copy(applyTime = LocalDateTime.now())
@@ -79,6 +82,8 @@ class WorkerJobPostingDetailViewModel @Inject constructor(
             jobPostingId = jobPostingId,
             jobPostingType = jobPostingType,
         ).onSuccess {
+            baseEvent(CareBaseEvent.ShowSnackBar("즐겨찾기에 추가되었어요.|SUCCESS"))
+
             when (jobPostingType) {
                 JobPostingType.CAREMEET -> {
                     _workerJobPostingDetail.value =
@@ -101,6 +106,8 @@ class WorkerJobPostingDetailViewModel @Inject constructor(
             jobPostingId = jobPostingId,
             jobPostingType = jobPostingType,
         ).onSuccess {
+            baseEvent(CareBaseEvent.ShowSnackBar("즐겨찾기에서 제거되었어요.|SUCCESS"))
+
             when (jobPostingType) {
                 JobPostingType.CAREMEET -> {
                     _workerJobPostingDetail.value =

--- a/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/worker/screen/CrawlingJobPostingDetailScreen.kt
+++ b/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/worker/screen/CrawlingJobPostingDetailScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -40,6 +42,7 @@ import com.idle.compose.clickable
 import com.idle.designresource.R
 import com.idle.designsystem.compose.component.CareCard
 import com.idle.designsystem.compose.component.CareMap
+import com.idle.designsystem.compose.component.CareSnackBar
 import com.idle.designsystem.compose.component.CareSubtitleTopBar
 import com.idle.designsystem.compose.component.CareTag
 import com.idle.designsystem.compose.foundation.CareTheme
@@ -49,6 +52,7 @@ import com.idle.domain.model.profile.WorkerProfile
 
 @Composable
 internal fun CrawlingJobPostingDetailScreen(
+    snackbarHostState: SnackbarHostState,
     profile: WorkerProfile?,
     jobPostingDetail: CrawlingJobPostingDetail,
     showPlaceDetail: (Boolean) -> Unit,
@@ -73,7 +77,18 @@ internal fun CrawlingJobPostingDetailScreen(
                 ),
                 onNavigationClick = { onBackPressedDispatcher?.onBackPressed() },
             )
-        }
+        },
+        snackbarHost = {
+            SnackbarHost(
+                hostState = snackbarHostState,
+                snackbar = { data ->
+                    CareSnackBar(
+                        data = data,
+                        modifier = Modifier.padding(bottom = 20.dp)
+                    )
+                }
+            )
+        },
     ) { paddingValue ->
         val starTintColor by animateColorAsState(
             targetValue = if (jobPostingDetail.isFavorite) CareTheme.colors.orange300

--- a/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/worker/screen/WorkerJobPostingDetailScreen.kt
+++ b/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/worker/screen/WorkerJobPostingDetailScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -27,6 +26,8 @@ import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -37,11 +38,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
@@ -52,6 +51,7 @@ import com.idle.designsystem.compose.component.CareButtonLine
 import com.idle.designsystem.compose.component.CareCard
 import com.idle.designsystem.compose.component.CareDialog
 import com.idle.designsystem.compose.component.CareMap
+import com.idle.designsystem.compose.component.CareSnackBar
 import com.idle.designsystem.compose.component.CareSubtitleTopBar
 import com.idle.designsystem.compose.component.CareTag
 import com.idle.designsystem.compose.component.CareTextFieldLong
@@ -65,6 +65,7 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 internal fun WorkerJobPostingDetailScreen(
+    snackbarHostState: SnackbarHostState,
     profile: WorkerProfile?,
     jobPostingDetail: WorkerJobPostingDetail,
     showPlaceDetail: (Boolean) -> Unit,
@@ -155,7 +156,18 @@ internal fun WorkerJobPostingDetailScreen(
                     ),
                     onNavigationClick = { onBackPressedDispatcher?.onBackPressed() },
                 )
-            }
+            },
+            snackbarHost = {
+                SnackbarHost(
+                    hostState = snackbarHostState,
+                    snackbar = { data ->
+                        CareSnackBar(
+                            data = data,
+                            modifier = Modifier.padding(bottom = 116.dp)
+                        )
+                    }
+                )
+            },
         ) { paddingValue ->
             val starTintColor by animateColorAsState(
                 targetValue = if (jobPostingDetail.isFavorite) CareTheme.colors.orange300

--- a/feature/signin/src/main/java/com/idle/signin/center/CenterSignInFragment.kt
+++ b/feature/signin/src/main/java/com/idle/signin/center/CenterSignInFragment.kt
@@ -39,6 +39,7 @@ import com.idle.designsystem.compose.component.CareSnackBar
 import com.idle.designsystem.compose.component.CareSubtitleTopBar
 import com.idle.designsystem.compose.component.CareTextField
 import com.idle.designsystem.compose.component.LabeledContent
+import com.idle.designsystem.compose.component.SnackBarType
 import com.idle.designsystem.compose.foundation.CareTheme
 import dagger.hilt.android.AndroidEntryPoint
 

--- a/feature/withdrawal/src/main/java/com/idle/withdrawal/WithdrawalViewModel.kt
+++ b/feature/withdrawal/src/main/java/com/idle/withdrawal/WithdrawalViewModel.kt
@@ -126,6 +126,7 @@ class WithdrawalViewModel @Inject constructor(
                     popUpTo = com.idle.withdrawal.R.id.withdrawalFragment,
                 )
             )
+            baseEvent(CareBaseEvent.ShowSnackBar("회원탈퇴가 완료되었어요.|ERROR"))
         }.onFailure { handleFailure(it as HttpResponseException) }
     }
 
@@ -136,6 +137,7 @@ class WithdrawalViewModel @Inject constructor(
                 .joinToString("|"),
         ).onSuccess {
             baseEvent(CareBaseEvent.NavigateToAuthWithClearBackStack)
+            baseEvent(CareBaseEvent.ShowSnackBar("회원탈퇴가 완료되었어요.|ERROR"))
         }.onFailure { handleFailure(it as HttpResponseException) }
     }
 }

--- a/feature/worker/home/src/main/java/com/idle/worker/home/WorkerHomeFragment.kt
+++ b/feature/worker/home/src/main/java/com/idle/worker/home/WorkerHomeFragment.kt
@@ -18,6 +18,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -42,6 +44,7 @@ import com.idle.compose.clickable
 import com.idle.designresource.R
 import com.idle.designsystem.compose.component.CareButtonCardLarge
 import com.idle.designsystem.compose.component.CareHeadingTopBar
+import com.idle.designsystem.compose.component.CareSnackBar
 import com.idle.designsystem.compose.component.CareTag
 import com.idle.designsystem.compose.foundation.CareTheme
 import com.idle.domain.model.jobposting.CrawlingJobPosting
@@ -63,6 +66,7 @@ internal class WorkerHomeFragment : BaseComposeFragment() {
             val jobPostings by jobPostings.collectAsStateWithLifecycle()
 
             WorkerHomeScreen(
+                snackbarHostState = snackbarHostState,
                 profile = profile,
                 workerJobPostings = jobPostings,
                 getJobPostings = ::getJobPostings,
@@ -77,6 +81,7 @@ internal class WorkerHomeFragment : BaseComposeFragment() {
 
 @Composable
 internal fun WorkerHomeScreen(
+    snackbarHostState: SnackbarHostState,
     profile: WorkerProfile?,
     workerJobPostings: List<JobPosting>,
     getJobPostings: () -> Unit,
@@ -126,7 +131,18 @@ internal fun WorkerHomeScreen(
                     bottom = 8.dp
                 ),
             )
-        }
+        },
+        snackbarHost = {
+            SnackbarHost(
+                hostState = snackbarHostState,
+                snackbar = { data ->
+                    CareSnackBar(
+                        data = data,
+                        modifier = Modifier.padding(bottom = 20.dp)
+                    )
+                }
+            )
+        },
     ) { paddingValue ->
         Column(
             modifier = Modifier

--- a/feature/worker/home/src/main/java/com/idle/worker/home/WorkerHomeViewModel.kt
+++ b/feature/worker/home/src/main/java/com/idle/worker/home/WorkerHomeViewModel.kt
@@ -88,6 +88,8 @@ class WorkerHomeViewModel @Inject constructor(
             jobPostingId = jobPostingId,
             applyMethod = ApplyMethod.APP
         ).onSuccess {
+            baseEvent(CareBaseEvent.ShowSnackBar("지원이 완료되었어요.|SUCCESS"))
+
             _jobPostings.value = _jobPostings.value.map {
                 if (it.jobPostingType == JobPostingType.CAREMEET && it.id == jobPostingId) {
                     val jobPosting = it as WorkerJobPosting
@@ -105,6 +107,8 @@ class WorkerHomeViewModel @Inject constructor(
             jobPostingId = jobPostingId,
             jobPostingType = jobPostingType,
         ).onSuccess {
+            baseEvent(CareBaseEvent.ShowSnackBar("즐겨찾기에 추가되었어요.|SUCCESS"))
+
             _jobPostings.value = _jobPostings.value.map {
                 when (it.jobPostingType) {
                     JobPostingType.CAREMEET -> {
@@ -129,6 +133,8 @@ class WorkerHomeViewModel @Inject constructor(
             jobPostingId = jobPostingId,
             jobPostingType = jobPostingType,
         ).onSuccess {
+            baseEvent(CareBaseEvent.ShowSnackBar("즐겨찾기에서 제거되었어요.|SUCCESS"))
+
             _jobPostings.value = _jobPostings.value.map {
                 when (it.jobPostingType) {
                     JobPostingType.CAREMEET -> {

--- a/feature/worker/job-posting/src/main/java/com/idle/worker/job/posting/WorkerJobPostingFragment.kt
+++ b/feature/worker/job-posting/src/main/java/com/idle/worker/job/posting/WorkerJobPostingFragment.kt
@@ -17,6 +17,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -39,6 +41,7 @@ import com.idle.compose.clickable
 import com.idle.designresource.R
 import com.idle.designsystem.compose.component.CareButtonCardLarge
 import com.idle.designsystem.compose.component.CareHeadingTopBar
+import com.idle.designsystem.compose.component.CareSnackBar
 import com.idle.designsystem.compose.component.CareStateAnimator
 import com.idle.designsystem.compose.component.CareTabBar
 import com.idle.designsystem.compose.component.CareTag
@@ -69,6 +72,7 @@ internal class WorkerJobPostingFragment : BaseComposeFragment() {
             }
 
             WorkerJobPostingScreen(
+                snackbarHostState = snackbarHostState,
                 recruitmentPostStatus = recruitmentPostStatus,
                 appliedJobPostings = appliedJobPostings,
                 favoritesJobPostings = favoritesJobPostings,
@@ -84,6 +88,7 @@ internal class WorkerJobPostingFragment : BaseComposeFragment() {
 
 @Composable
 internal fun WorkerJobPostingScreen(
+    snackbarHostState: SnackbarHostState,
     recruitmentPostStatus: RecruitmentPostStatus,
     appliedJobPostings: List<JobPosting>,
     favoritesJobPostings: List<JobPosting>,
@@ -104,6 +109,17 @@ internal fun WorkerJobPostingScreen(
                     top = 48.dp,
                     bottom = 8.dp
                 ),
+            )
+        },
+        snackbarHost = {
+            SnackbarHost(
+                hostState = snackbarHostState,
+                snackbar = { data ->
+                    CareSnackBar(
+                        data = data,
+                        modifier = Modifier.padding(bottom = 20.dp)
+                    )
+                }
             )
         },
     ) { paddingValue ->

--- a/feature/worker/job-posting/src/main/java/com/idle/worker/job/posting/WorkerJobPostingViewModel.kt
+++ b/feature/worker/job-posting/src/main/java/com/idle/worker/job/posting/WorkerJobPostingViewModel.kt
@@ -2,6 +2,7 @@ package com.idle.worker.job.posting
 
 import androidx.lifecycle.viewModelScope
 import com.idle.binding.base.BaseViewModel
+import com.idle.binding.base.CareBaseEvent
 import com.idle.domain.model.error.HttpResponseException
 import com.idle.domain.model.jobposting.ApplyMethod
 import com.idle.domain.model.jobposting.CrawlingJobPosting
@@ -94,6 +95,8 @@ class WorkerJobPostingViewModel @Inject constructor(
             jobPostingId = jobPostingId,
             applyMethod = ApplyMethod.APP
         ).onSuccess {
+            baseEvent(CareBaseEvent.ShowSnackBar("지원이 완료되었어요.|SUCCESS"))
+
             _appliedJobPostings.value = _appliedJobPostings.value.map {
                 if (it.jobPostingType == JobPostingType.CAREMEET && it.id == jobPostingId) {
                     val jobPosting = it as WorkerJobPosting
@@ -117,6 +120,8 @@ class WorkerJobPostingViewModel @Inject constructor(
             jobPostingId = jobPostingId,
             jobPostingType = jobPostingType,
         ).onSuccess {
+            baseEvent(CareBaseEvent.ShowSnackBar("즐겨찾기에 추가되었어요.|SUCCESS"))
+
             _appliedJobPostings.value = _appliedJobPostings.value.map {
                 when (it.jobPostingType) {
                     JobPostingType.CAREMEET -> {
@@ -155,6 +160,8 @@ class WorkerJobPostingViewModel @Inject constructor(
             jobPostingId = jobPostingId,
             jobPostingType = jobPostingType,
         ).onSuccess {
+            baseEvent(CareBaseEvent.ShowSnackBar("즐겨찾기에서 제거했어요.|SUCCESS"))
+
             _appliedJobPostings.value = _appliedJobPostings.value.map {
                 when (it.jobPostingType) {
                     JobPostingType.CAREMEET -> {

--- a/feature/worker/profile/src/main/java/com/idle/worker/profile/WorkerProfileFragment.kt
+++ b/feature/worker/profile/src/main/java/com/idle/worker/profile/WorkerProfileFragment.kt
@@ -21,6 +21,8 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
@@ -39,6 +41,7 @@ import com.idle.compose.clickable
 import com.idle.designresource.R
 import com.idle.designsystem.compose.component.CareButtonRound
 import com.idle.designsystem.compose.component.CareClickableTextField
+import com.idle.designsystem.compose.component.CareSnackBar
 import com.idle.designsystem.compose.component.CareSubtitleTopBar
 import com.idle.designsystem.compose.component.CareTag
 import com.idle.designsystem.compose.component.CareTextField
@@ -74,6 +77,7 @@ internal class WorkerProfileFragment : BaseComposeFragment() {
 
             workerProfile?.let {
                 WorkerProfileScreen(
+                    snackbarHostState = snackbarHostState,
                     isEditState = isEditState,
                     workerProfile = it,
                     workerIntroduce = workerIntroduce,
@@ -94,6 +98,7 @@ internal class WorkerProfileFragment : BaseComposeFragment() {
 
 @Composable
 internal fun WorkerProfileScreen(
+    snackbarHostState: SnackbarHostState,
     workerProfile: WorkerProfile,
     workerIntroduce: String,
     specialty: String,
@@ -147,6 +152,17 @@ internal fun WorkerProfileScreen(
                         .padding(start = 12.dp, top = 48.dp, end = 20.dp, bottom = 12.dp),
                 )
             }
+        },
+        snackbarHost = {
+            SnackbarHost(
+                hostState = snackbarHostState,
+                snackbar = { data ->
+                    CareSnackBar(
+                        data = data,
+                        modifier = Modifier.padding(bottom = 20.dp)
+                    )
+                }
+            )
         },
         containerColor = CareTheme.colors.white000,
         modifier = Modifier.addFocusCleaner(focusManager),

--- a/feature/worker/profile/src/main/java/com/idle/worker/profile/WorkerProfileViewModel.kt
+++ b/feature/worker/profile/src/main/java/com/idle/worker/profile/WorkerProfileViewModel.kt
@@ -77,6 +77,7 @@ class WorkerProfileViewModel @Inject constructor(
             imageFileUri = _profileImageUri.value?.toString(),
             jobSearchStatus = _workerProfile.value!!.jobSearchStatus,
         ).onSuccess {
+            baseEvent(CareBaseEvent.ShowSnackBar("정보 수정이 완료되었어요.|ERROR"))
             setEditState(false)
         }.onFailure {
             baseEvent(CareBaseEvent.ShowSnackBar(it.message.toString()))
@@ -97,17 +98,5 @@ class WorkerProfileViewModel @Inject constructor(
 
     fun setProfileImageUrl(uri: Uri?) {
         _profileImageUri.value = uri
-    }
-
-    internal fun setGender(gender: Gender) {
-        _gender.value = gender
-    }
-
-    internal fun setRoadNameAddress(address: String) {
-        _roadNameAddress.value = address
-    }
-
-    internal fun setLotNumberAddress(address: String) {
-        _lotNumberAddress.value = address
     }
 }


### PR DESCRIPTION
## 1. 🔥 변경된 내용

## 2. 📸 스크린샷(선택)

- **Default (Pixel6 Pro)**

![2024-09-0411 36 48-ezgif com-resize](https://github.com/user-attachments/assets/2e919158-5eef-4261-afe6-cabca114d08b)

- **Fold (Horizontal 접은 상태)**

![2024-09-0411 45 56-ezgif com-resize](https://github.com/user-attachments/assets/ce4e5eac-224d-474a-935c-2284f0747e09)

## 3. 🫡 고민한 부분

### 커스텀 스낵바 2가지 타입을 사용하기.

현재 디자인 시스템 컴포넌트에서 스낵바가 아래와 같이 2가지 타입으로 제공되는데,

![image](https://github.com/user-attachments/assets/044a7914-4065-4766-9ed7-8ac5c45cbf9c)

커스텀 스낵바를 아래와 같이 정의하였습니다.

```kotlin
@Composable
fun CareSnackBar(
    data: SnackbarData,
    modifier: Modifier = Modifier,
) {
    val (msg, type) = try {
        data.visuals.message.split("|").let {
            if (it.size >= 2) {
                it[0] to it[1]
            } else {
                data.visuals.message to SnackBarType.ERROR.name
            }
        }
    } catch (e: Exception) {
        data.visuals.message to SnackBarType.ERROR.name
    }

    val snackBarType = SnackBarType.create(type)

    val (backgroundColor, leftImage) = when (snackBarType) {
        SnackBarType.SUCCESS -> CareTheme.colors.gray500 to R.drawable.ic_check_gray
        SnackBarType.ERROR -> CareTheme.colors.red to R.drawable.ic_error
    }


    Row(
        verticalAlignment = Alignment.CenterVertically,
        modifier = modifier
            .padding(horizontal = 20.dp)
            .fillMaxWidth()
            .clip(RoundedCornerShape(8.dp))
            .background(backgroundColor)
            .padding(horizontal = 16.dp, vertical = 12.dp),
    ) {
        Image(
            painter = painterResource(id = leftImage),
            contentDescription = null,
            modifier = Modifier.padding(end = 8.dp),
        )

        Text(
            text = msg,
            style = CareTheme.typography.subtitle4,
            color = CareTheme.colors.white000,
        )

        Spacer(modifier = Modifier.weight(1f))

        Image(
            painter = painterResource(id = R.drawable.ic_cancel),
            contentDescription = null,
            modifier = Modifier.clickable { data.dismiss() }
        )
    }
}

private enum class SnackBarType {
    ERROR, SUCCESS;

    companion object {
        fun create(type: String): SnackBarType {
            return SnackBarType.entries.firstOrNull { it.name == type } ?: ERROR
        }
    }
}

@Preview(showBackground = true)
@Composable
fun CareSnackBarPreview() {
    CareSnackBar(
        data = MockSnackbarData("전화번호를 다시 확인해주세요."),
        modifier = Modifier.fillMaxWidth(),
    )
}
```

스낵바를 사용하는 쪽에서는,

아래와 같이 BaseViewModel에 정의되어있는 이벤트와

BaseComposeFragment에 정의된 snackbarHostState를 이용해서 하나의 메소드로 호출을 하게 되는데,

```kotlin
open class BaseViewModel : ViewModel() {
    private val _baseEventFlow = MutableSharedFlow<CareBaseEvent>()
    val baseEventFlow = _baseEventFlow.asSharedFlow()

    // ....

    fun baseEvent(event: CareBaseEvent) = viewModelScope.launch {
        _baseEventFlow.emit(event)
    }
}

sealed class CareBaseEvent {
    data class NavigateTo(val destination: DeepLinkDestination, val popUpTo: Int? = null) :
        CareBaseEvent()

    data class ShowSnackBar(val msg: String) : CareBaseEvent()
    data object NavigateToAuthWithClearBackStack : CareBaseEvent()
}
```

```kotlin
abstract class BaseComposeFragment : Fragment() {

    protected abstract val fragmentViewModel: BaseViewModel
    protected var snackbarHostState = SnackbarHostState()
    private lateinit var composeView: ComposeView

    // ....

    private fun handleEvent(event: CareBaseEvent) {
        when (event) {
            is CareBaseEvent.NavigateTo -> findNavController()
                .deepLinkNavigateTo(
                    context = requireContext(),
                    deepLinkDestination = event.destination,
                    popUpTo = event.popUpTo,
                )

            is CareBaseEvent.ShowSnackBar -> {
                viewLifecycleOwner.lifecycleScope.launch {
                    snackbarHostState.currentSnackbarData?.dismiss()
                    snackbarHostState.showSnackbar(event.msg)
                }
            }

            is CareBaseEvent.NavigateToAuthWithClearBackStack -> baseNavigation.navigateToAuth()
        }
    }
}
```

이 때 실제로 사용되는 구현부 화면에서는 아래와 같이 데이터를 받게 됩니다.

즉, SnackBarType을 BaseXXX에서 전달을 할 수가 없습니다.

```kotlin
snackbar = { data ->
    CareSnackBar(
        data = data,
        modifier = Modifier.padding(bottom = 20.dp)
    )
}
```

어떻게하면 효율적으로 사용할 수 있을까 고민을 했는데,

`snackBarMessage`에 뒤에 "|ERROR" 혹은 "|SUCESS"를 달아서,

```kotlin
val (msg, type) = try {
        data.visuals.message.split("|").let {
            if (it.size >= 2) {
                it[0] to it[1]
            } else {
                data.visuals.message to SnackBarType.ERROR.name
            }
        }
    } catch (e: Exception) {
        data.visuals.message to SnackBarType.ERROR.name
    }

    val snackBarType = SnackBarType.create(type)
```

컴포넌트 내부에서 파싱하여 타입을 만들도록하여 해결하였습니다.
