### PR TITLE
[IDLE-000] 지원 완료된 공고 하단 버튼 텍스트 변경 및 터치할 수 없도록 변경

### DIFF
--- a/core/data/src/main/java/com/idle/data/repository/auth/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/idle/data/repository/auth/AuthRepositoryImpl.kt
@@ -118,11 +118,11 @@ class AuthRepositoryImpl @Inject constructor(
             authCode = authCode,
         )
     ).fold(
-        onSuccess = {
+        onSuccess = { tokenResponse ->
             withContext(Dispatchers.IO) {
-                tokenDataSource.clearToken()
-                launch { userInfoDataSource.clearUserRole() }
-                launch { userInfoDataSource.clearUserInfo() }
+                tokenDataSource.setAccessToken(tokenResponse.accessToken)
+                launch { tokenDataSource.setRefreshToken(tokenResponse.refreshToken) }
+                launch { userInfoDataSource.setUserRole(UserType.WORKER.apiValue) }
                 Result.success(Unit)
             }
         },

--- a/core/designresource/src/main/res/values/strings.xml
+++ b/core/designresource/src/main/res/values/strings.xml
@@ -97,6 +97,7 @@
     <string name="pay_conditions">임금 조건</string>
     <string name="admissions_method">전형 방법</string>
     <string name="recruit">지원하기</string>
+    <string name="recruit_complete">지원 완료</string>
     <string name="worknet">워크넷</string>
     <string name="worknet_url">워크넷 링크</string>
     <string name="post_job_posting_note">공고 등록 후에도 공고 내용을 수정할 수 있어요.</string>

--- a/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/worker/screen/WorkerJobPostingDetailScreen.kt
+++ b/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/worker/screen/WorkerJobPostingDetailScreen.kt
@@ -51,6 +51,7 @@ import com.idle.compose.clickable
 import com.idle.designresource.R
 import com.idle.designsystem.compose.component.CareBottomSheetLayout
 import com.idle.designsystem.compose.component.CareButtonLine
+import com.idle.designsystem.compose.component.CareButtonMedium
 import com.idle.designsystem.compose.component.CareCard
 import com.idle.designsystem.compose.component.CareDialog
 import com.idle.designsystem.compose.component.CareMap
@@ -770,15 +771,16 @@ internal fun WorkerJobPostingDetailScreen(
                         modifier = Modifier.weight(1f),
                     )
 
-                    CareButtonLine(
-                        text = stringResource(id = R.string.recruit),
+                    val applyEnable = jobPostingDetail.applyTime == null
+
+                    CareButtonMedium(
+                        text = if (applyEnable) stringResource(id = R.string.recruit)
+                        else stringResource(id = R.string.recruit_complete),
                         onClick = {
-                            applyMethod = ApplyMethod.CALLING
+                            applyMethod = ApplyMethod.APP
                             showDialog = true
                         },
-                        containerColor = CareTheme.colors.orange500,
-                        borderColor = CareTheme.colors.orange500,
-                        textColor = CareTheme.colors.white000,
+                        enable = applyEnable,
                         modifier = Modifier.weight(1f),
                     )
                 }

--- a/presentation/src/main/java/com/idle/presentation/MainActivity.kt
+++ b/presentation/src/main/java/com/idle/presentation/MainActivity.kt
@@ -1,10 +1,12 @@
 package com.idle.presentation
 
+import android.animation.Animator
+import android.animation.ValueAnimator
 import android.content.Intent
 import android.os.Bundle
 import android.provider.Settings.ACTION_WIFI_SETTINGS
 import android.view.View
-import android.view.animation.TranslateAnimation
+import android.view.ViewGroup
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
@@ -206,18 +208,58 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun slideUp(view: View) {
-        val slide = TranslateAnimation(0f, 0f, view.height.toFloat(), 0f)
+        view.measure(
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        )
+        val targetHeight = view.measuredHeight
+        view.layoutParams.height = 0
+
+        val slide = ValueAnimator.ofInt(0, targetHeight)
+        slide.addUpdateListener { valueAnimator ->
+            val animatedValue = valueAnimator.animatedValue as Int
+            val layoutParams = view.layoutParams
+            layoutParams.height = animatedValue
+            view.layoutParams = layoutParams
+        }
         slide.duration = 300
-        slide.fillAfter = true
-        view.startAnimation(slide)
-        view.visibility = View.VISIBLE
+        slide.addListener(object : Animator.AnimatorListener {
+            override fun onAnimationStart(animation: Animator) {
+                view.visibility = View.VISIBLE
+            }
+
+            override fun onAnimationEnd(animation: Animator) {
+                view.isClickable = true
+            }
+
+            override fun onAnimationCancel(animation: Animator) {}
+            override fun onAnimationRepeat(animation: Animator) {}
+        })
+        slide.start()
     }
 
     private fun slideDown(view: View) {
-        val slide = TranslateAnimation(0f, 0f, 0f, view.height.toFloat())
+        val initialHeight = view.measuredHeight
+
+        val slide = ValueAnimator.ofInt(initialHeight, 0)
+        slide.addUpdateListener { valueAnimator ->
+            val animatedValue = valueAnimator.animatedValue as Int
+            val layoutParams = view.layoutParams
+            layoutParams.height = animatedValue
+            view.layoutParams = layoutParams
+        }
         slide.duration = 300
-        slide.fillAfter = true
-        view.startAnimation(slide)
-        view.visibility = View.GONE
+        slide.addListener(object : Animator.AnimatorListener {
+            override fun onAnimationStart(animation: Animator) {}
+
+            override fun onAnimationEnd(animation: Animator) {
+                view.visibility = View.GONE
+                view.isClickable = false
+            }
+
+            override fun onAnimationCancel(animation: Animator) {}
+            override fun onAnimationRepeat(animation: Animator) {}
+        })
+        slide.start()
     }
 }


### PR DESCRIPTION
## 1. 🔥 변경된 내용

- **화면 전환간 바텀 네비게이션 뷰가 자연스럽게 VISIBLE/GONE 되도록 변경**
- **지원 완료된 공고 하단 버튼 클릭할 수 없도록 변경**
- **로그아웃, 회원탈퇴 시 Amplitude userID 리셋**

## 2. 📸 스크린샷(선택)

https://github.com/user-attachments/assets/225cd334-3d29-4bd8-bccf-d30ad0652049

## 3. 💡 알게된 부분

### xml을 사용할 때 애니메이션

**TranslateAnimation**은 화면 상에서의 시각적 변화만 제공하며, 실제로 **뷰의 레이아웃(위치나 크기)**은 변경되지 않습니다. 이 때문에 터치 영역이나 클릭 가능 상태에 영향이 없고, 뷰는 여전히 원래 위치에 있는 것으로 처리됩니다.

반면에, **ValueAnimator**는 실제 뷰의 속성 값을 변경할 수 있기 때문에, layoutParams 같은 뷰의 속성을 직접 조작하면 실제 크기나 위치를 변경할 수 있습니다. 이로 인해, 터치 영역과 레이아웃에도 영향을 미치게 됩니다.

차이점 요약:
TranslateAnimation
- 시각적 애니메이션만을 제공. 뷰의 실제 위치나 크기는 변경되지 않음.
- 터치 영역이나 레이아웃 속성에는 영향을 미치지 않음.
- 애니메이션이 끝난 후에도 뷰는 실제로 같은 자리에 위치하며, 클릭 가능 상태도 그대로 유지될 수 있음.

ValueAnimator:
- 실제 속성 값(예: layoutParams.height, translationX, alpha)을 변경하여 뷰의 크기나 위치를 실제로 변경.
- 애니메이션 중에 뷰의 레이아웃과 터치 영역이 실제로 변경되므로, 클릭 가능 상태나 뷰의 위치가 동적으로 반영됨.

ValueAnimator의 예시:
```kotlin
val valueAnimator = ValueAnimator.ofInt(0, 100) // 0에서 100까지 값을 애니메이션
valueAnimator.addUpdateListener { animation ->
    val animatedValue = animation.animatedValue as Int
    view.layoutParams.height = animatedValue // 실제 뷰의 높이를 변경
    view.requestLayout() // 레이아웃을 다시 계산하여 적용
}
valueAnimator.duration = 300
valueAnimator.start()
```

위 코드는 ValueAnimator를 사용하여 실제로 뷰의 높이를 0에서 100까지 변경하는 예입니다. 이 경우, 뷰의 터치 영역과 실제 크기가 함께 변경되므로 터치 이벤트나 클릭 상태도 적절히 반영됩니다.

요약:

**TranslateAnimation**은 시각적인 변화만 제공하고 실제 위치나 크기를 변경하지 않습니다.
**ValueAnimator**는 실제로 뷰의 속성 값을 변경하여 크기나 위치를 동적으로 조정할 수 있으며, 이로 인해 레이아웃과 터치 영역도 변경됩니다.
