### PR TITLE
[IDLE-355] 네트워크 상태를 옵저빙하여 네트워크 연결이 끊어졌을 경우 다이얼로그가 뜨도록 변경

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
         android:name=".CareApplication"

--- a/core/domain/src/main/kotlin/com/idle/domain/model/error/HttpResponseException.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/model/error/HttpResponseException.kt
@@ -166,6 +166,8 @@ enum class ApiErrorCode(val serverCode: String, val description: String, val dis
     ),
 
     UnknownError("UNKNOWN", "알 수 없는 오류가 발생했습니다.", "알 수 없는 오류가 발생하였습니다."),
+
+    NetworkError("NETWORK", "네트워크가 연결되어있지 않습니다.", "인터넷이 연결되어 있지 않아요."),
     ;
 
     companion object {

--- a/core/network/src/main/java/com/idle/network/source/auth/AuthDataSource.kt
+++ b/core/network/src/main/java/com/idle/network/source/auth/AuthDataSource.kt
@@ -12,49 +12,49 @@ import com.idle.network.model.auth.SignUpWorkerRequest
 import com.idle.network.model.auth.WithdrawalCenterRequest
 import com.idle.network.model.auth.WithdrawalWorkerRequest
 import com.idle.network.model.token.TokenResponse
-import com.idle.network.util.onResponse
+import com.idle.network.util.safeApiCall
 import javax.inject.Inject
 
 class AuthDataSource @Inject constructor(
     private val authApi: AuthApi
 ) {
     suspend fun sendPhoneNumber(sendPhoneRequest: SendPhoneRequest): Result<Unit> =
-        authApi.sendPhoneNumber(sendPhoneRequest).onResponse()
+        safeApiCall { authApi.sendPhoneNumber(sendPhoneRequest) }
 
     suspend fun confirmAuthCode(confirmAuthCodeRequest: ConfirmAuthCodeRequest): Result<Unit> =
-        authApi.confirmAuthCode(confirmAuthCodeRequest).onResponse()
+        safeApiCall { authApi.confirmAuthCode(confirmAuthCodeRequest) }
 
     suspend fun signUpCenter(signUpCenterRequest: SignUpCenterRequest): Result<Unit> =
-        authApi.signUpCenter(signUpCenterRequest).onResponse()
+        safeApiCall { authApi.signUpCenter(signUpCenterRequest) }
 
     suspend fun signInCenter(signInCenterRequest: SignInCenterRequest): Result<TokenResponse> =
-        authApi.signInCenter(signInCenterRequest).onResponse()
+        safeApiCall { authApi.signInCenter(signInCenterRequest) }
 
     suspend fun signUpWorker(signUpWorkerRequest: SignUpWorkerRequest): Result<TokenResponse> =
-        authApi.signUpWorker(signUpWorkerRequest).onResponse()
+        safeApiCall { authApi.signUpWorker(signUpWorkerRequest) }
 
     suspend fun signInWorker(signInWorkerRequest: SignInWorkerRequest): Result<TokenResponse> =
-        authApi.signInWorker(signInWorkerRequest).onResponse()
+        safeApiCall { authApi.signInWorker(signInWorkerRequest) }
 
-    suspend fun logoutWorker(): Result<Unit> = authApi.logoutWorker().onResponse()
+    suspend fun logoutWorker(): Result<Unit> = safeApiCall { authApi.logoutWorker() }
 
-    suspend fun logoutCenter(): Result<Unit> = authApi.logoutCenter().onResponse()
+    suspend fun logoutCenter(): Result<Unit> = safeApiCall { authApi.logoutCenter() }
 
     suspend fun withdrawalCenter(withdrawalCenterRequest: WithdrawalCenterRequest): Result<Unit> =
-        authApi.withdrawalCenter(withdrawalCenterRequest).onResponse()
+        safeApiCall { authApi.withdrawalCenter(withdrawalCenterRequest) }
 
     suspend fun withdrawalWorker(withdrawalWorkerRequest: WithdrawalWorkerRequest): Result<Unit> =
-        authApi.withdrawalWorker(withdrawalWorkerRequest).onResponse()
+        safeApiCall { authApi.withdrawalWorker(withdrawalWorkerRequest) }
 
     suspend fun validateIdentifier(identifier: String): Result<Unit> =
-        authApi.validateIdentifier(identifier).onResponse()
+        safeApiCall { authApi.validateIdentifier(identifier) }
 
     suspend fun validateBusinessRegistrationNumber(
         businessRegistrationNumber: String
     ): Result<BusinessRegistrationResponse> =
-        authApi.validateBusinessRegistrationNumber(businessRegistrationNumber).onResponse()
+        safeApiCall { authApi.validateBusinessRegistrationNumber(businessRegistrationNumber) }
 
     suspend fun generateNewPassword(
         generateNewPasswordRequest: GenerateNewPasswordRequest
-    ): Result<Unit> = authApi.generateNewPassword(generateNewPasswordRequest).onResponse()
+    ): Result<Unit> = safeApiCall { authApi.generateNewPassword(generateNewPasswordRequest) }
 }

