### PR TITLE
[IDLE-377] FCM 연결 및 로그인, 회원가입시 디바이스 토큰 갱신 API 연결

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,4 +55,6 @@ dependencies {
     implementation(projects.core.data)
     implementation(projects.core.domain)
     implementation(projects.presentation)
+
+    implementation(libs.firebase.messaging)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,8 +28,12 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <meta-data
-            android:name="com.naver.maps.map.CLIENT_ID"
-            android:value="${NAVER_CLIENT_ID}" />
+        <service
+            android:name=".notification.NotificationService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
     </application>
 </manifest>

--- a/app/src/main/java/com/idle/care/di/AppModule.kt
+++ b/app/src/main/java/com/idle/care/di/AppModule.kt
@@ -1,0 +1,21 @@
+package com.idle.care.di
+
+import android.content.Context
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+object AppModule {
+
+    @Provides
+    @Singleton
+    fun provideNotificationHandler(
+        @ApplicationContext context: Context
+    ): com.idle.care.notification.NotificationHandler =
+        com.idle.care.notification.NotificationHandler(context)
+}

--- a/app/src/main/java/com/idle/care/notification/NotificationHandler.kt
+++ b/app/src/main/java/com/idle/care/notification/NotificationHandler.kt
@@ -1,0 +1,56 @@
+package com.idle.care.notification
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import com.idle.presentation.MainActivity
+import com.idle.presentation.R
+import javax.inject.Inject
+
+class NotificationHandler @Inject constructor(private val context: Context) {
+    private val notificationManager: NotificationManager =
+        context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+    init {
+        createNotificationChannel()
+    }
+
+    private fun createNotificationChannel() {
+        val notificationChannel =
+            NotificationChannel(CHANNEL_ID, CHANNEL_NAME, NotificationManager.IMPORTANCE_DEFAULT)
+                .apply {
+                    enableVibration(true)
+                    description = "description"
+                }
+
+        notificationManager.createNotificationChannel(notificationChannel)
+    }
+
+    fun deliverNotification(title: String, body: String) {
+        val intent = Intent(context, MainActivity::class.java)
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            NOTIFICATION_ID,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val builder = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(com.idle.care.R.mipmap.ic_launcher)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setContentIntent(pendingIntent)
+            .setAutoCancel(true)
+
+        notificationManager.notify(NOTIFICATION_ID, builder.build())
+    }
+
+    companion object {
+        const val CHANNEL_ID = "caremeet"
+        const val CHANNEL_NAME = "케어밋"
+        const val NOTIFICATION_ID = 0
+    }
+}

--- a/app/src/main/java/com/idle/care/notification/NotificationService.kt
+++ b/app/src/main/java/com/idle/care/notification/NotificationService.kt
@@ -1,0 +1,28 @@
+package com.idle.care.notification
+
+import android.util.Log
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class NotificationService : FirebaseMessagingService() {
+
+    @Inject
+    lateinit var notificationHandler: NotificationHandler
+
+    override fun onNewToken(token: String) {
+        super.onNewToken(token)
+        Log.d("token", token)
+    }
+
+    override fun onMessageReceived(message: RemoteMessage) {
+        super.onMessageReceived(message)
+
+        notificationHandler.deliverNotification(
+            title = message.notification?.title ?: "",
+            body = message.notification?.body ?: "",
+        )
+    }
+}

--- a/app/src/main/java/com/idle/care/notification/NotificationService.kt
+++ b/app/src/main/java/com/idle/care/notification/NotificationService.kt
@@ -3,26 +3,61 @@ package com.idle.care.notification
 import android.util.Log
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import com.idle.domain.model.auth.UserType
+import com.idle.domain.usecase.auth.GetUserRoleUseCase
+import com.idle.domain.usecase.auth.PutDeviceTokenUseCase
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
 class NotificationService : FirebaseMessagingService() {
 
     @Inject
+    lateinit var putDeviceTokenUseCase: PutDeviceTokenUseCase
+
+    @Inject
+    lateinit var getUserRoleUseCase: GetUserRoleUseCase
+
+    @Inject
     lateinit var notificationHandler: NotificationHandler
+
+    private val job = SupervisorJob()
+    private val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        Log.e("test", throwable.stackTraceToString())
+    }
+    private val scope = CoroutineScope(Dispatchers.IO + job + coroutineExceptionHandler)
 
     override fun onNewToken(token: String) {
         super.onNewToken(token)
-        Log.d("token", token)
+
+        scope.launch {
+            val userRole = getUserRoleUseCase()
+
+            when (userRole) {
+                UserType.CENTER.apiValue, UserType.WORKER.apiValue -> putDeviceTokenUseCase(token)
+            }
+        }
     }
 
     override fun onMessageReceived(message: RemoteMessage) {
         super.onMessageReceived(message)
 
+        val title = message.notification?.title ?: message.data["title"] ?: ""
+        val body = message.notification?.body ?: message.data["body"] ?: ""
+
         notificationHandler.deliverNotification(
-            title = message.notification?.title ?: "",
-            body = message.notification?.body ?: "",
+            title = title,
+            body = body,
         )
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        job.cancel()
     }
 }

