### PR TITLE
[IDLE-350] 회원 탈퇴시 특정 항목에 이유를 받을 수 있도록 변경 및 센터, 요양보호사 회원 탈퇴 마지막 화면 분기

### DIFF
--- a/core/common-ui/binding/src/main/java/com/idle/binding/base/BaseBindingFragment.kt
+++ b/core/common-ui/binding/src/main/java/com/idle/binding/base/BaseBindingFragment.kt
@@ -62,7 +62,7 @@ abstract class BaseBindingFragment<T : ViewDataBinding, V : BaseViewModel>
             )
 
         is CareBaseEvent.ShowSnackBar -> showSnackBar(event.msg)
-        is CareBaseEvent.NavigateToAuthWithClearBackStack -> baseNavigation.navigateToAuth()
+        is CareBaseEvent.NavigateToAuthWithClearBackStack -> baseNavigation.navigateToAuth(event.snackBarMsg)
     }
 
     override fun onDestroyView() {

--- a/core/common-ui/binding/src/main/java/com/idle/binding/base/BaseViewModel.kt
+++ b/core/common-ui/binding/src/main/java/com/idle/binding/base/BaseViewModel.kt
@@ -24,8 +24,7 @@ open class BaseViewModel : ViewModel() {
             ApiErrorCode.TokenExpiredException,
             ApiErrorCode.TokenNotFound,
             ApiErrorCode.NotSupportUserTokenType -> {
-                _baseEventFlow.emit(CareBaseEvent.ShowSnackBar(error.apiErrorCode.displayMsg + "|Error"))
-                _baseEventFlow.emit(CareBaseEvent.NavigateToAuthWithClearBackStack)
+                _baseEventFlow.emit(CareBaseEvent.NavigateToAuthWithClearBackStack(error.apiErrorCode.displayMsg + "|Error"))
             }
 
             else -> _baseEventFlow.emit(CareBaseEvent.ShowSnackBar(error.apiErrorCode.displayMsg + "|Error"))
@@ -38,5 +37,5 @@ sealed class CareBaseEvent {
         CareBaseEvent()
 
     data class ShowSnackBar(val msg: String) : CareBaseEvent()
-    data object NavigateToAuthWithClearBackStack : CareBaseEvent()
+    data class NavigateToAuthWithClearBackStack(val snackBarMsg: String) : CareBaseEvent()
 }

--- a/core/common-ui/binding/src/main/java/com/idle/binding/base/navigation/BaseNavigation.kt
+++ b/core/common-ui/binding/src/main/java/com/idle/binding/base/navigation/BaseNavigation.kt
@@ -1,5 +1,5 @@
 package com.idle.binding.base.navigation
 
 interface BaseNavigation {
-    fun navigateToAuth()
+    fun navigateToAuth(snackBarMsg: String)
 }

--- a/core/common-ui/compose/src/main/java/com/idle/compose/base/BaseComposeFragment.kt
+++ b/core/common-ui/compose/src/main/java/com/idle/compose/base/BaseComposeFragment.kt
@@ -83,7 +83,7 @@ abstract class BaseComposeFragment : Fragment() {
                 }
             }
 
-            is CareBaseEvent.NavigateToAuthWithClearBackStack -> baseNavigation.navigateToAuth()
+            is CareBaseEvent.NavigateToAuthWithClearBackStack -> baseNavigation.navigateToAuth(event.snackBarMsg)
         }
     }
 }

--- a/core/designresource/src/main/res/values/strings.xml
+++ b/core/designresource/src/main/res/values/strings.xml
@@ -193,7 +193,7 @@
     <string name="customer_info_format">%1$s등급 %2$s세 %3$s</string>
 
     <!-- Miscellaneous -->
-    <string name="auth_title">쉽고 빠르게 만나는\n집 근처 요양 일자리\n케어밋</string>
+    <string name="auth_title">쉽고 빠르게 만나는\n집 근처 요양 일자리, 케어밋</string>
     <string name="center_info_input_animation_label">센터 정보 입력을 관리하는 애니메이션</string>
     <string name="center_info_input">센터 정보를 입력해주세요.</string>
     <string name="start_center">센터 관리자로\n시작하기</string>

--- a/core/designresource/src/main/res/values/strings.xml
+++ b/core/designresource/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="withdrawal_reason_title">정말 탈퇴하시겠어요?</string>
     <string name="withdrawal_reason_description">계정을 삭제하시려는 이유를 알려주세요.\n소중한 피드백을 받아 더 나은 서비스로 보답하겠습니다.</string>
     <string name="withdrawal_phone_number_verification_title">마지막으로\n전화번호를 인증해주세요.</string>
+    <string name="withdrawal_password_verification_title">마지막으로\n비밀번호를 입력해주세요.</string>
     <string name="withdrawal_warning">탈퇴 버튼 선택 시 모든 정보가 삭제되며, 되돌릴 수 없습니다.</string>
 
     <!-- User Registration -->

