### PR TITLE
[IDLE-445] 설정화면에서 알림 권한을 설정할 수 있도록 구현

### DIFF
--- a/core/designsystem/binding/src/main/java/com/idle/designsystem/binding/component/Row.kt
+++ b/core/designsystem/binding/src/main/java/com/idle/designsystem/binding/component/Row.kt
@@ -1,5 +1,6 @@
 package com.idle.designsystem.binding.component
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
@@ -64,5 +65,15 @@ class CareRow @JvmOverloads constructor(
 
     fun getSwitchState(): Boolean {
         return switchView.isChecked
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    fun setOnSwitchClickListener(listener: () -> Unit) {
+        switchView.setOnTouchListener { _, event ->
+            if (event.action == android.view.MotionEvent.ACTION_UP) {
+                listener()
+            }
+            true  // 터치 이벤트를 소비하여 상태 변화 막기
+        }
     }
 }

--- a/core/designsystem/binding/src/main/res/layout/view_care_row.xml
+++ b/core/designsystem/binding/src/main/res/layout/view_care_row.xml
@@ -32,6 +32,7 @@
         android:id="@+id/row_switch_SC"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:clickable="true"
         android:gravity="center"
         android:thumb="@drawable/shape_switch_thumb"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/feature/setting/src/main/java/com/idle/setting/center/CenterSettingFragment.kt
+++ b/feature/setting/src/main/java/com/idle/setting/center/CenterSettingFragment.kt
@@ -3,10 +3,10 @@ package com.idle.setting.center
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import androidx.core.app.NotificationManagerCompat
 import androidx.core.net.toUri
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import com.idle.analytics.helper.AnalyticsHelper
 import com.idle.binding.DeepLinkDestination.CenterProfile
 import com.idle.binding.DeepLinkDestination.Withdrawal
 import com.idle.binding.base.BaseBindingFragment
@@ -22,7 +22,6 @@ import com.idle.setting.TERMS_AND_POLICES_URL
 import com.idle.setting.databinding.FragmentCenterSettingBinding
 import com.idle.setting.dialog.LogoutDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 
 @AndroidEntryPoint
 internal class CenterSettingFragment :
@@ -45,7 +44,20 @@ internal class CenterSettingFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        binding.viewModel = fragmentViewModel
+        binding.apply {
+            viewModel = fragmentViewModel
+            alarmRow.setOnSwitchClickListener {
+                val intent = Intent().apply {
+                    action = android.provider.Settings.ACTION_APP_NOTIFICATION_SETTINGS
+                    putExtra(
+                        android.provider.Settings.EXTRA_APP_PACKAGE,
+                        requireContext().packageName
+                    )
+                }
+                startActivity(intent)
+            }
+        }
+
         fragmentViewModel.apply {
             viewLifecycleOwner.repeatOnStarted {
                 centerSettingEvent.collect {
@@ -55,6 +67,13 @@ internal class CenterSettingFragment :
         }
 
         analyticsHelper.logScreenView(screenName = "center_setting_screen")
+    }
+
+    override fun onResume() {
+        super.onResume()
+        val notificationEnable = NotificationManagerCompat.from(requireContext())
+            .areNotificationsEnabled()
+        binding.alarmRow.setSwitchState(notificationEnable)
     }
 
     private fun handleSettingEvent(event: SettingEvent) {

--- a/feature/setting/src/main/java/com/idle/setting/worker/WorkerSettingFragment.kt
+++ b/feature/setting/src/main/java/com/idle/setting/worker/WorkerSettingFragment.kt
@@ -3,6 +3,7 @@ package com.idle.setting.worker
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import androidx.core.app.NotificationManagerCompat
 import androidx.core.net.toUri
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -43,7 +44,20 @@ internal class WorkerSettingFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        binding.viewModel = fragmentViewModel
+        binding.apply {
+            viewModel = fragmentViewModel
+            alarmRow.setOnSwitchClickListener {
+                val intent = Intent().apply {
+                    action = android.provider.Settings.ACTION_APP_NOTIFICATION_SETTINGS
+                    putExtra(
+                        android.provider.Settings.EXTRA_APP_PACKAGE,
+                        requireContext().packageName
+                    )
+                }
+                startActivity(intent)
+            }
+        }
+
         fragmentViewModel.apply {
             viewLifecycleOwner.repeatOnStarted {
                 workerSettingEvent.collect {
@@ -53,6 +67,13 @@ internal class WorkerSettingFragment :
         }
 
         analyticsHelper.logScreenView(screenName = "center_setting_screen")
+    }
+
+    override fun onResume() {
+        super.onResume()
+        val notificationEnable = NotificationManagerCompat.from(requireContext())
+            .areNotificationsEnabled()
+        binding.alarmRow.setSwitchState(notificationEnable)
     }
 
     private fun handleSettingEvent(event: SettingEvent) {

--- a/feature/setting/src/main/res/layout/fragment_center_setting.xml
+++ b/feature/setting/src/main/res/layout/fragment_center_setting.xml
@@ -46,6 +46,7 @@
             app:dividerColor="@color/gray_050" />
 
         <com.idle.designsystem.binding.component.CareRow
+            android:id="@+id/alarmRow"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"

--- a/feature/setting/src/main/res/layout/fragment_worker_setting.xml
+++ b/feature/setting/src/main/res/layout/fragment_worker_setting.xml
@@ -37,6 +37,7 @@
             app:dividerColor="@color/gray_050" />
 
         <com.idle.designsystem.binding.component.CareRow
+            android:id="@+id/alarmRow"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"

--- a/presentation/src/main/java/com/idle/presentation/MainActivity.kt
+++ b/presentation/src/main/java/com/idle/presentation/MainActivity.kt
@@ -97,7 +97,6 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         installSplashScreen()
@@ -274,11 +273,11 @@ class MainActivity : AppCompatActivity() {
         navController.addOnDestinationChangedListener { _, destination, arguments ->
             binding.apply {
                 val navMenuType = if (destination.id in centerBottomNavDestinationIds) {
-                    NavigationMenuType.Center
+                    NavigationMenuType.CENTER
                 } else if (destination.id in workerBottomNavDestinationIds) {
-                    NavigationMenuType.Worker
+                    NavigationMenuType.WORKER
                 } else {
-                    NavigationMenuType.Hide
+                    NavigationMenuType.HIDE
                 }
 
                 viewModel.setNavigationMenuType(navMenuType)
@@ -288,27 +287,27 @@ class MainActivity : AppCompatActivity() {
 
     private fun setNavigationMenuType(menuType: NavigationMenuType) {
         when (menuType) {
-            NavigationMenuType.Center -> binding.apply {
+            NavigationMenuType.CENTER -> binding.apply {
                 if (mainBNVWorker.visibility == View.VISIBLE) {
                     slideDown(mainBNVWorker)
                 }
                 if (mainBNVCenter.visibility != View.VISIBLE) {
                     slideUp(mainBNVCenter)
-                    mainBNVCenter.setupWithNavController(navController)
                 }
+                mainBNVCenter.setupWithNavController(navController)
             }
 
-            NavigationMenuType.Worker -> binding.apply {
+            NavigationMenuType.WORKER -> binding.apply {
                 if (mainBNVCenter.visibility == View.VISIBLE) {
                     slideDown(mainBNVCenter)
                 }
                 if (mainBNVWorker.visibility != View.VISIBLE) {
                     slideUp(mainBNVWorker)
-                    mainBNVWorker.setupWithNavController(navController)
                 }
+                mainBNVWorker.setupWithNavController(navController)
             }
 
-            NavigationMenuType.Hide -> binding.apply {
+            NavigationMenuType.HIDE -> binding.apply {
                 if (mainBNVCenter.visibility == View.VISIBLE) {
                     slideDown(mainBNVCenter)
                 }

--- a/presentation/src/main/java/com/idle/presentation/MainViewModel.kt
+++ b/presentation/src/main/java/com/idle/presentation/MainViewModel.kt
@@ -40,7 +40,7 @@ class MainViewModel @Inject constructor(
     private val getCenterStatusUseCase: GetCenterStatusUseCase,
 ) : BaseViewModel() {
     private val _navigationMenuType =
-        MutableStateFlow<NavigationMenuType>(NavigationMenuType.Hide)
+        MutableStateFlow<NavigationMenuType>(NavigationMenuType.HIDE)
     val navigationMenuType = _navigationMenuType.asStateFlow()
 
     private val _forceUpdate = MutableStateFlow<ForceUpdate?>(null)
@@ -122,10 +122,8 @@ class MainViewModel @Inject constructor(
     }
 }
 
-sealed class NavigationMenuType {
-    data object Center : NavigationMenuType()
-    data object Worker : NavigationMenuType()
-    data object Hide : NavigationMenuType()
+enum class NavigationMenuType {
+    CENTER, WORKER, HIDE;
 }
 
 sealed class MainEvent {

--- a/presentation/src/main/res/layout/activity_main.xml
+++ b/presentation/src/main/res/layout/activity_main.xml
@@ -19,8 +19,8 @@
         <com.google.android.material.divider.MaterialDivider
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            app:layout_constraintBottom_toTopOf="@id/main_BNV_center"
-            app:dividerColor="#E3E3E3" />
+            app:dividerColor="#E3E3E3"
+            app:layout_constraintBottom_toTopOf="@id/main_BNV_center" />
 
         <com.google.android.material.bottomnavigation.BottomNavigationView
             android:id="@+id/main_BNV_center"
@@ -28,9 +28,9 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@color/white"
-            app:itemBackground="@color/white"
             android:paddingStart="8dp"
             android:paddingEnd="8dp"
+            app:itemBackground="@color/white"
             app:itemPaddingBottom="8dp"
             app:itemPaddingTop="8dp"
             app:itemTextColor="@drawable/selector_menu_color"
@@ -44,9 +44,9 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@color/white"
-            app:itemBackground="@color/white"
             android:paddingStart="8dp"
             android:paddingEnd="8dp"
+            app:itemBackground="@color/white"
             app:itemPaddingBottom="8dp"
             app:itemPaddingTop="8dp"
             app:itemTextColor="@drawable/selector_menu_color"


### PR DESCRIPTION
## 1. 🔥 변경된 내용
- **설정 화면에서 알림을 설정할 수 있도록 변경**

## 2. 📸 스크린샷(선택)

https://github.com/user-attachments/assets/b8a45c3c-c678-460b-bd20-07b3b6ee3b14

## 3. 💡 알게된 부분

### 권한 설정을 새롭게 키는 경우는 상관이 없는데, 있다가 없애는 경우는 ConfigurationChange가 일어남.

[권한이 취소되면 앱 프로세스가 종료됨](https://developer.android.com/training/permissions/requesting?hl=ko#app_process_terminates_when_permission_revoked)

<img width="890" alt="image" src="https://github.com/user-attachments/assets/0d673037-d7b1-4bc6-b489-352cf731bbf7">

이 때 BottomNavigationView, DrawerLayout과 같은 뷰가 연결이 끊길 수 있기 때문에 `onCreate()` 에서 재연결을 해주어야함.

```kotlin
    private fun setNavigationMenuType(menuType: NavigationMenuType) {
        when (menuType) {
            NavigationMenuType.CENTER -> binding.apply {
                if (mainBNVWorker.visibility == View.VISIBLE) {
                    slideDown(mainBNVWorker)
                }
                if (mainBNVCenter.visibility != View.VISIBLE) {
                    slideUp(mainBNVCenter)
                    mainBNVCenter.setupWithNavController(navController)  // <-- 기존
                }
            }

            NavigationMenuType.WORKER -> binding.apply {
                if (mainBNVCenter.visibility == View.VISIBLE) {
                    slideDown(mainBNVCenter)
                }
                if (mainBNVWorker.visibility != View.VISIBLE) {
                    slideUp(mainBNVWorker)
                    mainBNVWorker.setupWithNavController(navController) // <-- 기존
                }
            }

            NavigationMenuType.HIDE -> binding.apply {
                if (mainBNVCenter.visibility == View.VISIBLE) {
                    slideDown(mainBNVCenter)
                }
                if (mainBNVWorker.visibility == View.VISIBLE) {
                    slideDown(mainBNVWorker)
                }
            }
        }
    }
```

원래는 `setupWithNavController(navController)` 를 최대한 중복호출 하지 않으려고 하여서 `if`문 안에 넣었지만,

프로세스가 종료된 이후 재생성될 때 Visible하고 있다고 판단하고 `setupWithNavController()`를 호출하지 않아서 생기는 이슈가 있었음.

이후 아래처럼 항상 호출되도록 수정

```kotlin
    private fun setNavigationMenuType(menuType: NavigationMenuType) {
        when (menuType) {
            NavigationMenuType.CENTER -> binding.apply {
                if (mainBNVWorker.visibility == View.VISIBLE) {
                    slideDown(mainBNVWorker)
                }
                if (mainBNVCenter.visibility != View.VISIBLE) {
                    slideUp(mainBNVCenter)
                }
                mainBNVCenter.setupWithNavController(navController)
            }

            NavigationMenuType.WORKER -> binding.apply {
                if (mainBNVCenter.visibility == View.VISIBLE) {
                    slideDown(mainBNVCenter)
                }
                if (mainBNVWorker.visibility != View.VISIBLE) {
                    slideUp(mainBNVWorker)
                }
                mainBNVWorker.setupWithNavController(navController)
            }

            NavigationMenuType.HIDE -> binding.apply {
                if (mainBNVCenter.visibility == View.VISIBLE) {
                    slideDown(mainBNVCenter)
                }
                if (mainBNVWorker.visibility == View.VISIBLE) {
                    slideDown(mainBNVWorker)
                }
            }
        }
    }
```