--- a/core/network/src/main/java/com/idle/network/source/jobposting/JobPostingDataSource.kt
+++ b/core/network/src/main/java/com/idle/network/source/jobposting/JobPostingDataSource.kt
@@ -15,83 +15,89 @@ import com.idle.network.model.jobposting.GetJobPostingsResponse
 import com.idle.network.model.jobposting.GetWorkerJobPostingDetailResponse
 import com.idle.network.model.jobposting.JobPostingRequest
 import com.idle.network.util.onResponse
+import com.idle.network.util.safeApiCall
 import javax.inject.Inject
 
 class JobPostingDataSource @Inject constructor(
     private val jobPostingApi: JobPostingApi
 ) {
     suspend fun postJobPosting(jobPostingRequest: JobPostingRequest): Result<Unit> =
-        jobPostingApi.postJobPosting(jobPostingRequest).onResponse()
+        safeApiCall { jobPostingApi.postJobPosting(jobPostingRequest) }
 
     suspend fun updateJobPosting(
         jobPostingId: String,
         jobPostingRequest: JobPostingRequest
-    ): Result<Unit> = jobPostingApi.updateJobPosting(
-        jobPostingId = jobPostingId,
-        jobPostingRequest = jobPostingRequest
-    ).onResponse()
+    ): Result<Unit> = safeApiCall {
+        jobPostingApi.updateJobPosting(
+            jobPostingId = jobPostingId,
+            jobPostingRequest = jobPostingRequest
+        )
+    }
 
     suspend fun getCenterJobPostingDetail(jobPostingId: String):
-            Result<GetCenterJobPostingDetailResponse> =
-        jobPostingApi.getJobPostingDetailCenter(jobPostingId).onResponse()
+            Result<GetCenterJobPostingDetailResponse> = safeApiCall {
+        jobPostingApi.getJobPostingDetailCenter(jobPostingId)
+    }
 
     suspend fun getWorkerJobPostingDetail(jobPostingId: String):
-            Result<GetWorkerJobPostingDetailResponse> =
-        jobPostingApi.getJobPostingDetailWorker(jobPostingId).onResponse()
+            Result<GetWorkerJobPostingDetailResponse> = safeApiCall {
+        jobPostingApi.getJobPostingDetailWorker(jobPostingId)
+    }
 
     suspend fun getJobPostings(next: String?, limit: Int): Result<GetJobPostingsResponse> =
-        jobPostingApi.getJobPostings(next = next, limit = limit).onResponse()
+        safeApiCall { jobPostingApi.getJobPostings(next = next, limit = limit) }
 
     suspend fun getJobPostingsApplied(next: String?, limit: Int): Result<GetJobPostingsResponse> =
-        jobPostingApi.getJobPostingsApplied(next = next, limit = limit).onResponse()
+        safeApiCall { jobPostingApi.getJobPostingsApplied(next = next, limit = limit) }
 
     suspend fun getMyFavoriteJobPostings(): Result<GetFavoriteJobPostingsResponse> =