--- a/core/domain/src/main/kotlin/com/idle/domain/model/error/HttpResponseException.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/model/error/HttpResponseException.kt
@@ -94,7 +94,7 @@ enum class ApiErrorCode(val serverCode: String, val description: String, val dis
     AlreadyApplied("APPLY-001", "해당 공고에 같은 지원 수단으로 지원한 과거 이력이 존재하는 경우 발생합니다.", "이미 지원한 공고 입니다."),
 
     // API Errors
-    InvalidParameter("API-001", "API 요청 시, 잘못된 parameter를 입력한 경우 발생합니다.", "잘못된 입력입니다."),
+    InvalidParameter("API-001", "API 요청 시, 잘못된 parameter를 입력한 경우 발생합니다.", "올바르지 않은 입력입니다."),
 
     // SECURITY Errors
     UnAuthorizedRequest(

--- a/feature/auth/build.gradle.kts
+++ b/feature/auth/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("care.android.feature-compose")
+    alias(libs.plugins.androidx.navigation.safeargs)
 }
 
 android {

--- a/feature/auth/src/main/java/com/idle/auth/AuthFragment.kt
+++ b/feature/auth/src/main/java/com/idle/auth/AuthFragment.kt
@@ -1,6 +1,5 @@
 package com.idle.auth
 
-import android.util.Log
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.fadeIn
@@ -25,6 +24,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -38,12 +38,13 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.idle.analytics.helper.LocalAnalyticsHelper
+import androidx.navigation.fragment.navArgs
 import com.idle.analytics.helper.TrackScreenViewEvent
 import com.idle.binding.DeepLinkDestination
 import com.idle.binding.DeepLinkDestination.CenterSignIn
 import com.idle.binding.DeepLinkDestination.CenterSignUp
 import com.idle.binding.DeepLinkDestination.WorkerSignUp
+import com.idle.binding.base.CareBaseEvent
 import com.idle.binding.base.CareBaseEvent.NavigateTo
 import com.idle.compose.base.BaseComposeFragment
 import com.idle.compose.clickable
@@ -58,11 +59,18 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 internal class AuthFragment : BaseComposeFragment() {
     override val fragmentViewModel: AuthViewModel by viewModels()
+    private val args: AuthFragmentArgs by navArgs()
 
     @Composable
     override fun ComposeLayout() {
         fragmentViewModel.apply {
             val userRole by userRole.collectAsStateWithLifecycle()
+
+            LaunchedEffect(true) {
+                if (args.snackBarMsg != "default") {
+                    baseEvent(CareBaseEvent.ShowSnackBar(args.snackBarMsg))
+                }
+            }
 
             AuthScreen(
                 snackbarHostState = snackbarHostState,
@@ -73,7 +81,6 @@ internal class AuthFragment : BaseComposeFragment() {
         }
     }
 }
-
 
 @Composable
 internal fun AuthScreen(
@@ -94,7 +101,7 @@ internal fun AuthScreen(
                 snackbar = { data ->
                     CareSnackBar(
                         data = data,
-                        modifier = Modifier.padding(bottom = 138.dp)
+                        modifier = Modifier.padding(bottom = 20.dp)
                     )
                 }
             )
@@ -264,6 +271,6 @@ internal fun AuthScreen(
             }
         }
     }
-    
+
     TrackScreenViewEvent(screenName = "auth_screen")
 }

--- a/feature/auth/src/main/res/navigation/nav_auth.xml
+++ b/feature/auth/src/main/res/navigation/nav_auth.xml
@@ -4,10 +4,18 @@
     android:id="@+id/nav_auth"
     app:startDestination="@id/authFragment">
 
+    <action
+        android:id="@+id/action_global_nav_auth"
+        app:destination="@id/authFragment" />
+
     <fragment
         android:id="@+id/authFragment"
         android:name="com.idle.auth.AuthFragment"
         android:label="AuthFragment">
         <deepLink app:uri="@string/auth_deeplink_url" />
+        <argument
+            android:name="snackBarMsg"
+            android:defaultValue="default"
+            app:argType="string" />
     </fragment>
 </navigation>

--- a/feature/setting/src/main/java/com/idle/setting/center/CenterSettingViewModel.kt
+++ b/feature/setting/src/main/java/com/idle/setting/center/CenterSettingViewModel.kt
@@ -40,7 +40,7 @@ class CenterSettingViewModel @Inject constructor(
 
     fun logout() = viewModelScope.launch {
         logoutCenterUseCase().onSuccess {
-            baseEvent(CareBaseEvent.NavigateToAuthWithClearBackStack)
+            baseEvent(CareBaseEvent.NavigateToAuthWithClearBackStack("로그아웃이 완료되었습니다.|SUCCESS"))
         }.onFailure { handleFailure(it as HttpResponseException) }
     }
 

--- a/feature/setting/src/main/java/com/idle/setting/worker/WorkerSettingViewModel.kt
+++ b/feature/setting/src/main/java/com/idle/setting/worker/WorkerSettingViewModel.kt
@@ -39,7 +39,7 @@ class WorkerSettingViewModel @Inject constructor(
 
     fun logout() = viewModelScope.launch {
         logoutWorkerUseCase().onSuccess {
-            baseEvent(CareBaseEvent.NavigateToAuthWithClearBackStack)
+            baseEvent(CareBaseEvent.NavigateToAuthWithClearBackStack("로그아웃이 완료되었습니다.|SUCCESS"))
         }.onFailure { handleFailure(it as HttpResponseException) }
     }
 

--- a/feature/signin/src/main/java/com/idle/signin/center/CenterSignInViewModel.kt
+++ b/feature/signin/src/main/java/com/idle/signin/center/CenterSignInViewModel.kt
@@ -49,7 +49,7 @@ class CenterSignInViewModel @Inject constructor(
                     AnalyticsEvent(
                         type = AnalyticsEvent.Types.ACTION,
                         properties = mutableMapOf(
-                            ACTION_NAME to "login",
+                            ACTION_NAME to "center_login",
                             ACTION_RESULT to false,
                         )
                     )

--- a/feature/signin/src/main/java/com/idle/signin/center/newpassword/NewPasswordFragment.kt
+++ b/feature/signin/src/main/java/com/idle/signin/center/newpassword/NewPasswordFragment.kt
@@ -23,6 +23,7 @@ import com.idle.compose.addFocusCleaner
 import com.idle.compose.base.BaseComposeFragment
 import com.idle.designresource.R
 import com.idle.designsystem.compose.component.CareSnackBar
+import com.idle.designsystem.compose.component.CareStateAnimator
 import com.idle.designsystem.compose.component.CareSubtitleTopBar
 import com.idle.designsystem.compose.foundation.CareTheme
 import com.idle.signin.center.newpassword.step.GenerateNewPasswordScreen
@@ -37,7 +38,10 @@ class NewPasswordFragment : BaseComposeFragment() {
     override fun ComposeLayout() {
         fragmentViewModel.apply {
             val phoneNumber by phoneNumber.collectAsStateWithLifecycle()
-            val authCode by centerAuthCode.collectAsStateWithLifecycle()
+            val authCode by authCode.collectAsStateWithLifecycle()
+            val timerMinute by timerMinute.collectAsStateWithLifecycle()
+            val timerSeconds by timerSeconds.collectAsStateWithLifecycle()
+            val isConfirmAuthCode by isConfirmAuthCode.collectAsStateWithLifecycle()
             val newPasswordProcess by newPasswordProcess.collectAsStateWithLifecycle()
             val newPassword by newPassword.collectAsStateWithLifecycle()
             val newPasswordForConfirm by newPasswordForConfirm.collectAsStateWithLifecycle()
@@ -46,7 +50,10 @@ class NewPasswordFragment : BaseComposeFragment() {
                 snackbarHostState = snackbarHostState,
                 newPasswordStep = newPasswordProcess,
                 phoneNumber = phoneNumber,
-                certificationNumber = authCode,
+                authCode = authCode,
+                timerMinute = timerMinute,
+                timerSeconds = timerSeconds,
+                isConfirmAuthCode = isConfirmAuthCode,
                 newPassword = newPassword,
                 newPasswordForConfirm = newPasswordForConfirm,
                 setNewPasswordProcess = ::setNewPasswordProcess,
@@ -65,7 +72,10 @@ class NewPasswordFragment : BaseComposeFragment() {
 internal fun NewPasswordScreen(
     snackbarHostState: SnackbarHostState,
     phoneNumber: String,
-    certificationNumber: String,
+    authCode: String,
+    timerMinute: String,
+    timerSeconds: String,
+    isConfirmAuthCode: Boolean,
     newPassword: String,
     newPasswordForConfirm: String,
     newPasswordStep: NewPasswordStep,
@@ -102,24 +112,32 @@ internal fun NewPasswordScreen(
                 .padding(paddingValue)
                 .padding(start = 20.dp, end = 20.dp, top = 24.dp),
         ) {
-            when (newPasswordStep) {
-                NewPasswordStep.PHONE_NUMBER -> PhoneNumberScreen(
-                    phoneNumber = phoneNumber,
-                    certificationNumber = certificationNumber,
-                    onPhoneNumberChanged = onPhoneNumberChanged,
-                    onAuthCodeChanged = onAuthCodeChanged,
-                    sendPhoneNumber = sendPhoneNumber,
-                    confirmAuthCode = confirmAuthCode,
-                    setNewPasswordProcess = setNewPasswordProcess,
-                )
+            CareStateAnimator(
+                targetState = newPasswordStep,
+                label = "새 비밀번호 발급을 관리하는 애니메이션",
+            ) { step ->
+                when (step) {
+                    NewPasswordStep.PHONE_NUMBER -> PhoneNumberScreen(
+                        phoneNumber = phoneNumber,
+                        authCode = authCode,
+                        timerMinute = timerMinute,
+                        timerSeconds = timerSeconds,
+                        isConfirmAuthCode = isConfirmAuthCode,
+                        onPhoneNumberChanged = onPhoneNumberChanged,
+                        onAuthCodeChanged = onAuthCodeChanged,
+                        sendPhoneNumber = sendPhoneNumber,
+                        confirmAuthCode = confirmAuthCode,
+                        setNewPasswordProcess = setNewPasswordProcess,
+                    )
 
-                NewPasswordStep.GENERATE_NEW_PASSWORD -> GenerateNewPasswordScreen(
-                    newPassword = newPassword,
-                    newPasswordForConfirm = newPasswordForConfirm,
-                    onNewPasswordChanged = onNewPasswordChanged,
-                    onNewPasswordForConfirmChanged = onNewPasswordForConfirmChanged,
-                    setNewPasswordProcess = setNewPasswordProcess,
-                )
+                    NewPasswordStep.GENERATE_NEW_PASSWORD -> GenerateNewPasswordScreen(
+                        newPassword = newPassword,
+                        newPasswordForConfirm = newPasswordForConfirm,
+                        onNewPasswordChanged = onNewPasswordChanged,
+                        onNewPasswordForConfirmChanged = onNewPasswordForConfirmChanged,
+                        setNewPasswordProcess = setNewPasswordProcess,
+                    )
+                }
             }
         }
     }

--- a/feature/signin/src/main/java/com/idle/signin/center/newpassword/NewPasswordViewModel.kt
+++ b/feature/signin/src/main/java/com/idle/signin/center/newpassword/NewPasswordViewModel.kt
@@ -1,5 +1,6 @@
 package com.idle.signin.center.newpassword
 
+import androidx.core.text.isDigitsOnly
 import androidx.lifecycle.viewModelScope
 import com.idle.binding.base.BaseViewModel
 import com.idle.binding.base.CareBaseEvent
@@ -51,7 +52,9 @@ class NewPasswordViewModel @Inject constructor(
     internal val newPasswordForConfirm = _newPasswordForConfirm.asStateFlow()
 
     internal fun setPhoneNumber(phoneNumber: String) {
-        _phoneNumber.value = phoneNumber
+        if (phoneNumber.isDigitsOnly() && phoneNumber.length <= 11) {
+            _phoneNumber.value = phoneNumber
+        }
     }
 
     internal fun setAuthCode(certificateNumber: String) {

--- a/feature/signin/src/main/java/com/idle/signin/center/newpassword/step/GenerateNewPasswordScreen.kt
+++ b/feature/signin/src/main/java/com/idle/signin/center/newpassword/step/GenerateNewPasswordScreen.kt
@@ -13,8 +13,10 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -39,6 +41,7 @@ internal fun GenerateNewPasswordScreen(
     setNewPasswordProcess: (NewPasswordStep) -> Unit,
 ) {
     val focusRequester = remember { FocusRequester() }
+    val focusManager = LocalFocusManager.current
 
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
@@ -80,7 +83,7 @@ internal fun GenerateNewPasswordScreen(
                 hint = stringResource(id = R.string.password_hint),
                 onValueChanged = onNewPasswordChanged,
                 visualTransformation = PasswordVisualTransformation(),
-                onDone = { },
+                onDone = { focusManager.moveFocus(FocusDirection.Down) },
                 modifier = Modifier
                     .fillMaxWidth()
                     .focusRequester(focusRequester),
@@ -96,7 +99,11 @@ internal fun GenerateNewPasswordScreen(
                 hint = stringResource(id = R.string.confirm_password_hint),
                 onValueChanged = onNewPasswordForConfirmChanged,
                 visualTransformation = PasswordVisualTransformation(),
-                onDone = { },
+                onDone = {
+                    if (newPasswordForConfirm.isNotBlank() && newPassword == newPasswordForConfirm) {
+                        //Todo
+                    }
+                },
                 modifier = Modifier.fillMaxWidth(),
             )
         }
@@ -105,8 +112,10 @@ internal fun GenerateNewPasswordScreen(
 
         CareButtonLarge(
             text = stringResource(id = R.string.change_password),
-            enable = newPasswordForConfirm.isNotBlank(),
-            onClick = { },
+            enable = newPasswordForConfirm.isNotBlank() && newPassword == newPasswordForConfirm,
+            onClick = {
+                //Todo
+            },
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(bottom = 28.dp),

--- a/feature/signin/src/main/java/com/idle/signin/center/newpassword/step/GenerateNewPasswordScreen.kt
+++ b/feature/signin/src/main/java/com/idle/signin/center/newpassword/step/GenerateNewPasswordScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -78,6 +79,7 @@ internal fun GenerateNewPasswordScreen(
                 value = newPassword,
                 hint = stringResource(id = R.string.password_hint),
                 onValueChanged = onNewPasswordChanged,
+                visualTransformation = PasswordVisualTransformation(),
                 onDone = { },
                 modifier = Modifier
                     .fillMaxWidth()
@@ -93,6 +95,7 @@ internal fun GenerateNewPasswordScreen(
                 value = newPasswordForConfirm,
                 hint = stringResource(id = R.string.confirm_password_hint),
                 onValueChanged = onNewPasswordForConfirmChanged,
+                visualTransformation = PasswordVisualTransformation(),
                 onDone = { },
                 modifier = Modifier.fillMaxWidth(),
             )

--- a/feature/signin/src/main/java/com/idle/signin/center/newpassword/step/PhoneNumberScreen.kt
+++ b/feature/signin/src/main/java/com/idle/signin/center/newpassword/step/PhoneNumberScreen.kt
@@ -13,8 +13,10 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.idle.designresource.R
@@ -39,6 +41,7 @@ internal fun PhoneNumberScreen(
     setNewPasswordProcess: (NewPasswordStep) -> Unit,
 ) {
     val focusRequester = remember { FocusRequester() }
+    val focusManager = LocalFocusManager.current
 
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
@@ -67,7 +70,13 @@ internal fun PhoneNumberScreen(
                 CareTextField(
                     value = phoneNumber,
                     hint = stringResource(id = R.string.phone_number_hint),
-                    onValueChanged = onPhoneNumberChanged,
+                    onValueChanged = {
+                        onPhoneNumberChanged(it)
+                        if (it.length == 11) {
+                            sendPhoneNumber()
+                            focusManager.moveFocus(FocusDirection.Down)
+                        }
+                    },
                     readOnly = (timerMinute != "" && timerSeconds != ""),
                     onDone = { if (phoneNumber.length == 11) sendPhoneNumber() },
                     modifier = Modifier

--- a/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpFragment.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpFragment.kt
@@ -135,8 +135,6 @@ internal fun CenterSignUpScreen(
 ) {
     val onBackPressedDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
     val focusManager = LocalFocusManager.current
-    val (businessRegistrationProcessed, setBusinessRegistrationProcessed)
-            = remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -200,13 +198,11 @@ internal fun CenterSignUpScreen(
                             centerAuthCodeTimerSeconds = centerAuthCodeTimerSeconds,
                             centerAuthCode = centerAuthCode,
                             isConfirmAuthCode = isConfirmAuthCode,
-                            businessRegistrationProcessed = businessRegistrationProcessed,
                             onCenterPhoneNumberChanged = onCenterPhoneNumberChanged,
                             onCenterAuthCodeChanged = onCenterAuthCodeChanged,
                             setSignUpStep = setSignUpStep,
                             sendPhoneNumber = sendPhoneNumber,
                             confirmAuthCode = confirmAuthCode,
-                            setBusinessRegistrationProcessed = setBusinessRegistrationProcessed,
                         )
 
                     CenterSignUpStep.BUSINESS_REGISTRATION ->

--- a/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpViewModel.kt
@@ -1,5 +1,6 @@
 package com.idle.signin.center
 
+import androidx.core.text.isDigitsOnly
 import androidx.lifecycle.viewModelScope
 import com.idle.binding.DeepLinkDestination
 import com.idle.binding.base.BaseViewModel
@@ -84,7 +85,7 @@ class CenterSignUpViewModel @Inject constructor(
     }
 
     internal fun setCenterPhoneNumber(phoneNumber: String) {
-        if (phoneNumber.length <= 11) {
+        if (phoneNumber.isDigitsOnly() && phoneNumber.length <= 11) {
             _centerPhoneNumber.value = phoneNumber
         }
     }
@@ -149,6 +150,8 @@ class CenterSignUpViewModel @Inject constructor(
             .onSuccess {
                 cancelTimer()
                 _isConfirmAuthCode.value = true
+
+                _signUpStep.value = CenterSignUpStep.BUSINESS_REGISTRATION
             }
             .onFailure { handleFailure(it as HttpResponseException) }
     }

--- a/feature/signup/src/main/java/com/idle/signup/center/step/IdPasswordScreen.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/step/IdPasswordScreen.kt
@@ -39,7 +39,6 @@ import com.idle.designsystem.compose.component.LabeledContent
 import com.idle.designsystem.compose.foundation.CareTheme
 import com.idle.signin.center.CenterSignUpStep
 import com.idle.signin.center.CenterSignUpStep.ID_PASSWORD
-import com.idle.signin.center.CenterSignUpStep.PHONE_NUMBER
 import com.idle.signup.LogCenterSignUpStep
 
 @Composable

--- a/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpFragment.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpFragment.kt
@@ -138,7 +138,6 @@ internal fun WorkerSignUpScreen(
 ) {
     val onBackPressedDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
     val focusManager = LocalFocusManager.current
-    val (addressProcessed, setAddressProcessed) = remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -191,13 +190,11 @@ internal fun WorkerSignUpScreen(
                         workerAuthCodeTimerSeconds = workerAuthCodeTimerSeconds,
                         workerAuthCode = workerAuthCode,
                         isConfirmAuthCode = isConfirmAuthCode,
-                        addressProcessed = addressProcessed,
                         onWorkerPhoneNumberChanged = onWorkerPhoneNumberChanged,
                         onWorkerAuthCodeChanged = onWorkerAuthCodeChanged,
                         setSignUpStep = setSignUpStep,
                         sendPhoneNumber = sendPhoneNumber,
                         confirmAuthCode = confirmAuthCode,
-                        setAddressProcessed = setAddressProcessed,
                         navigateToAuth = navigateToAuth,
                     )
 

--- a/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpViewModel.kt
@@ -1,5 +1,6 @@
 package com.idle.signin.worker
 
+import androidx.core.text.isDigitsOnly
 import androidx.lifecycle.viewModelScope
 import com.idle.binding.DeepLinkDestination.WorkerHome
 import com.idle.binding.base.BaseViewModel
@@ -70,7 +71,7 @@ class WorkerSignUpViewModel @Inject constructor(
     }
 
     internal fun setWorkerPhoneNumber(phoneNumber: String) {
-        if (phoneNumber.length <= 11) {
+        if (phoneNumber.isDigitsOnly() && phoneNumber.length <= 11) {
             _workerPhoneNumber.value = phoneNumber
         }
     }
@@ -144,6 +145,7 @@ class WorkerSignUpViewModel @Inject constructor(
             confirmAuthCodeUseCase(_workerPhoneNumber.value, _workerAuthCode.value).onSuccess {
                 cancelTimer()
                 _isConfirmAuthCode.value = true
+                _signUpStep.value = WorkerSignUpStep.findStep(PHONE_NUMBER.step + 1)
             }.onFailure { handleFailure(it as HttpResponseException) }
         }
     }

--- a/feature/withdrawal/src/main/java/com/idle/withdrawal/WithdrawalFragment.kt
+++ b/feature/withdrawal/src/main/java/com/idle/withdrawal/WithdrawalFragment.kt
@@ -47,6 +47,9 @@ internal class WithdrawalFragment : BaseComposeFragment() {
             val authCodeTimerSeconds by authCodeTimerSeconds.collectAsStateWithLifecycle()
             val isConfirmAuthCode by isConfirmAuthCode.collectAsStateWithLifecycle()
             val userType by rememberSaveable { mutableStateOf(UserType.create(args.userType)) }
+            val inconvenientReason by inconvenientReason.collectAsStateWithLifecycle()
+            val anotherPlatformReason by anotherPlatformReason.collectAsStateWithLifecycle()
+            val lackFeaturesReason by lackFeaturesReason.collectAsStateWithLifecycle()
 
             WithdrawalStep(
                 userType = userType,
@@ -54,8 +57,14 @@ internal class WithdrawalFragment : BaseComposeFragment() {
                 timerMinute = authCodeTimerMinute,
                 timerSeconds = authCodeTimerSeconds,
                 isConfirmAuthCode = isConfirmAuthCode,
+                inconvenientReason = inconvenientReason,
+                anotherPlatformReason = anotherPlatformReason,
+                lackFeaturesReason = lackFeaturesReason,
                 setWithdrawalStep = ::setWithdrawalStep,
                 onReasonChanged = ::setWithdrawalReason,
+                onInconvenientReasonChanged = ::setInconvenientReason,
+                onAnotherPlatformReasonChanged = ::setAnotherPlatformReason,
+                onLackFeaturesReasonChanged = ::setLackFeaturesReason,
                 onPhoneNumberChanged = ::setPhoneNumber,
                 onAuthCodeChanged = ::setAuthCode,
                 sendPhoneNumber = ::sendPhoneNumber,
@@ -83,8 +92,14 @@ internal fun WithdrawalStep(
     timerMinute: String,
     timerSeconds: String,
     isConfirmAuthCode: Boolean,
+    inconvenientReason: String,
+    anotherPlatformReason: String,
+    lackFeaturesReason: String,
     setWithdrawalStep: (WithdrawalStep) -> Unit,
     onReasonChanged: (WithdrawalReason) -> Unit,
+    onInconvenientReasonChanged: (String) -> Unit,
+    onAnotherPlatformReasonChanged: (String) -> Unit,
+    onLackFeaturesReasonChanged: (String) -> Unit,
     onPhoneNumberChanged: (String) -> Unit,
     onAuthCodeChanged: (String) -> Unit,
     sendPhoneNumber: () -> Unit,
@@ -116,7 +131,7 @@ internal fun WithdrawalStep(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
                 .padding(paddingValue)
-                .padding(start = 20.dp, end = 20.dp, top = 24.dp, bottom = 28.dp),
+                .padding(start = 20.dp, end = 20.dp, top = 24.dp),
         ) {
             CareStateAnimator(
                 targetState = withdrawalStep,
@@ -125,8 +140,14 @@ internal fun WithdrawalStep(
                 when (withdrawalStep) {
                     WithdrawalStep.REASON -> ReasonScreen(
                         userType = userType,
+                        inconvenientReason = inconvenientReason,
+                        anotherPlatformReason = anotherPlatformReason,
+                        lackFeaturesReason = lackFeaturesReason,
                         onReasonChanged = onReasonChanged,
                         setWithdrawalStep = setWithdrawalStep,
+                        onInconvenientReasonChanged = onInconvenientReasonChanged,
+                        onAnotherPlatformReasonChanged = onAnotherPlatformReasonChanged,
+                        onLackFeaturesReasonChanged = onLackFeaturesReasonChanged,
                         navigateToSetting = navigateToSetting,
                     )
 

--- a/feature/withdrawal/src/main/java/com/idle/withdrawal/WithdrawalFragment.kt
+++ b/feature/withdrawal/src/main/java/com/idle/withdrawal/WithdrawalFragment.kt
@@ -27,7 +27,6 @@ import androidx.navigation.fragment.navArgs
 import com.idle.binding.DeepLinkDestination.CenterSetting
 import com.idle.binding.DeepLinkDestination.WorkerSetting
 import com.idle.binding.base.CareBaseEvent
-import com.idle.binding.repeatOnStarted
 import com.idle.compose.addFocusCleaner
 import com.idle.compose.base.BaseComposeFragment
 import com.idle.designresource.R
@@ -61,14 +60,6 @@ internal class WithdrawalFragment : BaseComposeFragment() {
             val userType by rememberSaveable { mutableStateOf(UserType.create(args.userType)) }
             var showDialog by rememberSaveable { mutableStateOf(false) }
 
-            viewLifecycleOwner.repeatOnStarted {
-                withdrawalEvent.collect { event ->
-                    when (event) {
-                        WithdrawalEvent.WithdrawalSuccess -> showDialog = true
-                    }
-                }
-            }
-
             if (showDialog) {
                 CareDialog(
                     title = "정말 탈퇴하시겠어요?",
@@ -84,8 +75,7 @@ internal class WithdrawalFragment : BaseComposeFragment() {
                     onDismissRequest = { showDialog = false },
                     onLeftButtonClick = { showDialog = false },
                     onRightButtonClick = {
-                        baseEvent(CareBaseEvent.NavigateToAuthWithClearBackStack)
-                        baseEvent(CareBaseEvent.ShowSnackBar("회원탈퇴가 완료되었어요.|ERROR"))
+                        withdrawal(userType)
                         showDialog = false
                     },
                     modifier = Modifier
@@ -115,7 +105,7 @@ internal class WithdrawalFragment : BaseComposeFragment() {
                 onPasswordChanged = ::setPassword,
                 sendPhoneNumber = ::sendPhoneNumber,
                 confirmAuthCode = ::confirmAuthCode,
-                withdrawal = { withdrawal(userType) },
+                withdrawal = { showDialog = true },
                 navigateToSetting = {
                     baseEvent(
                         CareBaseEvent.NavigateTo(

--- a/feature/withdrawal/src/main/java/com/idle/withdrawal/WithdrawalViewModel.kt
+++ b/feature/withdrawal/src/main/java/com/idle/withdrawal/WithdrawalViewModel.kt
@@ -157,8 +157,7 @@ class WithdrawalViewModel @Inject constructor(
                 .joinToString("|"),
             password = password.value
         ).onSuccess {
-            baseEvent(CareBaseEvent.NavigateToAuthWithClearBackStack)
-            baseEvent(CareBaseEvent.ShowSnackBar("회원탈퇴가 완료되었어요.|ERROR"))
+            baseEvent(CareBaseEvent.NavigateToAuthWithClearBackStack("회원탈퇴가 완료되었어요.|ERROR"))
         }.onFailure { handleFailure(it as HttpResponseException) }
     }
 
@@ -168,8 +167,7 @@ class WithdrawalViewModel @Inject constructor(
                 .sortedBy { it.ordinal }
                 .joinToString("|"),
         ).onSuccess {
-            baseEvent(CareBaseEvent.NavigateToAuthWithClearBackStack)
-            baseEvent(CareBaseEvent.ShowSnackBar("회원탈퇴가 완료되었어요.|ERROR"))
+            baseEvent(CareBaseEvent.NavigateToAuthWithClearBackStack("회원탈퇴가 완료되었어요.|ERROR"))
         }.onFailure { handleFailure(it as HttpResponseException) }
     }
 }

--- a/feature/withdrawal/src/main/java/com/idle/withdrawal/WithdrawalViewModel.kt
+++ b/feature/withdrawal/src/main/java/com/idle/withdrawal/WithdrawalViewModel.kt
@@ -47,6 +47,15 @@ class WithdrawalViewModel @Inject constructor(
     private val _isConfirmAuthCode = MutableStateFlow(false)
     val isConfirmAuthCode = _isConfirmAuthCode.asStateFlow()
 
+    private val _inconvenientReason = MutableStateFlow<String>("")
+    val inconvenientReason = _inconvenientReason.asStateFlow()
+
+    private val _anotherPlatformReason = MutableStateFlow<String>("")
+    val anotherPlatformReason = _anotherPlatformReason.asStateFlow()
+
+    private val _lackFeaturesReason = MutableStateFlow<String>("")
+    val lackFeaturesReason = _lackFeaturesReason.asStateFlow()
+
     internal fun setWithdrawalStep(step: WithdrawalStep) {
         _withdrawalStep.value = step
     }
@@ -59,7 +68,9 @@ class WithdrawalViewModel @Inject constructor(
     }
 
     internal fun setPhoneNumber(phoneNumber: String) {
-        _phoneNumber.value = phoneNumber
+        if (phoneNumber.length <= 11) {
+            _phoneNumber.value = phoneNumber
+        }
     }
 
     internal fun setAuthCode(authCode: String) {
@@ -70,6 +81,18 @@ class WithdrawalViewModel @Inject constructor(
         sendPhoneNumberUseCase(_phoneNumber.value)
             .onSuccess { startTimer() }
             .onFailure { handleFailure(it as HttpResponseException) }
+    }
+
+    internal fun setInconvenientReason(reason: String) {
+        _inconvenientReason.value = reason
+    }
+
+    internal fun setAnotherPlatformReason(reason: String) {
+        _anotherPlatformReason.value = reason
+    }
+
+    internal fun setLackFeaturesReason(reason: String) {
+        _lackFeaturesReason.value = reason
     }
 
     private fun startTimer() {

--- a/feature/withdrawal/src/main/java/com/idle/withdrawal/step/PasswordScreen.kt
+++ b/feature/withdrawal/src/main/java/com/idle/withdrawal/step/PasswordScreen.kt
@@ -1,0 +1,100 @@
+package com.idle.withdrawal.step
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import com.idle.designresource.R
+import com.idle.designsystem.compose.component.CareButtonMedium
+import com.idle.designsystem.compose.component.CareTextField
+import com.idle.designsystem.compose.component.LabeledContent
+import com.idle.designsystem.compose.foundation.CareTheme
+import com.idle.withdrawal.WithdrawalStep
+
+@Composable
+internal fun PasswordScreen(
+    password: String,
+    onPasswordChanged: (String) -> Unit,
+    setWithdrawalStep: (WithdrawalStep) -> Unit,
+    withdrawal: () -> Unit,
+    navigateToSetting: () -> Unit,
+) {
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+    BackHandler { setWithdrawalStep(WithdrawalStep.findStep(WithdrawalStep.PASSWORD.step - 1)) }
+
+    Column(
+        horizontalAlignment = Alignment.Start,
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        Text(
+            text = stringResource(id = R.string.withdrawal_password_verification_title),
+            style = CareTheme.typography.heading2,
+            color = CareTheme.colors.gray900,
+            modifier = Modifier.padding(bottom = 36.dp),
+        )
+
+        LabeledContent(
+            subtitle = stringResource(id = R.string.password),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            CareTextField(
+                value = password,
+                hint = stringResource(id = R.string.password_hint),
+                onValueChanged = onPasswordChanged,
+                visualTransformation = PasswordVisualTransformation(),
+                onDone = { },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(focusRequester),
+            )
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 28.dp),
+        ) {
+            CareButtonMedium(
+                text = stringResource(id = R.string.cancel),
+                textColor = CareTheme.colors.gray300,
+                containerColor = CareTheme.colors.white000,
+                border = BorderStroke(width = 1.dp, color = CareTheme.colors.gray200),
+                onClick = { navigateToSetting() },
+                modifier = Modifier.weight(1f),
+            )
+
+            CareButtonMedium(
+                text = stringResource(id = R.string.withdrawal),
+                textColor = CareTheme.colors.white000,
+                containerColor = CareTheme.colors.red,
+                enable = password.isNotBlank(),
+                onClick = withdrawal,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}

--- a/feature/withdrawal/src/main/java/com/idle/withdrawal/step/PhoneNumberScreen.kt
+++ b/feature/withdrawal/src/main/java/com/idle/withdrawal/step/PhoneNumberScreen.kt
@@ -53,7 +53,7 @@ internal fun PhoneNumberScreen(
         focusRequester.requestFocus()
     }
 
-    BackHandler { setWithdrawalStep(WithdrawalStep.findStep(WithdrawalStep.PHONENUMBER.step - 1)) }
+    BackHandler { setWithdrawalStep(WithdrawalStep.findStep(WithdrawalStep.PHONE_NUMBER.step - 1)) }
 
     Column(
         horizontalAlignment = Alignment.Start,
@@ -180,5 +180,5 @@ internal fun PhoneNumberScreen(
         }
     }
 
-    LogWithdrawalStep(step = WithdrawalStep.PHONENUMBER)
+    LogWithdrawalStep(step = WithdrawalStep.PHONE_NUMBER)
 }

--- a/feature/withdrawal/src/main/java/com/idle/withdrawal/step/PhoneNumberScreen.kt
+++ b/feature/withdrawal/src/main/java/com/idle/withdrawal/step/PhoneNumberScreen.kt
@@ -81,10 +81,8 @@ internal fun PhoneNumberScreen(
                     value = phoneNumber,
                     hint = stringResource(id = R.string.phone_number_hint),
                     onValueChanged = {
-                        if (it.length <= 11) {
-                            onPhoneNumberChanged(it)
-                            phoneNumber = it
-                        }
+                        onPhoneNumberChanged(it)
+                        phoneNumber = it
                     },
                     readOnly = (timerMinute != "" && timerSeconds != ""),
                     onDone = { if (phoneNumber.length == 11) sendPhoneNumber() },
@@ -158,7 +156,9 @@ internal fun PhoneNumberScreen(
 
         Row(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 28.dp),
         ) {
             CareButtonMedium(
                 text = stringResource(id = R.string.cancel),

--- a/feature/withdrawal/src/main/java/com/idle/withdrawal/step/ReasonScreen.kt
+++ b/feature/withdrawal/src/main/java/com/idle/withdrawal/step/ReasonScreen.kt
@@ -28,10 +28,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.idle.compose.clickable
 import com.idle.designresource.R
 import com.idle.designsystem.compose.component.CareButtonMedium
+import com.idle.designsystem.compose.component.CareTextFieldLong
 import com.idle.designsystem.compose.foundation.CareTheme
 import com.idle.domain.model.auth.UserType
 import com.idle.withdrawal.LogWithdrawalStep
@@ -43,8 +45,14 @@ import com.idle.withdrawal.WithdrawalStep
 @Composable
 internal fun ReasonScreen(
     userType: UserType,
+    inconvenientReason: String,
+    anotherPlatformReason: String,
+    lackFeaturesReason: String,
     onReasonChanged: (WithdrawalReason) -> Unit,
     setWithdrawalStep: (WithdrawalStep) -> Unit,
+    onInconvenientReasonChanged: (String) -> Unit,
+    onAnotherPlatformReasonChanged: (String) -> Unit,
+    onLackFeaturesReasonChanged: (String) -> Unit,
     navigateToSetting: () -> Unit,
 ) {
     val scrollState = rememberScrollState()
@@ -79,17 +87,70 @@ internal fun ReasonScreen(
                 if (userType == UserType.WORKER && reason == NO_LONGER_OPERATING_CENTER) return@forEach
                 if (userType == UserType.CENTER && reason == NO_LONGER_WISH_TO_CONTINUE) return@forEach
 
-                WithdrawalReasonItem(
-                    text = reason.displayName,
-                    checked = (reason in withdrawalReason),
-                    onClick = {
-                        onReasonChanged(reason)
-                        withdrawalReason = withdrawalReason.toMutableSet().apply {
-                            if (reason in this) remove(reason)
-                            else add(reason)
-                        }.toSet()
-                    },
-                )
+                when (reason) {
+                    WithdrawalReason.INCONVENIENT_PLATFORM_USE -> WithdrawalReasonItem(
+                        text = reason.displayName,
+                        checked = (reason in withdrawalReason),
+                        description = "어떤 부분에서 불편함을 느끼셨나요?",
+                        hint = "어떤 부분에서 불편함을 느끼셨나요? 보내주신 의견은 플랫폼 개선에 큰 도움이 됩니다!",
+                        useReasonTextField = true,
+                        reason = inconvenientReason,
+                        onReasonChanged = onInconvenientReasonChanged,
+                        onClick = {
+                            onReasonChanged(reason)
+                            withdrawalReason = withdrawalReason.toMutableSet().apply {
+                                if (reason in this) remove(reason)
+                                else add(reason)
+                            }.toSet()
+                        },
+                    )
+
+                    WithdrawalReason.USING_ANOTHER_PLATFORM -> WithdrawalReasonItem(
+                        text = reason.displayName,
+                        checked = (reason in withdrawalReason),
+                        description = "사용하시는 플랫폼의 이름은 무엇인가요?",
+                        hint = "어떤 플랫폼을 사용하시나요?",
+                        reason = anotherPlatformReason,
+                        useReasonTextField = true,
+                        onReasonChanged = onAnotherPlatformReasonChanged,
+                        onClick = {
+                            onReasonChanged(reason)
+                            withdrawalReason = withdrawalReason.toMutableSet().apply {
+                                if (reason in this) remove(reason)
+                                else add(reason)
+                            }.toSet()
+                        },
+                    )
+
+                    WithdrawalReason.LACK_OF_DESIRED_FEATURES -> WithdrawalReasonItem(
+                        text = reason.displayName,
+                        checked = (reason in withdrawalReason),
+                        description = "어떤 기능이 필요하신가요?",
+                        hint = "어떤 기능이 필요하신가요? 보내주신 의견은 개발 담당자에게 즉시 전달됩니다.",
+                        reason = lackFeaturesReason,
+                        useReasonTextField = true,
+                        onReasonChanged = onLackFeaturesReasonChanged,
+                        onClick = {
+                            onReasonChanged(reason)
+                            withdrawalReason = withdrawalReason.toMutableSet().apply {
+                                if (reason in this) remove(reason)
+                                else add(reason)
+                            }.toSet()
+                        },
+                    )
+
+                    else -> WithdrawalReasonItem(
+                        text = reason.displayName,
+                        checked = (reason in withdrawalReason),
+                        onClick = {
+                            onReasonChanged(reason)
+                            withdrawalReason = withdrawalReason.toMutableSet().apply {
+                                if (reason in this) remove(reason)
+                                else add(reason)
+                            }.toSet()
+                        },
+                    )
+                }
             }
         }
 
@@ -101,13 +162,15 @@ internal fun ReasonScreen(
             color = CareTheme.colors.red,
             textAlign = TextAlign.Center,
             modifier = Modifier
-                .padding(bottom = 12.dp)
+                .padding(top = 48.dp, bottom = 12.dp)
                 .fillMaxWidth(),
         )
 
         Row(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 28.dp),
         ) {
             CareButtonMedium(
                 text = stringResource(id = R.string.cancel),
@@ -122,7 +185,10 @@ internal fun ReasonScreen(
                 text = stringResource(id = R.string.withdrawal),
                 textColor = CareTheme.colors.white000,
                 containerColor = CareTheme.colors.red,
-                enable = withdrawalReason.isNotEmpty(),
+                enable = withdrawalReason.isNotEmpty() &&
+                        (WithdrawalReason.LACK_OF_DESIRED_FEATURES in withdrawalReason && lackFeaturesReason.isNotBlank()) &&
+                        (WithdrawalReason.INCONVENIENT_PLATFORM_USE in withdrawalReason && inconvenientReason.isNotBlank()) &&
+                        (WithdrawalReason.USING_ANOTHER_PLATFORM in withdrawalReason && anotherPlatformReason.isNotBlank()),
                 onClick = { setWithdrawalStep(WithdrawalStep.findStep(WithdrawalStep.REASON.step + 1)) },
                 modifier = Modifier.weight(1f),
             )
@@ -137,6 +203,11 @@ private fun WithdrawalReasonItem(
     text: String,
     checked: Boolean,
     onClick: () -> Unit,
+    useReasonTextField: Boolean = false,
+    description: String = "",
+    reason: String = "",
+    hint: String = "",
+    onReasonChanged: (String) -> Unit = {},
 ) {
     val backgroundColor by animateColorAsState(
         targetValue = if (!checked) CareTheme.colors.white000
@@ -147,39 +218,74 @@ private fun WithdrawalReasonItem(
         else CareTheme.colors.orange500
     )
 
-    Row(
-        verticalAlignment = Alignment.Top,
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
-            modifier = Modifier
-                .size(20.dp)
-                .background(
-                    color = backgroundColor,
-                    shape = RoundedCornerShape(2.dp),
-                )
-                .border(
-                    width = 1.dp,
-                    color = borderColor,
-                    shape = RoundedCornerShape(2.dp),
-                )
-                .clickable { onClick() }
+    Column(horizontalAlignment = Alignment.Start) {
+        Row(
+            verticalAlignment = Alignment.Top,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier.fillMaxWidth(),
         ) {
-            AnimatedVisibility(visible = checked) {
-                Image(
-                    painter = painterResource(id = R.drawable.ic_check),
-                    contentDescription = null
-                )
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+                modifier = Modifier
+                    .size(20.dp)
+                    .background(
+                        color = backgroundColor,
+                        shape = RoundedCornerShape(2.dp),
+                    )
+                    .border(
+                        width = 1.dp,
+                        color = borderColor,
+                        shape = RoundedCornerShape(2.dp),
+                    )
+                    .clickable { onClick() }
+            ) {
+                AnimatedVisibility(visible = checked) {
+                    Image(
+                        painter = painterResource(id = R.drawable.ic_check),
+                        contentDescription = null
+                    )
+                }
             }
+
+            Text(
+                text = text,
+                style = CareTheme.typography.body2,
+                color = CareTheme.colors.gray500,
+            )
         }
 
-        Text(
-            text = text,
-            style = CareTheme.typography.body2,
-            color = CareTheme.colors.gray500,
+        if (useReasonTextField && checked) {
+            Text(
+                text = description,
+                style = CareTheme.typography.subtitle4,
+                color = CareTheme.colors.gray500,
+                modifier = Modifier.padding(top = 12.dp, bottom = 6.dp),
+            )
+
+            CareTextFieldLong(
+                value = reason,
+                onValueChanged = onReasonChanged,
+                hint = hint,
+                modifier = Modifier.padding(bottom = 8.dp),
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewWithdrawalReasonItem() {
+    CareTheme {
+        WithdrawalReasonItem(
+            text = "Sample Withdrawal Reason",
+            checked = true,
+            onClick = { /* No action for preview */ },
+            useReasonTextField = true,
+            description = "Please describe your reason:",
+            reason = "",
+            hint = "Enter your reason",
+            onReasonChanged = {}
         )
     }
 }

--- a/feature/withdrawal/src/main/java/com/idle/withdrawal/step/ReasonScreen.kt
+++ b/feature/withdrawal/src/main/java/com/idle/withdrawal/step/ReasonScreen.kt
@@ -185,11 +185,20 @@ internal fun ReasonScreen(
                 text = stringResource(id = R.string.withdrawal),
                 textColor = CareTheme.colors.white000,
                 containerColor = CareTheme.colors.red,
-                enable = withdrawalReason.isNotEmpty() &&
-                        (WithdrawalReason.LACK_OF_DESIRED_FEATURES in withdrawalReason && lackFeaturesReason.isNotBlank()) &&
-                        (WithdrawalReason.INCONVENIENT_PLATFORM_USE in withdrawalReason && inconvenientReason.isNotBlank()) &&
-                        (WithdrawalReason.USING_ANOTHER_PLATFORM in withdrawalReason && anotherPlatformReason.isNotBlank()),
-                onClick = { setWithdrawalStep(WithdrawalStep.findStep(WithdrawalStep.REASON.step + 1)) },
+                enable = withdrawalReason.isNotEmpty() && withdrawalReason.all {
+                    when (it) {
+                        WithdrawalReason.LACK_OF_DESIRED_FEATURES -> lackFeaturesReason.isNotBlank()
+                        WithdrawalReason.INCONVENIENT_PLATFORM_USE -> inconvenientReason.isNotBlank()
+                        WithdrawalReason.USING_ANOTHER_PLATFORM -> anotherPlatformReason.isNotBlank()
+                        else -> true
+                    }
+                },
+                onClick = {
+                    when (userType) {
+                        UserType.WORKER -> setWithdrawalStep(WithdrawalStep.PHONE_NUMBER)
+                        UserType.CENTER -> setWithdrawalStep(WithdrawalStep.PASSWORD)
+                    }
+                },
                 modifier = Modifier.weight(1f),
             )
         }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -1,7 +1,6 @@
-import java.util.Properties
-
 plugins {
     id("care.android.feature-binding")
+    alias(libs.plugins.androidx.navigation.safeargs)
 }
 
 android {

--- a/presentation/src/main/java/com/idle/presentation/navigation/BaseNavigationImpl.kt
+++ b/presentation/src/main/java/com/idle/presentation/navigation/BaseNavigationImpl.kt
@@ -2,14 +2,15 @@ package com.idle.presentation.navigation
 
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
+import com.idle.auth.AuthFragmentDirections
 import com.idle.binding.base.navigation.BaseNavigation
-import com.idle.presentation.R
+import com.idle.presentation.NavMainDirections.Companion.actionGlobalNavAuth
 import javax.inject.Inject
 
 class BaseNavigationImpl @Inject constructor(
     private val fragment: Fragment
 ) : BaseNavigation {
-    override fun navigateToAuth() {
-        fragment.findNavController().navigate(R.id.action_global_nav_auth)
+    override fun navigateToAuth(snackBarMsg: String) {
+        fragment.findNavController().navigate(AuthFragmentDirections.actionGlobalNavAuth(snackBarMsg))
     }
 }

--- a/presentation/src/main/res/navigation/nav_main.xml
+++ b/presentation/src/main/res/navigation/nav_main.xml
@@ -9,14 +9,12 @@
     <include app:graph="@navigation/nav_signin" />
     <include app:graph="@navigation/nav_signup" />
     <include app:graph="@navigation/nav_withdrawal" />
-
     <include app:graph="@navigation/nav_center_home" />
     <include app:graph="@navigation/nav_applicant_inquiry" />
     <include app:graph="@navigation/nav_center_profile" />
     <include app:graph="@navigation/nav_center_setting" />
     <include app:graph="@navigation/nav_center_job_posting_post" />
     <include app:graph="@navigation/nav_register_center_info" />
-
     <include app:graph="@navigation/nav_worker_home" />
     <include app:graph="@navigation/nav_worker_profile" />
     <include app:graph="@navigation/nav_worker_setting" />
@@ -26,8 +24,8 @@
     <action
         android:id="@+id/action_global_nav_auth"
         app:destination="@id/nav_auth"
-        app:popUpTo="@id/nav_main"
         app:enterAnim="@anim/anim_pop_slide_in_horizontally"
         app:exitAnim="@anim/anim_pop_slide_out_horizontally"
+        app:popUpTo="@id/nav_main"
         app:popUpToInclusive="true" />
 </navigation>


### PR DESCRIPTION
## 1. 🔥 변경된 내용

- **회원 탈퇴 시 특정 항목에 이유를 받을 수 있도록 변경**
- **회원 탈퇴 마지막 스텝에 센터, 요양보호사 화면 분기**
- **회원 탈퇴 마지막에 다이얼로그가 뜨도록 변경**

## 2. 📸 스크린샷(선택)

https://github.com/user-attachments/assets/554bec4a-0fe9-49f6-baa5-a15b790f9e4c

## 3. 새로 알게된 점

### nav_main 그래프에서 auth 모듈로 이동하는 전역 액션에서 safeArgs를 보내는 방법

https://stackoverflow.com/questions/62591099/using-global-actions-with-multiple-graphs-in-jetpack-navigation