### PR TITLE
[IDLE-370] 프로필 이미지를 업로드할 때 리사이징 및 webp, jpeg 확장자로 변경하여 이미지 최적화

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
     namespace = "com.idle.care"
 
     defaultConfig {
-        versionCode = 4
-        versionName = "1.0.3"
+        versionCode = 5
+        versionName = "1.0.4"
         targetSdk = 34
 
         val properties = Properties()

--- a/core/data/src/main/java/com/idle/data/repository/profile/ProfileRepositoryImpl.kt
+++ b/core/data/src/main/java/com/idle/data/repository/profile/ProfileRepositoryImpl.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
+import android.os.Build
 import androidx.core.net.toUri
 import com.idle.datastore.datasource.UserInfoDataSource
 import com.idle.domain.model.auth.Gender
@@ -199,7 +200,7 @@ class ProfileRepositoryImpl @Inject constructor(
             reqWidth = reqWidth,
             reqHeight = reqHeight,
         ).use { inputStream ->
-            val imageFormat = getImageFormat(context, imageFileUri.toUri())
+            val imageFormat = MIMEType.WEBP
 
             val profileImageUploadUrlResponse = getProfileImageUploadUrl(
                 userType = userType,
@@ -261,7 +262,13 @@ class ProfileRepositoryImpl @Inject constructor(
                 val resizedBitmap = BitmapFactory.decodeStream(newInputStream, null, options)
 
                 val byteArrayOutputStream = ByteArrayOutputStream()
-                resizedBitmap?.compress(Bitmap.CompressFormat.JPEG, 100, byteArrayOutputStream)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    resizedBitmap?.compress(
+                        Bitmap.CompressFormat.WEBP_LOSSY,
+                        100,
+                        byteArrayOutputStream
+                    )
+                }
                 val byteArray = byteArrayOutputStream.toByteArray()
 
                 return ByteArrayInputStream(byteArray)

--- a/core/data/src/main/java/com/idle/data/repository/profile/ProfileRepositoryImpl.kt
+++ b/core/data/src/main/java/com/idle/data/repository/profile/ProfileRepositoryImpl.kt
@@ -200,7 +200,9 @@ class ProfileRepositoryImpl @Inject constructor(
             reqWidth = reqWidth,
             reqHeight = reqHeight,
         ).use { inputStream ->
-            val imageFormat = MIMEType.WEBP
+            val imageFormat = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                MIMEType.WEBP
+            } else MIMEType.JPG
 
             val profileImageUploadUrlResponse = getProfileImageUploadUrl(
                 userType = userType,
@@ -237,12 +239,6 @@ class ProfileRepositoryImpl @Inject constructor(
         }
     }
 
-    private fun getImageFormat(context: Context, uri: Uri): MIMEType {
-        val contentResolver = context.contentResolver
-        val mimeType = contentResolver.getType(uri)
-        return MIMEType.create(mimeType)
-    }
-
     private fun resizeImage(
         context: Context,
         uri: Uri,
@@ -264,9 +260,11 @@ class ProfileRepositoryImpl @Inject constructor(
                 val byteArrayOutputStream = ByteArrayOutputStream()
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                     resizedBitmap?.compress(
-                        Bitmap.CompressFormat.WEBP_LOSSY,
-                        100,
-                        byteArrayOutputStream
+                        Bitmap.CompressFormat.WEBP_LOSSY, 100, byteArrayOutputStream
+                    )
+                } else {
+                    resizedBitmap?.compress(
+                        Bitmap.CompressFormat.JPEG, 100, byteArrayOutputStream
                     )
                 }
                 val byteArray = byteArrayOutputStream.toByteArray()

--- a/core/data/src/main/java/com/idle/data/repository/profile/ProfileRepositoryImpl.kt
+++ b/core/data/src/main/java/com/idle/data/repository/profile/ProfileRepositoryImpl.kt
@@ -194,12 +194,14 @@ class ProfileRepositoryImpl @Inject constructor(
         reqWidth: Int,
         reqHeight: Int
     ): Result<Unit> = runCatching {
-        resizeImage(
+        val resizeImage = resizeImage(
             context = context,
             uri = imageFileUri.toUri(),
             reqWidth = reqWidth,
             reqHeight = reqHeight,
-        ).use { inputStream ->
+        )
+
+        resizeImage.use { inputStream ->
             val imageFormat = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 MIMEType.WEBP
             } else MIMEType.JPG
@@ -245,7 +247,9 @@ class ProfileRepositoryImpl @Inject constructor(
         reqWidth: Int,
         reqHeight: Int
     ): InputStream {
-        context.contentResolver.openInputStream(uri)?.use { inputStream ->
+        val originImageStream = context.contentResolver.openInputStream(uri)
+
+        originImageStream?.use { inputStream ->
             val options = BitmapFactory.Options().apply {
                 inJustDecodeBounds = true
             }

--- a/core/domain/src/main/kotlin/com/idle/domain/model/jobposting/CrawlingJobPosting.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/model/jobposting/CrawlingJobPosting.kt
@@ -1,7 +1,5 @@
 package com.idle.domain.model.jobposting
 
-import java.time.LocalDate
-
 data class CrawlingJobPosting(
     override val id: String,
     override val distance: Int,
@@ -12,5 +10,4 @@ data class CrawlingJobPosting(
     val workingSchedule: String,
     val payInfo: String,
     val applyDeadline: String,
-    val createdAt: LocalDate,
 ) : JobPosting(id, distance, jobPostingType, isFavorite)

--- a/core/domain/src/main/kotlin/com/idle/domain/repositorry/profile/ProfileRepository.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/repositorry/profile/ProfileRepository.kt
@@ -43,6 +43,8 @@ interface ProfileRepository {
     suspend fun updateProfileImage(
         userType: String,
         imageFileUri: String,
+        reqWidth: Int,
+        reqHeight: Int
     ): Result<Unit>
 
     suspend fun getWorkerId(): Result<String>

--- a/core/domain/src/main/kotlin/com/idle/domain/usecase/profile/UpdateCenterProfileUseCase.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/usecase/profile/UpdateCenterProfileUseCase.kt
@@ -27,6 +27,8 @@ class UpdateCenterProfileUseCase @Inject constructor(
                     profileRepository.updateProfileImage(
                         userType = UserType.CENTER.apiValue,
                         imageFileUri = imageFileUri,
+                        reqWidth = 1005,
+                        reqHeight = 762,
                     ).getOrThrow()
                 }
             }

--- a/core/domain/src/main/kotlin/com/idle/domain/usecase/profile/UpdateCenterProfileUseCase.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/usecase/profile/UpdateCenterProfileUseCase.kt
@@ -27,8 +27,8 @@ class UpdateCenterProfileUseCase @Inject constructor(
                     profileRepository.updateProfileImage(
                         userType = UserType.CENTER.apiValue,
                         imageFileUri = imageFileUri,
-                        reqWidth = 1005,
-                        reqHeight = 762,
+                        reqWidth = 1340,
+                        reqHeight = 1016,
                     ).getOrThrow()
                 }
             }

--- a/core/domain/src/main/kotlin/com/idle/domain/usecase/profile/UpdateWorkerProfileUseCase.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/usecase/profile/UpdateWorkerProfileUseCase.kt
@@ -36,8 +36,8 @@ class UpdateWorkerProfileUseCase @Inject constructor(
                     profileRepository.updateProfileImage(
                         userType = UserType.WORKER.apiValue,
                         imageFileUri = imageFileUri,
-                        reqWidth = 278,
-                        reqHeight = 278,
+                        reqWidth = 384,
+                        reqHeight = 384,
                     ).getOrThrow()
                 }
             }

--- a/core/domain/src/main/kotlin/com/idle/domain/usecase/profile/UpdateWorkerProfileUseCase.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/usecase/profile/UpdateWorkerProfileUseCase.kt
@@ -36,6 +36,8 @@ class UpdateWorkerProfileUseCase @Inject constructor(
                     profileRepository.updateProfileImage(
                         userType = UserType.WORKER.apiValue,
                         imageFileUri = imageFileUri,
+                        reqWidth = 278,
+                        reqHeight = 278,
                     ).getOrThrow()
                 }
             }

--- a/core/network/src/main/java/com/idle/network/model/jobposting/GetCrawlingJobPostingsResponse.kt
+++ b/core/network/src/main/java/com/idle/network/model/jobposting/GetCrawlingJobPostingsResponse.kt
@@ -27,7 +27,6 @@ data class CrawlingJobPostingResponse(
     val payInfo: String,
     val applyDeadline: String,
     val jobPostingType: String,
-    val createdAt: String,
     val isFavorite: Boolean,
 ) {
     fun toVO() = CrawlingJobPosting(
@@ -39,7 +38,6 @@ data class CrawlingJobPostingResponse(
         payInfo = payInfo,
         applyDeadline = applyDeadline,
         jobPostingType = JobPostingType.create(jobPostingType),
-        createdAt = LocalDate.parse(createdAt, DateTimeFormatter.ofPattern("yyyy-MM-dd")),
         isFavorite = isFavorite,
     )
 }

--- a/core/network/src/main/java/com/idle/network/util/safeApiCall.kt
+++ b/core/network/src/main/java/com/idle/network/util/safeApiCall.kt
@@ -1,6 +1,5 @@
 package com.idle.network.util
 
-import android.util.Log
 import com.idle.domain.model.error.ApiErrorCode
 import com.idle.domain.model.error.HttpResponseException
 import com.idle.domain.model.error.HttpResponseStatus
@@ -13,8 +12,6 @@ internal inline fun <T> safeApiCall(apiCall: () -> Response<T>): Result<T> {
         val response = apiCall()
         response.onResponse()
     } catch (e: Exception) {
-        Log.d("test", e.stackTraceToString())
-
         Result.failure(
             HttpResponseException(
                 status = HttpResponseStatus.create(-1),

--- a/core/network/src/main/java/com/idle/network/util/safeApiCall.kt
+++ b/core/network/src/main/java/com/idle/network/util/safeApiCall.kt
@@ -1,5 +1,6 @@
 package com.idle.network.util
 
+import android.util.Log
 import com.idle.domain.model.error.ApiErrorCode
 import com.idle.domain.model.error.HttpResponseException
 import com.idle.domain.model.error.HttpResponseStatus
@@ -12,6 +13,8 @@ internal inline fun <T> safeApiCall(apiCall: () -> Response<T>): Result<T> {
         val response = apiCall()
         response.onResponse()
     } catch (e: Exception) {
+        Log.d("test", e.stackTraceToString())
+
         Result.failure(
             HttpResponseException(
                 status = HttpResponseStatus.create(-1),

--- a/feature/center/profile/src/main/java/com/idle/center/profile/CenterProfileViewModel.kt
+++ b/feature/center/profile/src/main/java/com/idle/center/profile/CenterProfileViewModel.kt
@@ -92,6 +92,9 @@ class CenterProfileViewModel @Inject constructor(
 
     internal fun setEditState(state: Boolean) {
         _isEditState.value = state
+        if(!state){
+            getMyCenterProfile()
+        }
     }
 
     internal fun setProfileImageUrl(uri: Uri?) {

--- a/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpViewModel.kt
@@ -110,7 +110,7 @@ class WorkerSignUpViewModel @Inject constructor(
     internal fun sendPhoneNumber() = viewModelScope.launch {
         sendPhoneNumberUseCase(_workerPhoneNumber.value)
             .onSuccess { startTimer() }
-            .onFailure { baseEvent(CareBaseEvent.ShowSnackBar(it.message.toString())) }
+            .onFailure { handleFailure(it as HttpResponseException) }
     }
 
     private fun startTimer() {

--- a/feature/worker/home/src/main/java/com/idle/worker/home/WorkerHomeFragment.kt
+++ b/feature/worker/home/src/main/java/com/idle/worker/home/WorkerHomeFragment.kt
@@ -484,9 +484,7 @@ private fun WorkerWorkNetCard(
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(4.dp),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 8.dp)
+                modifier = Modifier.fillMaxWidth(),
             ) {
                 CareTag(
                     text = stringResource(id = R.string.worknet),
@@ -543,9 +541,7 @@ private fun WorkerWorkNetCard(
 
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 8.dp),
+                modifier = Modifier.fillMaxWidth(),
             ) {
                 Image(
                     painter = painterResource(R.drawable.ic_money),

--- a/feature/worker/home/src/main/java/com/idle/worker/home/WorkerHomeViewModel.kt
+++ b/feature/worker/home/src/main/java/com/idle/worker/home/WorkerHomeViewModel.kt
@@ -70,6 +70,10 @@ class WorkerHomeViewModel @Inject constructor(
                 callType = JobPostingCallType.CRAWLING
             }
             _jobPostings.value += postings
+
+            if (_jobPostings.value.isEmpty()) {
+                getJobPostings()
+            }
         }.onFailure { handleFailure(it as HttpResponseException) }
     }
 

--- a/feature/worker/job-posting/src/main/java/com/idle/worker/job/posting/WorkerJobPostingFragment.kt
+++ b/feature/worker/job-posting/src/main/java/com/idle/worker/job/posting/WorkerJobPostingFragment.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardColors
@@ -22,6 +23,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -85,6 +87,7 @@ internal class WorkerJobPostingFragment : BaseComposeFragment() {
                 recruitmentPostStatus = recruitmentPostStatus,
                 appliedJobPostings = appliedJobPostings,
                 favoritesJobPostings = favoritesJobPostings,
+                getAppliedJobPostings = ::getAppliedJobPostings,
                 setRecruitmentPostStatus = ::setRecruitmentPostStatus,
                 applyJobPosting = ::applyJobPosting,
                 addFavoriteJobPosting = ::addFavoriteJobPosting,
@@ -102,6 +105,7 @@ internal fun WorkerJobPostingScreen(
     recruitmentPostStatus: RecruitmentPostStatus,
     appliedJobPostings: List<JobPosting>,
     favoritesJobPostings: List<JobPosting>,
+    getAppliedJobPostings: () -> Unit,
     setRecruitmentPostStatus: (RecruitmentPostStatus) -> Unit,
     applyJobPosting: (String) -> Unit,
     addFavoriteJobPosting: (String, JobPostingType) -> Unit,
@@ -110,6 +114,20 @@ internal fun WorkerJobPostingScreen(
 ) {
     var showDialog by remember { mutableStateOf(false) }
     var selectedJobPosting by remember { mutableStateOf<WorkerJobPosting?>(null) }
+    val listState = rememberLazyListState()
+    val lastVisibleIndex by remember {
+        derivedStateOf {
+            listState.firstVisibleItemIndex + listState.layoutInfo.visibleItemsInfo.size - 1
+        }
+    }
+    val isNearEnd =
+        appliedJobPostings.isNotEmpty() && lastVisibleIndex >= (appliedJobPostings.size - 3)
+
+    LaunchedEffect(isNearEnd) {
+        if (isNearEnd) {
+            getAppliedJobPostings()
+        }
+    }
 
     if (showDialog) {
         CareDialog(
@@ -187,6 +205,7 @@ internal fun WorkerJobPostingScreen(
                 when (status) {
                     RecruitmentPostStatus.APPLY -> {
                         LazyColumn(
+                            state = listState,
                             verticalArrangement = Arrangement.spacedBy(8.dp),
                             modifier = Modifier
                                 .padding(start = 20.dp, end = 20.dp, top = 16.dp)

--- a/feature/worker/job-posting/src/main/java/com/idle/worker/job/posting/WorkerJobPostingFragment.kt
+++ b/feature/worker/job-posting/src/main/java/com/idle/worker/job/posting/WorkerJobPostingFragment.kt
@@ -483,9 +483,7 @@ private fun WorkerWorkNetCard(
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(4.dp),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 8.dp)
+                modifier = Modifier.fillMaxWidth(),
             ) {
                 CareTag(
                     text = stringResource(id = R.string.worknet),
@@ -542,9 +540,7 @@ private fun WorkerWorkNetCard(
 
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 8.dp),
+                modifier = Modifier.fillMaxWidth(),
             ) {
                 Image(
                     painter = painterResource(R.drawable.ic_money),

--- a/feature/worker/job-posting/src/main/java/com/idle/worker/job/posting/WorkerJobPostingViewModel.kt
+++ b/feature/worker/job-posting/src/main/java/com/idle/worker/job/posting/WorkerJobPostingViewModel.kt
@@ -69,6 +69,10 @@ class WorkerJobPostingViewModel @Inject constructor(
     }
 
     internal fun getAppliedJobPostings() = viewModelScope.launch {
+        if(appliedJobPostingCallType == JobPostingCallType.END){
+            return@launch
+        }
+
         getJobPostingsAppliedUseCase(next = next.value).onSuccess { (nextId, postings) ->
             next.value = nextId
 

--- a/feature/worker/profile/src/main/java/com/idle/worker/profile/WorkerProfileViewModel.kt
+++ b/feature/worker/profile/src/main/java/com/idle/worker/profile/WorkerProfileViewModel.kt
@@ -102,6 +102,9 @@ class WorkerProfileViewModel @Inject constructor(
 
     internal fun setEditState(state: Boolean) {
         _isEditState.value = state
+        if (!state) {
+            getMyWorkerProfile()
+        }
     }
 
     internal fun setProfileImageUrl(uri: Uri?) {

--- a/feature/worker/profile/src/main/java/com/idle/worker/profile/WorkerProfileViewModel.kt
+++ b/feature/worker/profile/src/main/java/com/idle/worker/profile/WorkerProfileViewModel.kt
@@ -5,6 +5,7 @@ import androidx.core.net.toUri
 import androidx.lifecycle.viewModelScope
 import com.idle.binding.base.BaseViewModel
 import com.idle.binding.base.CareBaseEvent
+import com.idle.domain.model.error.HttpResponseException
 import com.idle.domain.model.profile.JobSearchStatus
 import com.idle.domain.model.profile.WorkerProfile
 import com.idle.domain.usecase.profile.GetLocalMyWorkerProfileUseCase
@@ -58,15 +59,13 @@ class WorkerProfileViewModel @Inject constructor(
             _roadNameAddress.value = it.roadNameAddress
             _lotNumberAddress.value = it.lotNumberAddress
             _jobSearchStatus.value = it.jobSearchStatus
-        }.onFailure { baseEvent(CareBaseEvent.ShowSnackBar(it.message.toString())) }
+        }.onFailure { handleFailure(it as HttpResponseException) }
     }
 
     internal fun getWorkerProfile(workerId: String) = viewModelScope.launch {
         getWorkerProfileUseCase(workerId).onSuccess {
             _workerProfile.value = it
-        }.onFailure {
-            baseEvent(CareBaseEvent.ShowSnackBar(it.message.toString()))
-        }
+        }.onFailure { handleFailure(it as HttpResponseException) }
     }
 
     internal fun updateWorkerProfile() = viewModelScope.launch {
@@ -89,7 +88,7 @@ class WorkerProfileViewModel @Inject constructor(
             baseEvent(CareBaseEvent.ShowSnackBar("정보 수정이 완료되었어요.|SUCCESS"))
             setEditState(false)
         }.onFailure {
-            baseEvent(CareBaseEvent.ShowSnackBar(it.message.toString()))
+            handleFailure(it as HttpResponseException)
         }
     }
 


### PR DESCRIPTION
## 1. 🔥 변경된 내용
- **프로필 이미지를 업로드할 때 이미지 리사이징**
- **이미지 확장자를 30 이상 버전에서는 손실 webp, 미만 버전에서는 jpeg로 포매팅해서 업로드**

## 2. 📸 스크린샷(선택)

1. jpeg 원본
2. jpeg 이미지 리사이징
3. 이미지 리사이징 - webp 무손실
4. 이미지 리사이징 - webp 손실 
![image](https://github.com/user-attachments/assets/6d5d45dc-96fb-4faa-a33f-3d3d5f801f16)


## 3. 💡 알게된 부분

[이미지 최적화 관련 노션에 문서화](https://grove-maraca-55d.notion.site/ebd9150e8aa84d848abd230fbc155bab?pvs=4)