-        jobPostingApi.getMyFavoriteJobPostings().onResponse()
+        safeApiCall { jobPostingApi.getMyFavoriteJobPostings() }
 
     suspend fun getMyFavoriteCrawlingJobPostings(): Result<GetFavoriteCrawlingJobPostingsResponse> =
-        jobPostingApi.getMyFavoriteCrawlingJobPostings().onResponse()
+        safeApiCall { jobPostingApi.getMyFavoriteCrawlingJobPostings() }
 
     suspend fun getJobPostingsInProgress(): Result<GetJobPostingsCenterResponse> =
-        jobPostingApi.getJobPostingsInProgress().onResponse()
+        safeApiCall { jobPostingApi.getJobPostingsInProgress() }
 
     suspend fun getJobPostingsCompleted(): Result<GetJobPostingsCenterResponse> =
-        jobPostingApi.getJobPostingsCompleted().onResponse()
+        safeApiCall { jobPostingApi.getJobPostingsCompleted() }
 
     suspend fun getApplicantCount(jobPostingId: String): Result<GetApplicantCountResponse> =
-        jobPostingApi.getApplicantCount(jobPostingId).onResponse()
+        safeApiCall { jobPostingApi.getApplicantCount(jobPostingId) }
 
     suspend fun applyJobPosting(applyJobPostingRequest: ApplyJobPostingRequest): Result<Unit> =
-        jobPostingApi.applyJobPosting(applyJobPostingRequest).onResponse()
+        safeApiCall { jobPostingApi.applyJobPosting(applyJobPostingRequest) }
 
     suspend fun addFavoriteJobPosting(
         jobPostingId: String,
         favoriteJobPostingRequest: FavoriteJobPostingRequest,
-    ): Result<Unit> =
+    ): Result<Unit> = safeApiCall {
         jobPostingApi.addFavoriteJobPosting(
             jobPostingId = jobPostingId,
             favoriteJobPostingRequest = favoriteJobPostingRequest
-        ).onResponse()
+        )
+    }
 
     suspend fun removeFavoriteJobPosting(jobPostingId: String): Result<Unit> =
-        jobPostingApi.removeFavoriteJobPosting(jobPostingId = jobPostingId).onResponse()
+        safeApiCall { jobPostingApi.removeFavoriteJobPosting(jobPostingId) }
 
     suspend fun getApplicants(jobPostingId: String): Result<GetApplicantsResponse> =
-        jobPostingApi.getApplicants(jobPostingId).onResponse()
+        safeApiCall { jobPostingApi.getApplicants(jobPostingId) }
 
     suspend fun endJobPosting(jobPostingId: String): Result<Unit> =
-        jobPostingApi.endJobPosting(jobPostingId).onResponse()
+        safeApiCall { jobPostingApi.endJobPosting(jobPostingId) }
 
     suspend fun deleteJobPosting(jobPostingId: String): Result<Unit> =
-        jobPostingApi.deleteJobPosting(jobPostingId).onResponse()
+        safeApiCall { jobPostingApi.deleteJobPosting(jobPostingId) }
 
     suspend fun getCrawlingJobPostings(
         next: String?,
         limit: Int
     ): Result<GetCrawlingJobPostingsResponse> =
-        jobPostingApi.getCrawlingJobPostings(next = next, limit = limit).onResponse()
+        safeApiCall { jobPostingApi.getCrawlingJobPostings(next = next, limit = limit) }
 
     suspend fun getCrawlingJobPostingsDetail(
         jobPostingId: String
     ): Result<GetCrawlingJobPostingDetailResponse> =
-        jobPostingApi.getCrawlingJobPostingsDetail(jobPostingId).onResponse()
+        safeApiCall { jobPostingApi.getCrawlingJobPostingsDetail(jobPostingId) }
 }

--- a/core/network/src/main/java/com/idle/network/source/profile/ProfileDataSource.kt
+++ b/core/network/src/main/java/com/idle/network/source/profile/ProfileDataSource.kt
@@ -10,7 +10,7 @@ import com.idle.network.model.profile.RegisterCenterProfileRequest
 import com.idle.network.model.profile.UpdateCenterProfileRequest
 import com.idle.network.model.profile.UpdateWorkerProfileRequest
 import com.idle.network.model.profile.UploadProfileImageUrlResponse