--- a/core/data/src/main/java/com/idle/data/repository/auth/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/idle/data/repository/auth/AuthRepositoryImpl.kt
@@ -63,9 +63,9 @@ class AuthRepositoryImpl @Inject constructor(
         ).fold(
             onSuccess = { tokenResponse ->
                 withContext(Dispatchers.IO) {
-                    tokenDataSource.setAccessToken(tokenResponse.accessToken)
                     launch { tokenDataSource.setRefreshToken(tokenResponse.refreshToken) }
                     launch { userInfoDataSource.setUserRole(UserType.CENTER.apiValue) }
+                    tokenDataSource.setAccessToken(tokenResponse.accessToken)
                     Result.success(Unit)
                 }
             },
@@ -100,9 +100,9 @@ class AuthRepositoryImpl @Inject constructor(
     ).fold(
         onSuccess = { tokenResponse ->
             withContext(Dispatchers.IO) {
-                tokenDataSource.setAccessToken(tokenResponse.accessToken)
                 launch { tokenDataSource.setRefreshToken(tokenResponse.refreshToken) }
                 launch { userInfoDataSource.setUserRole(UserType.WORKER.apiValue) }
+                tokenDataSource.setAccessToken(tokenResponse.accessToken)
                 Result.success(Unit)
             }
         },
@@ -120,9 +120,9 @@ class AuthRepositoryImpl @Inject constructor(
     ).fold(
         onSuccess = { tokenResponse ->
             withContext(Dispatchers.IO) {
-                tokenDataSource.setAccessToken(tokenResponse.accessToken)
                 launch { tokenDataSource.setRefreshToken(tokenResponse.refreshToken) }
                 launch { userInfoDataSource.setUserRole(UserType.WORKER.apiValue) }
+                tokenDataSource.setAccessToken(tokenResponse.accessToken)
                 Result.success(Unit)
             }
         },
@@ -133,9 +133,9 @@ class AuthRepositoryImpl @Inject constructor(
         .fold(
             onSuccess = {
                 withContext(Dispatchers.IO) {
-                    tokenDataSource.clearToken()
                     launch { userInfoDataSource.clearUserRole() }
                     launch { userInfoDataSource.clearUserInfo() }
+                    tokenDataSource.clearToken()
                     Result.success(Unit)
                 }
             },
@@ -146,9 +146,9 @@ class AuthRepositoryImpl @Inject constructor(
         .fold(
             onSuccess = {
                 withContext(Dispatchers.IO) {
-                    tokenDataSource.clearToken()
                     launch { userInfoDataSource.clearUserRole() }
                     launch { userInfoDataSource.clearUserInfo() }
+                    tokenDataSource.clearToken()
                     Result.success(Unit)
                 }
             },
@@ -164,9 +164,9 @@ class AuthRepositoryImpl @Inject constructor(
         ).fold(
             onSuccess = {
                 withContext(Dispatchers.IO) {
-                    tokenDataSource.clearToken()
                     launch { userInfoDataSource.clearUserRole() }
                     launch { userInfoDataSource.clearUserInfo() }
+                    tokenDataSource.clearToken()
                     Result.success(Unit)
                 }
             },
@@ -178,9 +178,9 @@ class AuthRepositoryImpl @Inject constructor(
             .fold(
                 onSuccess = {
                     withContext(Dispatchers.IO) {
-                        tokenDataSource.clearToken()
                         launch { userInfoDataSource.clearUserRole() }
                         launch { userInfoDataSource.clearUserInfo() }
+                        tokenDataSource.clearToken()
                         Result.success(Unit)
                     }
                 },

--- a/core/data/src/main/java/com/idle/data/repository/auth/TokenRepositoryImpl.kt
+++ b/core/data/src/main/java/com/idle/data/repository/auth/TokenRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.idle.data.repository.auth
 
 import com.idle.datastore.datasource.TokenDataSource
 import com.idle.domain.repositorry.auth.TokenRepository
+import com.idle.network.model.auth.PostDeviceTokenRequest
 import com.idle.network.source.auth.AuthDataSource
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -16,6 +17,6 @@ class TokenRepositoryImpl @Inject constructor(
         tokenDataSource.accessToken.first()
     }
 
-    override suspend fun putFCMDeviceToken(token: String): Result<Unit> =
-        authDataSource.postDeviceToken(token)
+    override suspend fun putDeviceToken(token: String): Result<Unit> =
+        authDataSource.postDeviceToken(PostDeviceTokenRequest(token))
 }

--- a/core/data/src/main/java/com/idle/data/repository/auth/TokenRepositoryImpl.kt
+++ b/core/data/src/main/java/com/idle/data/repository/auth/TokenRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.idle.data.repository.auth
 
 import com.idle.datastore.datasource.TokenDataSource
 import com.idle.domain.repositorry.auth.TokenRepository
+import com.idle.network.source.auth.AuthDataSource
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
@@ -9,8 +10,12 @@ import javax.inject.Inject
 
 class TokenRepositoryImpl @Inject constructor(
     private val tokenDataSource: TokenDataSource,
+    private val authDataSource: AuthDataSource,
 ) : TokenRepository {
     override suspend fun getAccessToken(): String = withContext(Dispatchers.IO) {
         tokenDataSource.accessToken.first()
     }
+
+    override suspend fun putFCMDeviceToken(token: String): Result<Unit> =
+        authDataSource.postDeviceToken(token)
 }

--- a/core/data/src/main/java/com/idle/data/repository/auth/TokenRepositoryImpl.kt
+++ b/core/data/src/main/java/com/idle/data/repository/auth/TokenRepositoryImpl.kt
@@ -17,6 +17,6 @@ class TokenRepositoryImpl @Inject constructor(
         tokenDataSource.accessToken.first()
     }
 
-    override suspend fun putDeviceToken(token: String): Result<Unit> =
+    override suspend fun setDeviceToken(token: String): Result<Unit> =
         authDataSource.postDeviceToken(PostDeviceTokenRequest(token))
 }

--- a/core/data/src/main/java/com/idle/data/repository/config/ConfigRepositoryImpl.kt
+++ b/core/data/src/main/java/com/idle/data/repository/config/ConfigRepositoryImpl.kt
@@ -4,15 +4,19 @@ import com.idle.domain.model.config.ForceUpdate
 import com.idle.domain.repositorry.config.ConfigRepository
 import com.idle.network.model.config.ForceUpdateResponse
 import com.idle.network.source.remoteconfig.ConfigDataSource
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class ConfigRepositoryImpl @Inject constructor(
     private val configDataSource: ConfigDataSource,
 ) : ConfigRepository {
     override suspend fun getForceUpdate(): Result<ForceUpdate> = runCatching {
-        configDataSource.getReferenceType(
-            key = ConfigDataSource.FORCE_UPDATE,
-            defaultValue = ForceUpdateResponse(),
-        ).toVO()
+        withContext(Dispatchers.IO) {
+            configDataSource.getReferenceType(
+                key = ConfigDataSource.FORCE_UPDATE,
+                defaultValue = ForceUpdateResponse(),
+            ).toVO()
+        }
     }
 }

--- a/core/data/src/main/java/com/idle/data/repository/config/ConfigRepositoryImpl.kt
+++ b/core/data/src/main/java/com/idle/data/repository/config/ConfigRepositoryImpl.kt
@@ -4,19 +4,15 @@ import com.idle.domain.model.config.ForceUpdate
 import com.idle.domain.repositorry.config.ConfigRepository
 import com.idle.network.model.config.ForceUpdateResponse
 import com.idle.network.source.remoteconfig.ConfigDataSource
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class ConfigRepositoryImpl @Inject constructor(
     private val configDataSource: ConfigDataSource,
 ) : ConfigRepository {
     override suspend fun getForceUpdate(): Result<ForceUpdate> = runCatching {
-        withContext(Dispatchers.IO) {
-            configDataSource.getReferenceType(
-                key = ConfigDataSource.FORCE_UPDATE,
-                defaultValue = ForceUpdateResponse(),
-            ).toVO()
-        }
+        configDataSource.getReferenceType(
+            key = ConfigDataSource.FORCE_UPDATE,
+            defaultValue = ForceUpdateResponse(),
+        ).toVO()
     }
 }

--- a/core/data/src/test/java/com/idle/data/repository/auth/AuthRepositoryImplTest.kt
+++ b/core/data/src/test/java/com/idle/data/repository/auth/AuthRepositoryImplTest.kt
@@ -21,13 +21,20 @@ class AuthRepositoryImplTest {
     private lateinit var tokenDataSource: TokenDataSource
     private lateinit var userInfoDataSource: UserInfoDataSource
     private lateinit var authRepository: AuthRepositoryImpl
+    private lateinit var tokenRepository: TokenRepositoryImpl
 
     @BeforeEach
     fun setUp() {
         authDataSource = mockk()
         tokenDataSource = mockk()
         userInfoDataSource = mockk()
-        authRepository = AuthRepositoryImpl(authDataSource, tokenDataSource, userInfoDataSource)
+        tokenRepository = mockk()
+        authRepository = AuthRepositoryImpl(
+            authDataSource = authDataSource,
+            tokenDataSource = tokenDataSource,
+            userInfoDataSource = userInfoDataSource,
+            tokenRepository = tokenRepository,
+        )
 
         coEvery { tokenDataSource.setAccessToken(any()) } just Runs
         coEvery { tokenDataSource.setRefreshToken(any()) } just Runs
@@ -35,10 +42,12 @@ class AuthRepositoryImplTest {
         coEvery { tokenDataSource.clearToken() } just Runs
         coEvery { userInfoDataSource.clearUserRole() } just Runs
         coEvery { userInfoDataSource.clearUserInfo() } just Runs
+        coEvery { authDataSource.getDeviceToken() } returns "testToken"
+        coEvery { tokenRepository.setDeviceToken(any())} returns Result.success(Unit)
     }
 
     @Test
-    fun `센터장이 로그인 성공했을 경우 토큰을 저장한다`() = runTest {
+    fun `센터장이 로그인 성공했을 경우 토큰을 저장하고 디바이스 토큰을 서버로 보낸다`() = runTest {
         // Given
         val tokenResponse = TokenResponse("accessToken", "refreshToken")
         coEvery { authDataSource.signInCenter(any()) } returns Result.success(tokenResponse)
@@ -51,10 +60,11 @@ class AuthRepositoryImplTest {
         coVerify { tokenDataSource.setAccessToken("accessToken") }
         coVerify { tokenDataSource.setRefreshToken("refreshToken") }
         coVerify { userInfoDataSource.setUserRole(UserType.CENTER.apiValue) }
+        coVerify { tokenRepository.setDeviceToken("testToken") }
     }
 
     @Test
-    fun `요양보호사가 회원가입에 성공했을 경우 토큰을 저장한다`() = runTest {
+    fun `요양보호사가 회원가입에 성공했을 경우 토큰을 저장하고 디바이스 토큰을 서버로 보낸다`() = runTest {
         // Given
         val tokenResponse = TokenResponse("accessToken", "refreshToken")
         coEvery { authDataSource.signUpWorker(any()) } returns Result.success(tokenResponse)
@@ -67,10 +77,11 @@ class AuthRepositoryImplTest {
         coVerify { tokenDataSource.setAccessToken("accessToken") }
         coVerify { tokenDataSource.setRefreshToken("refreshToken") }
         coVerify { userInfoDataSource.setUserRole(UserType.WORKER.apiValue) }
+        coVerify { tokenRepository.setDeviceToken("testToken") }
     }
 
     @Test
-    fun `요양보호사가 로그인했을 경우 토큰을 저장한다`() = runTest {
+    fun `요양보호사가 로그인했을 경우 토큰을 저장하고 디바이스 토큰을 서버로 보낸다`() = runTest {
         // Given
         val tokenResponse = TokenResponse("accessToken", "refreshToken")
         coEvery { authDataSource.signInWorker(any()) } returns Result.success(tokenResponse)
@@ -83,6 +94,7 @@ class AuthRepositoryImplTest {
         coVerify { tokenDataSource.setAccessToken("accessToken") }
         coVerify { tokenDataSource.setRefreshToken("refreshToken") }
         coVerify { userInfoDataSource.setUserRole(UserType.WORKER.apiValue) }
+        coVerify { tokenRepository.setDeviceToken("testToken") }
     }
 
     @Test

--- a/core/data/src/test/java/com/idle/data/repository/profile/ProfileRepositoryImplTest.kt
+++ b/core/data/src/test/java/com/idle/data/repository/profile/ProfileRepositoryImplTest.kt
@@ -1,8 +1,8 @@
 package com.idle.data.repository.profile
 
 import com.idle.datastore.datasource.UserInfoDataSource
+import com.idle.domain.model.auth.Gender
 import com.idle.domain.model.profile.CenterProfile
-import com.idle.domain.model.profile.Gender
 import com.idle.domain.model.profile.JobSearchStatus
 import com.idle.domain.model.profile.WorkerProfile
 import com.idle.network.model.profile.GetCenterProfileResponse

--- a/core/domain/src/main/kotlin/com/idle/domain/repositorry/auth/TokenRepository.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/repositorry/auth/TokenRepository.kt
@@ -2,5 +2,5 @@ package com.idle.domain.repositorry.auth
 
 interface TokenRepository {
     suspend fun getAccessToken(): String
-    suspend fun putDeviceToken(token: String): Result<Unit>
+    suspend fun setDeviceToken(token: String): Result<Unit>
 }

--- a/core/domain/src/main/kotlin/com/idle/domain/repositorry/auth/TokenRepository.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/repositorry/auth/TokenRepository.kt
@@ -2,5 +2,5 @@ package com.idle.domain.repositorry.auth
 
 interface TokenRepository {
     suspend fun getAccessToken(): String
-    suspend fun putFCMDeviceToken(token: String): Result<Unit>
+    suspend fun putDeviceToken(token: String): Result<Unit>
 }

--- a/core/domain/src/main/kotlin/com/idle/domain/repositorry/auth/TokenRepository.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/repositorry/auth/TokenRepository.kt
@@ -2,4 +2,5 @@ package com.idle.domain.repositorry.auth
 
 interface TokenRepository {
     suspend fun getAccessToken(): String
+    suspend fun putFCMDeviceToken(token: String): Result<Unit>
 }

--- a/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/PutDeviceTokenUseCase.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/PutDeviceTokenUseCase.kt
@@ -1,0 +1,10 @@
+package com.idle.domain.usecase.auth
+
+import com.idle.domain.repositorry.auth.TokenRepository
+import javax.inject.Inject
+
+class PutDeviceTokenUseCase @Inject constructor(
+    private val tokenRepository: TokenRepository,
+) {
+    suspend operator fun invoke(token: String) = tokenRepository.putFCMDeviceToken(token)
+}

--- a/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/PutDeviceTokenUseCase.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/PutDeviceTokenUseCase.kt
@@ -6,5 +6,5 @@ import javax.inject.Inject
 class PutDeviceTokenUseCase @Inject constructor(
     private val tokenRepository: TokenRepository,
 ) {
-    suspend operator fun invoke(token: String) = tokenRepository.putDeviceToken(token)
+    suspend operator fun invoke(token: String) = tokenRepository.setDeviceToken(token)
 }

--- a/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/PutDeviceTokenUseCase.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/usecase/auth/PutDeviceTokenUseCase.kt
@@ -6,5 +6,5 @@ import javax.inject.Inject
 class PutDeviceTokenUseCase @Inject constructor(
     private val tokenRepository: TokenRepository,
 ) {
-    suspend operator fun invoke(token: String) = tokenRepository.putFCMDeviceToken(token)
+    suspend operator fun invoke(token: String) = tokenRepository.putDeviceToken(token)
 }

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -43,4 +43,5 @@ dependencies {
     implementation(libs.okhttp.logging)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.firebase.config)
+    implementation(libs.firebase.messaging)
 }

--- a/core/network/src/main/java/com/idle/network/api/AuthApi.kt
+++ b/core/network/src/main/java/com/idle/network/api/AuthApi.kt
@@ -3,6 +3,7 @@ package com.idle.network.api
 import com.idle.network.model.auth.BusinessRegistrationResponse
 import com.idle.network.model.auth.ConfirmAuthCodeRequest
 import com.idle.network.model.auth.GenerateNewPasswordRequest
+import com.idle.network.model.auth.PostDeviceTokenRequest
 import com.idle.network.model.auth.SendPhoneRequest
 import com.idle.network.model.auth.SignInCenterRequest
 import com.idle.network.model.auth.SignInWorkerRequest
@@ -48,7 +49,7 @@ interface AuthApi {
     suspend fun logoutWorker(): Response<Unit>
 
     @POST("/api/v1/common/token")
-    suspend fun postDeviceToken(token:String): Response<Unit>
+    suspend fun postDeviceToken(@Body postDeviceTokenRequest: PostDeviceTokenRequest): Response<Unit>
 
     @POST("/api/v1/auth/center/withdraw")
     suspend fun withdrawalCenter(

--- a/core/network/src/main/java/com/idle/network/api/AuthApi.kt
+++ b/core/network/src/main/java/com/idle/network/api/AuthApi.kt
@@ -47,6 +47,9 @@ interface AuthApi {
     @POST("/api/v1/auth/carer/logout")
     suspend fun logoutWorker(): Response<Unit>
 
+    @POST("/api/v1/common/token")
+    suspend fun postDeviceToken(token:String): Response<Unit>
+
     @POST("/api/v1/auth/center/withdraw")
     suspend fun withdrawalCenter(
         @Body withdrawalCenterRequest: WithdrawalCenterRequest

--- a/core/network/src/main/java/com/idle/network/di/FirebaseModule.kt
+++ b/core/network/src/main/java/com/idle/network/di/FirebaseModule.kt
@@ -1,10 +1,10 @@
 package com.idle.network.di
 
 import com.google.firebase.Firebase
+import com.google.firebase.messaging.FirebaseMessaging
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.ktx.remoteConfigSettings
 import com.google.firebase.remoteconfig.remoteConfig
-import com.idle.network.R
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -22,4 +22,8 @@ object FirebaseModule {
         }
         setConfigSettingsAsync(configSettings)
     }
+
+    @Singleton
+    @Provides
+    fun provideFirebaseMessaging(): FirebaseMessaging = FirebaseMessaging.getInstance()
 }

--- a/core/network/src/main/java/com/idle/network/model/auth/PostDeviceTokenRequest.kt
+++ b/core/network/src/main/java/com/idle/network/model/auth/PostDeviceTokenRequest.kt
@@ -1,0 +1,6 @@
+package com.idle.network.model.auth
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PostDeviceTokenRequest(val token: String)

--- a/core/network/src/main/java/com/idle/network/source/auth/AuthDataSource.kt
+++ b/core/network/src/main/java/com/idle/network/source/auth/AuthDataSource.kt
@@ -36,6 +36,9 @@ class AuthDataSource @Inject constructor(
     suspend fun signInWorker(signInWorkerRequest: SignInWorkerRequest): Result<TokenResponse> =
         safeApiCall { authApi.signInWorker(signInWorkerRequest) }
 
+    suspend fun postDeviceToken(token: String): Result<Unit> =
+        safeApiCall { authApi.postDeviceToken(token) }
+
     suspend fun logoutWorker(): Result<Unit> = safeApiCall { authApi.logoutWorker() }
 
     suspend fun logoutCenter(): Result<Unit> = safeApiCall { authApi.logoutCenter() }

--- a/core/network/src/main/java/com/idle/network/source/auth/AuthDataSource.kt
+++ b/core/network/src/main/java/com/idle/network/source/auth/AuthDataSource.kt
@@ -5,6 +5,7 @@ import com.idle.network.api.AuthApi
 import com.idle.network.model.auth.BusinessRegistrationResponse
 import com.idle.network.model.auth.ConfirmAuthCodeRequest
 import com.idle.network.model.auth.GenerateNewPasswordRequest
+import com.idle.network.model.auth.PostDeviceTokenRequest
 import com.idle.network.model.auth.SendPhoneRequest
 import com.idle.network.model.auth.SignInCenterRequest
 import com.idle.network.model.auth.SignInWorkerRequest
@@ -41,8 +42,8 @@ class AuthDataSource @Inject constructor(
     suspend fun signInWorker(signInWorkerRequest: SignInWorkerRequest): Result<TokenResponse> =
         safeApiCall { authApi.signInWorker(signInWorkerRequest) }
 
-    suspend fun postDeviceToken(token: String): Result<Unit> =
-        safeApiCall { authApi.postDeviceToken(token) }
+    suspend fun postDeviceToken(postDeviceTokenRequest: PostDeviceTokenRequest): Result<Unit> =
+        safeApiCall { authApi.postDeviceToken(postDeviceTokenRequest) }
 
     suspend fun logoutWorker(): Result<Unit> = safeApiCall { authApi.logoutWorker() }
 

--- a/core/network/src/main/java/com/idle/network/source/remoteconfig/ConfigDataSource.kt
+++ b/core/network/src/main/java/com/idle/network/source/remoteconfig/ConfigDataSource.kt
@@ -19,7 +19,9 @@ class ConfigDataSource @Inject constructor(
                     continuation.resume(remoteConfig[key])
                 } else {
                     task.exception?.let { continuation.resumeWithException(it) }
-                        ?: continuation.resume(null)
+                        ?: continuation.resumeWithException(
+                            Exception("Unknown error occurred when use remoteConfig")
+                        )
                 }
             }
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -85,8 +85,9 @@ ktlint = "12.1.1"
 
 ## firebase
 googleServices = "4.4.2"
-firebaseBom = "33.1.2"
+firebaseBom = "33.3.0"
 crashlytics = "3.0.2"
+messaging = "23.2.1"
 
 # https://coil-kt.github.io/coil/#jetpack-compose
 coil = "2.7.0"
@@ -152,6 +153,7 @@ firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.r
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
 firebase-config = { group = "com.google.firebase", name = "firebase-config-ktx" }
+firebase-messaging = { module = "com.google.firebase:firebase-messaging", version.ref = "messaging" }
 
 amplitude-analytics = { module = "com.amplitude:analytics-android", version.ref = "amplitudeAnalytics" }
 


### PR DESCRIPTION
## 1. 🔥 변경된 내용
- **FCM 메세지 연결 및 테스트**
- **로그인시 디바이스 토큰을 서버에 갱신하도록 변경**

_로그아웃, 회원탈퇴시 디바이스 토큰을 제거하는 로직은 서버에서 처리하기로 결정_

## 2. 📸 스크린샷(선택)

<img width="308" alt="image" src="https://github.com/user-attachments/assets/94a657e2-55bd-43e6-b6b8-336482fa6f1a">

## 3. 💡 알게된 부분

## Service를 사용할 때 비즈니스 로직 호출은 어떻게하나요?

ViewModel을 사용하지않고 Domain 레이어를 바로 호출.

ViewModel이라 함은 UI에서 보여줄 데이터를 Acitivty 및 Fragment보다 더 긴 라이프사이클로 보관하는 역할을 하는데,

Service를 사용할 때에는 생명주기도 짧을뿐더러 UI에 보여줄 것이 없으므로 딱히 사용할 필요가 없음.

```kotlin
@AndroidEntryPoint
class NotificationService : FirebaseMessagingService() {

    @Inject
    lateinit var putDeviceTokenUseCase: PutDeviceTokenUseCase

    @Inject
    lateinit var getUserRoleUseCase: GetUserRoleUseCase

    @Inject
    lateinit var notificationHandler: NotificationHandler

    private val job = SupervisorJob()
    private val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
        Log.e("test", throwable.stackTraceToString())
    }
    private val scope = CoroutineScope(Dispatchers.IO + job + coroutineExceptionHandler)

    override fun onNewToken(token: String) {
        super.onNewToken(token)

        scope.launch {
            val userRole = getUserRoleUseCase()

            when (userRole) {
                UserType.CENTER.apiValue, UserType.WORKER.apiValue -> putDeviceTokenUseCase(token)
            }
        }
    }

    override fun onMessageReceived(message: RemoteMessage) {
        super.onMessageReceived(message)

        val title = message.notification?.title ?: message.data["title"] ?: ""
        val body = message.notification?.body ?: message.data["body"] ?: ""

        notificationHandler.deliverNotification(
            title = title,
            body = body,
        )
    }

    override fun onDestroy() {
        super.onDestroy()
        job.cancel()
    }
}
```

[레퍼런스](https://github.com/android/architecture-components-samples/issues/137)

<br><br><br>

## Service를 사용할 때 LifecyleScope가 없는데 코루틴 스코프는 어떻게 여나요?

아래와 같이 SupervisorJob()을 이용하여 코루틴 스코프를 만듬.

`viewModelScope` 내부도 SupervisorJob()으로 구현되어있음.

```kotlin
private val job = SupervisorJob()
private val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
        Log.e("test", throwable.stackTraceToString())
    }
private val scope = CoroutineScope(Dispatchers.IO + job + coroutineExceptionHandler)

// ...

override fun onDestroy() {
        super.onDestroy()
        job.cancel()
    }
```

추가적으로 OnDestroy()에서 진행중이던 Job을 취소하였는데,

때에따라 서비스의 생명주기에 상관없이 계쏙해서 진행되어야 하는 로직이면 onDestroy()에서 cancel()을 하지않아도 됨.

[레퍼런스](https://stackoverflow.com/questions/63405673/how-to-call-suspend-function-from-service-android)