### PR TITLE
[IDLE-367] API호출을 병렬적으로 하였을 때 토큰이 만료되었을경우 Authenticator를 동시에 수행해서 로그인으로 가지던 버그 수정

### DIFF
--- a/core/data/src/main/java/com/idle/data/repository/jobposting/JobPostingRepositoryImpl.kt
+++ b/core/data/src/main/java/com/idle/data/repository/jobposting/JobPostingRepositoryImpl.kt
@@ -204,7 +204,7 @@ class JobPostingRepositoryImpl @Inject constructor(
 
     override suspend fun getCrawlingJobPostings(
         next: String?,
-        limit: Int
+        limit: Int,
     ): Result<Pair<String?, List<CrawlingJobPosting>>> =
         jobPostingDataSource.getCrawlingJobPostings(next, limit).mapCatching { it.toVO() }
 

--- a/core/datastore/src/main/java/com/idle/datastore/datasource/TokenDataSource.kt
+++ b/core/datastore/src/main/java/com/idle/datastore/datasource/TokenDataSource.kt
@@ -6,10 +6,9 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import com.idle.datastore.util.clear
 import com.idle.datastore.util.getValue
 import com.idle.datastore.util.setValue
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -27,7 +26,7 @@ class TokenDataSource @Inject constructor(
         dataStore.setValue(REFRESH_TOKEN, refreshToken)
     }
 
-    suspend fun clearToken() = withContext(Dispatchers.IO) {
+    suspend fun clearToken() = coroutineScope {
         dataStore.clear(ACCESS_TOKEN)
         launch { dataStore.clear(REFRESH_TOKEN) }
     }

--- a/core/network/src/main/java/com/idle/network/authenticator/CareAuthenticator.kt
+++ b/core/network/src/main/java/com/idle/network/authenticator/CareAuthenticator.kt
@@ -54,8 +54,9 @@ class CareAuthenticator @Inject constructor(
         }.getOrNull() ?: return null
 
         runBlocking {
+            val job = launch { tokenManager.setRefreshToken(token.refreshToken) }
             tokenManager.setAccessToken(token.accessToken)
-            launch { tokenManager.setRefreshToken(token.refreshToken) }
+            job.join()
         }
 
         val newRequest = response.request


### PR DESCRIPTION
## 1. 🔥 변경된 내용
- **요양 보호사 홈, 공고관리 화면과 같이 동시에 API를 여러개 병렬적으로 호출하였을 때 토큰이 만료되었을 때 Authenticator를 병렬적으로 호출하던 버그 수정**

## 2. 📸 스크린샷(선택)

아래와 같이 **공고 관리** 화면에 진입 시, **지원한 공고**, **찜한 공고**를 동시에 병렬적으로 API 호출.

<img width="311" alt="image" src="https://github.com/user-attachments/assets/3b7c7f57-519f-4db8-ba35-07b183230d8e">

<br><br><br>

만일, 이 때 액세스 토큰이 만료되었을 경우 **동시에 Authenticator를 호출**하게 되고, 먼저 **refresh에 성공**했음에도 

**갱신하기 이전의 토큰을 이용하여 refresh를 호출**을 하여서 **refreshToken이 만료되었다고 판단**하여 로그인으로 가던 버그가 있었음.

<img width="912" alt="image" src="https://github.com/user-attachments/assets/f1534b25-43aa-43e8-8989-c7e3f300dfb0">

## 3. 💡 알게된 부분
- **Authenticator에 동기화 로직을 둬서 해결**