-import com.idle.network.util.onResponse
+import com.idle.network.util.safeApiCall
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.InputStream
@@ -20,21 +20,20 @@ class ProfileDataSource @Inject constructor(
     private val userApi: UserApi,
 ) {
     suspend fun getMyCenterProfile(): Result<GetCenterProfileResponse> =
-        userApi.getMyCenterProfile().onResponse()
+        safeApiCall { userApi.getMyCenterProfile() }
 
     suspend fun updateMyCenterProfile(updateCenterProfileRequest: UpdateCenterProfileRequest): Result<Unit> =
-        userApi.updateMyCenterProfile(updateCenterProfileRequest).onResponse()
+        safeApiCall { userApi.updateMyCenterProfile(updateCenterProfileRequest) }
 
     suspend fun getCenterProfile(centerId: String): Result<GetCenterProfileResponse> =
-        userApi.getCenterProfile(centerId).onResponse()
+        safeApiCall { userApi.getCenterProfile(centerId) }
 
     suspend fun getProfileImageUploadUrl(
         userType: String,
         imageFileExtension: String
-    ): Result<UploadProfileImageUrlResponse> = userApi.getImageUploadUrl(
-        userType = userType,
-        imageFileExtension = imageFileExtension,
-    ).onResponse()
+    ): Result<UploadProfileImageUrlResponse> = safeApiCall {
+        userApi.getImageUploadUrl(userType, imageFileExtension)
+    }
 
     suspend fun uploadProfileImage(
         uploadUrl: String,
@@ -44,37 +43,36 @@ class ProfileDataSource @Inject constructor(
         val requestImage = imageInputStream.readBytes()
             .toRequestBody(imageFileExtension.toMediaTypeOrNull())
 
-        return userApi.uploadProfileImage(
-            uploadUrl = uploadUrl,
-            requestImage = requestImage,
-        ).onResponse()
+        return safeApiCall {
+            userApi.uploadProfileImage(uploadUrl = uploadUrl, requestImage = requestImage)
+        }
     }
 
     suspend fun callbackImageUpload(
         userType: String,
         callbackImageUploadRequest: CallbackImageUploadRequest,
-    ): Result<Unit> = userApi.callbackImageUpload(
-        userType = userType,
-        callbackImageUploadRequest = callbackImageUploadRequest,
-    ).onResponse()
+    ): Result<Unit> = safeApiCall {
+        userApi.callbackImageUpload(
+            userType = userType,
+            callbackImageUploadRequest = callbackImageUploadRequest
+        )
+    }
 
     suspend fun getMyWorkerProfile(): Result<GetWorkerProfileResponse> =
-        userApi.getMyWorkerProfile().onResponse()
+        safeApiCall { userApi.getMyWorkerProfile() }
 
     suspend fun getWorkerProfile(workerId: String): Result<GetWorkerProfileResponse> =
-        userApi.getWorkerProfile(workerId).onResponse()
+        safeApiCall { userApi.getWorkerProfile(workerId) }
 
-    suspend fun updateWorkerProfile(
-        updateWorkerProfileRequest: UpdateWorkerProfileRequest
-    ): Result<Unit> = userApi.updateWorkerProfile(updateWorkerProfileRequest)
-        .onResponse()
+    suspend fun updateWorkerProfile(updateWorkerProfileRequest: UpdateWorkerProfileRequest): Result<Unit> =
+        safeApiCall { userApi.updateWorkerProfile(updateWorkerProfileRequest) }
 
-    suspend fun registerCenterProfile(
-        registerCenterProfileRequest: RegisterCenterProfileRequest
-    ): Result<Unit> = userApi.registerCenterProfile(registerCenterProfileRequest).onResponse()
+    suspend fun registerCenterProfile(registerCenterProfileRequest: RegisterCenterProfileRequest): Result<Unit> =
+        safeApiCall { userApi.registerCenterProfile(registerCenterProfileRequest) }
 
-    suspend fun getWorkerId(): Result<GetWorkerIdResponse> = userApi.getWorkerId().onResponse()
+    suspend fun getWorkerId(): Result<GetWorkerIdResponse> =
+        safeApiCall { userApi.getWorkerId() }
 
     suspend fun getCenterStatus(): Result<GetCenterStatusResponse> =
-        userApi.getCenterStatus().onResponse()
+        safeApiCall { userApi.getCenterStatus() }
 }

--- a/core/network/src/main/java/com/idle/network/source/remoteconfig/ConfigDataSource.kt
+++ b/core/network/src/main/java/com/idle/network/source/remoteconfig/ConfigDataSource.kt
@@ -1,6 +1,5 @@
 package com.idle.network.source.remoteconfig
 
-import android.util.Log
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigValue
 import com.google.firebase.remoteconfig.get

--- a/core/network/src/main/java/com/idle/network/util/safeApiCall.kt
+++ b/core/network/src/main/java/com/idle/network/util/safeApiCall.kt
@@ -1,0 +1,12 @@
+package com.idle.network.util
+
+import retrofit2.Response
+
+internal suspend inline fun <T> safeApiCall(apiCall: () -> Response<T>): Result<T> {
+    return try {
+        val response = apiCall()
+        response.onResponse()
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+}

--- a/core/network/src/main/java/com/idle/network/util/safeApiCall.kt
+++ b/core/network/src/main/java/com/idle/network/util/safeApiCall.kt
@@ -1,5 +1,8 @@
 package com.idle.network.util
 
+import com.idle.domain.model.error.ApiErrorCode
+import com.idle.domain.model.error.HttpResponseException
+import com.idle.domain.model.error.HttpResponseStatus
 import retrofit2.Response
 
 internal inline fun <T> safeApiCall(apiCall: () -> Response<T>): Result<T> {
@@ -7,6 +10,11 @@ internal inline fun <T> safeApiCall(apiCall: () -> Response<T>): Result<T> {
         val response = apiCall()
         response.onResponse()
     } catch (e: Exception) {
-        Result.failure(e)
+        Result.failure(
+            HttpResponseException(
+                status = HttpResponseStatus.create(-1),
+                apiErrorCode = ApiErrorCode.NetworkError
+            )
+        )
     }
 }

--- a/core/network/src/main/java/com/idle/network/util/safeApiCall.kt
+++ b/core/network/src/main/java/com/idle/network/util/safeApiCall.kt
@@ -2,7 +2,7 @@ package com.idle.network.util
 
 import retrofit2.Response
 
-internal suspend inline fun <T> safeApiCall(apiCall: () -> Response<T>): Result<T> {
+internal inline fun <T> safeApiCall(apiCall: () -> Response<T>): Result<T> {
     return try {
         val response = apiCall()
         response.onResponse()

--- a/presentation/src/main/java/com/idle/presentation/MainActivity.kt
+++ b/presentation/src/main/java/com/idle/presentation/MainActivity.kt
@@ -114,7 +114,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun showNetworkDialog() {
-        if (networkDialog == null || networkDialog?.isShowing == false) {
+        networkDialog?.show() ?: run {
             networkDialog = AlertDialog.Builder(this@MainActivity).apply {
                 setTitle("인터넷이 연결되어 있지 않아요")
                 setMessage("Wi-Fi 또는 데이터 연결을 확인한 후 다시 시도해 주세요.")

--- a/presentation/src/main/java/com/idle/presentation/MainActivity.kt
+++ b/presentation/src/main/java/com/idle/presentation/MainActivity.kt
@@ -26,6 +26,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var forceUpdateFragment: ForceUpdateFragment
     private lateinit var binding: ActivityMainBinding
     private lateinit var navController: NavController
+    private var networkDialog: AlertDialog? = null
     private val viewModel: MainViewModel by viewModels()
     private val centerBottomNavDestinationIds: Set<Int> by lazy {
         resources.obtainTypedArray(R.array.centerNavDestinationIds).let { typedArray ->
@@ -57,11 +58,13 @@ class MainActivity : AppCompatActivity() {
         installSplashScreen()
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
         repeatOnStarted {
             networkObserver.networkState.collect { state ->
                 if (state == NetworkState.NOT_CONNECTED) {
                     showNetworkDialog()
                 } else {
+                    dismissNetworkDialog()
                     viewModel.getForceUpdateInfo()
                 }
             }
@@ -111,19 +114,24 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun showNetworkDialog() {
-        AlertDialog.Builder(this@MainActivity).apply {
-            setTitle("인터넷이 연결되어 있지 않아요")
-            setMessage("Wi-Fi 또는 데이터 연결을 확인한 후 다시 시도해 주세요.")
-            setPositiveButton("설정") { _, _ ->
-                startActivity(Intent(ACTION_WIFI_SETTINGS))
-            }
-            setNegativeButton("종료") { _, _ ->
-                finish()
-            }
-            setCancelable(false)
-            create()
-            show()
+        if (networkDialog == null || networkDialog?.isShowing == false) {
+            networkDialog = AlertDialog.Builder(this@MainActivity).apply {
+                setTitle("인터넷이 연결되어 있지 않아요")
+                setMessage("Wi-Fi 또는 데이터 연결을 확인한 후 다시 시도해 주세요.")
+                setPositiveButton("설정") { _, _ ->
+                    startActivity(Intent(ACTION_WIFI_SETTINGS))
+                }
+                setNegativeButton("종료") { _, _ ->
+                    finish()
+                }
+                setCancelable(false)
+            }.show()
         }
+    }
+
+    private fun dismissNetworkDialog() {
+        networkDialog?.dismiss()
+        networkDialog = null
     }
 
     private fun setDestinationListener() {

--- a/presentation/src/main/java/com/idle/presentation/MainViewModel.kt
+++ b/presentation/src/main/java/com/idle/presentation/MainViewModel.kt
@@ -22,15 +22,11 @@ class MainViewModel @Inject constructor(
     private val _forceUpdate = MutableStateFlow<ForceUpdate?>(null)
     val forceUpdate = _forceUpdate.asStateFlow()
 
-    init {
-        getForceUpdateInfo()
-    }
-
     fun setNavigationMenuType(navigationMenuType: NavigationMenuType) {
         _navigationMenuType.value = navigationMenuType
     }
 
-    private fun getForceUpdateInfo() = viewModelScope.launch {
+    fun getForceUpdateInfo() = viewModelScope.launch {
         getForceUpdateInfoUseCase().onSuccess {
             _forceUpdate.value = it
         }.onFailure {

--- a/presentation/src/main/java/com/idle/presentation/di/AppModuel.kt
+++ b/presentation/src/main/java/com/idle/presentation/di/AppModuel.kt
@@ -1,0 +1,21 @@
+package com.idle.presentation.di
+
+import android.content.Context
+import com.idle.presentation.network.NetworkObserver
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppModule {
+
+    @Provides
+    @Singleton
+    fun provideNetworkObserver(
+        @ApplicationContext context: Context,
+    ): NetworkObserver = NetworkObserver(context)
+}

--- a/presentation/src/main/java/com/idle/presentation/network/NetworkObserver.kt
+++ b/presentation/src/main/java/com/idle/presentation/network/NetworkObserver.kt
@@ -1,0 +1,68 @@
+package com.idle.presentation.network
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities.TRANSPORT_CELLULAR
+import android.net.NetworkCapabilities.TRANSPORT_WIFI
+import android.net.NetworkRequest
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+class NetworkObserver @Inject constructor(context: Context) {
+    private val _networkState = MutableStateFlow<NetworkState>(NetworkState.NONE)
+    val networkState = _networkState.asStateFlow()
+
+    private val connectivityManager =
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+    private val networkCallback = object : ConnectivityManager.NetworkCallback() {
+        override fun onAvailable(network: Network) {
+            super.onAvailable(network)
+            _networkState.value = NetworkState.CONNECTED
+        }
+
+        override fun onLost(network: Network) {
+            super.onLost(network)
+            _networkState.value = NetworkState.NOT_CONNECTED
+        }
+    }
+
+    init {
+        checkNetworkState()
+        subscribeNetworkCallback()
+    }
+
+    internal fun checkNetworkState() {
+        val caps = connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
+
+        if (caps == null) {
+            _networkState.value = NetworkState.NOT_CONNECTED
+            return
+        }
+
+        _networkState.value =
+            if (caps.hasTransport(TRANSPORT_WIFI) || caps.hasTransport(TRANSPORT_CELLULAR)) {
+                NetworkState.CONNECTED
+            } else {
+                NetworkState.NOT_CONNECTED
+            }
+    }
+
+    internal fun unsubscribeNetworkCallback() =
+        connectivityManager.unregisterNetworkCallback(networkCallback)
+
+    private fun subscribeNetworkCallback() {
+        val networkRequest = NetworkRequest.Builder()
+            .addTransportType(TRANSPORT_WIFI)
+            .addTransportType(TRANSPORT_CELLULAR)
+            .build()
+
+        connectivityManager.registerNetworkCallback(networkRequest, networkCallback)
+    }
+}
+
+enum class NetworkState {
+    NONE, CONNECTED, NOT_CONNECTED
+}


### PR DESCRIPTION
## 1. 🔥 변경된 내용
- **네트워크 연결이 없는 상태에서 api호출을 할 경우 앱에 크래시가 나는데, 이를 safeApiCall로 해결**
- **네트워크 연결상태를 옵저빙하여 네트워크 연결이 끊어졌을경우 연결을 유도하도록 다이얼로그를 띄움**
- 초기 화면에서 **네트워크 상태 체크 -> 앱 업데이트 버전 체크 -> 앱 진입** 순서로 흘러간다.

[네트워크 연결 레퍼런스](https://github.com/tgyuuAn/BaekyoungE/pull/53)

## 2. 📸 스크린샷(선택)

<img src="https://github.com/user-attachments/assets/cd2c566b-9a44-4e75-a725-0f3cda7957a5" width="300"/>

## 3. 💡 알게된 부분

### 네트워크 연결이 없는 상태에서 api 호출을 할 경우...

```kotlin
internal fun <T> Response<T>.onResponse(): Result<T> {
    if (isSuccessful) {
        body()?.let {
            return Result.success(it)
        } ?: return Result.success(Unit as T)
    } else {
        errorBody()?.let {
            val json = Json { ignoreUnknownKeys = true }
            val errorResponse = json.decodeFromString<ErrorResponse>(it.string())

            return Result.failure(
                HttpResponseException(
                    status = HttpResponseStatus.create(code()),
                    apiErrorCode = ApiErrorCode.create(errorResponse.code),
                    msg = errorResponse.message,
                )
            )
        } ?: return Result.failure(
            HttpResponseException(
                status = HttpResponseStatus.create(-1),
                apiErrorCode = ApiErrorCode.UnknownError
            )
        )
    }
}
```

위 확장함수로 모든 에러를 잡지 못한다.

왜냐하면 위 함수는 네트워크 통신의 결과를 핸들링하는 함수이기 때문.

즉, 네트워크 연결이 되어있지 않은 상태로 통신 과정에서 나는 에러는 잡지못함. -> 크래시가 났다.

<br><br><br>

그래서 아래와 같은 `safeApiCall` 을 정의 및 연결에 실패했을 경우 네트워크 연결에 맞는 에러를 내려준다.

```kotlin
internal inline fun <T> safeApiCall(apiCall: () -> Response<T>): Result<T> {
    return try {
        val response = apiCall()
        response.onResponse()
    } catch (e: Exception) {
        Result.failure(
            HttpResponseException(
                status = HttpResponseStatus.create(-1),
                apiErrorCode = ApiErrorCode.NetworkError
            )
        )
    }
}
```

<br><br><br>

```kotlin
  suspend fun withdrawalWorker(withdrawalWorkerRequest: WithdrawalWorkerRequest): Result<Unit> =
        safeApiCall { authApi.withdrawalWorker(withdrawalWorkerRequest) }

    suspend fun validateIdentifier(identifier: String): Result<Unit> =
        safeApiCall { authApi.validateIdentifier(identifier) }
```

이후 모든 api 통신에 래핑!!!!!!!!