### PR TITLE
[IDLE-465] 채팅방 UI 구현

### DIFF
--- a/core/common-ui/binding/src/main/java/com/idle/binding/DeepLinkDestination.kt
+++ b/core/common-ui/binding/src/main/java/com/idle/binding/DeepLinkDestination.kt
@@ -46,12 +46,16 @@ sealed class DeepLinkDestination(
 
     data class ChattingDetail(
         val chattingRoomId: String,
-        val userId: String
+        val receiverId: String,
+        val receiverUserType: String,
+        val senderId: String,
     ) : DeepLinkDestination(
         addressRes = R.string.chatting_detail_deeplink_url,
         params = mapOf(
             "chattingRoomId" to chattingRoomId,
-            "userId" to userId,
+            "receiverId" to receiverId,
+            "receiverUserType" to receiverUserType,
+            "senderId" to senderId,
         )
     )
 

--- a/core/designresource/src/main/res/values/deeplinks.xml
+++ b/core/designresource/src/main/res/values/deeplinks.xml
@@ -6,7 +6,7 @@
     <string name="withdrawal_deeplink_url">care://withdrawal/{userType}</string>
     <string name="signup_complete_deeplink_url">care://signup/complete</string>
     <string name="new_password_deeplink_url">care://newPassword</string>
-    <string name="chatting_detail_deeplink_url">care://chatting/detail/{chattingRoomId}/{userId}</string>
+    <string name="chatting_detail_deeplink_url">care://chatting/detail/{chattingRoomId}/{receiverId}/{receiverUserType}/{senderId}</string>
 
     <string name="worker_signup_deeplink_url">care://signup/worker</string>
     <string name="worker_home_deeplink_url">care://worker/home</string>

--- a/core/domain/src/main/kotlin/com/idle/domain/model/auth/UserType.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/model/auth/UserType.kt
@@ -5,7 +5,7 @@ enum class UserType(val apiValue: String) {
 
     companion object {
         fun create(value: String?): UserType {
-            return UserType.entries.firstOrNull { it.name == value } ?: CENTER
+            return UserType.entries.firstOrNull { it.apiValue == value } ?: CENTER
         }
     }
 }

--- a/core/domain/src/main/kotlin/com/idle/domain/model/chatting/ChatMessage.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/model/chatting/ChatMessage.kt
@@ -5,6 +5,7 @@ import java.time.LocalDateTime
 data class ChatMessage(
     val id: String,
     val roomId: String,
+    val senderId: String,
     val senderType: SenderType,
     val contents: List<Content>,
     val createdAt: LocalDateTime,

--- a/core/domain/src/main/kotlin/com/idle/domain/usecase/chatting/GetChatMessagesUseCase.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/usecase/chatting/GetChatMessagesUseCase.kt
@@ -1,0 +1,60 @@
+package com.idle.domain.usecase.chatting
+
+import com.idle.domain.model.chatting.ChatMessage
+import com.idle.domain.model.chatting.Content
+import com.idle.domain.model.chatting.ContentType
+import com.idle.domain.model.chatting.SenderType
+import java.time.LocalDateTime
+import javax.inject.Inject
+
+class GetChatMessagesUseCase @Inject constructor() {
+    suspend operator fun invoke(roomId: String): Result<List<ChatMessage>> = Result.success(
+        listOf(
+            ChatMessage(
+                id = "1",
+                roomId = "room1",
+                senderId = "user1",
+                senderType = SenderType.USER,
+                contents = listOf(
+                    Content(
+                        type = ContentType.TEXT,
+                        value = "안녕하세요! 문의드리고 싶어서 연락드렸습니다."
+                    )
+                ),
+                createdAt = LocalDateTime.now().minusDays(3)
+            ),
+            ChatMessage(
+                id = "2",
+                roomId = "room1",
+                senderId = "user2",
+                senderType = SenderType.USER,
+                contents = listOf(Content(type = ContentType.TEXT, value = "안녕하세요! 어떤 문의사항이신가요?")),
+                createdAt = LocalDateTime.now().minusDays(2)
+            ),
+            ChatMessage(
+                id = "3",
+                roomId = "room1",
+                senderId = "user1",
+                senderType = SenderType.USER,
+                contents = listOf(Content(type = ContentType.TEXT, value = "추가로 여쭤보고 싶은 게 있습니다.")),
+                createdAt = LocalDateTime.now().minusDays(1)
+            ),
+            ChatMessage(
+                id = "4",
+                roomId = "room1",
+                senderId = "user2",
+                senderType = SenderType.USER,
+                contents = listOf(Content(type = ContentType.TEXT, value = "알겠습니다. 무엇이 궁금하신가요?")),
+                createdAt = LocalDateTime.now().minusMinutes(3)
+            ),
+            ChatMessage(
+                id = "5",
+                roomId = "room1",
+                senderId = "user1",
+                senderType = SenderType.USER,
+                contents = listOf(Content(type = ContentType.TEXT, value = "감사합니다! 친절한 답변 감사합니다.")),
+                createdAt = LocalDateTime.now().minusMinutes(1)
+            )
+        )
+    )
+}

--- a/core/domain/src/main/kotlin/com/idle/domain/util/TimeUtil.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/util/TimeUtil.kt
@@ -50,3 +50,8 @@ fun LocalDateTime.formatRelativeTimeDescription(): String {
         else -> "${daysDifference / 7}주 전"
     }
 }
+
+fun LocalDateTime.formatTimeToHourMinute24(): String {
+    val formatter = DateTimeFormatter.ofPattern("HH:mm").withZone(seoulZone)
+    return this.format(formatter)
+}

--- a/core/domain/src/main/kotlin/com/idle/domain/util/TimeUtil.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/util/TimeUtil.kt
@@ -52,6 +52,11 @@ fun LocalDateTime.formatRelativeTimeDescription(): String {
 }
 
 fun LocalDateTime.formatTimeToHourMinute24(): String {
-    val formatter = DateTimeFormatter.ofPattern("HH:mm").withZone(seoulZone)
+    val formatter = DateTimeFormatter.ofPattern("HH:mm")
+    return this.format(formatter)
+}
+
+fun LocalDateTime.formatYearMonthDate(): String {
+    val formatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일")
     return this.format(formatter)
 }

--- a/feature/center/chatting/src/main/java/com/idle/center/chatting/CenterChattingFragment.kt
+++ b/feature/center/chatting/src/main/java/com/idle/center/chatting/CenterChattingFragment.kt
@@ -39,6 +39,7 @@ import com.idle.compose.clickable
 import com.idle.designsystem.compose.component.CareHeadingTopBar
 import com.idle.designsystem.compose.component.LoadingCircle
 import com.idle.designsystem.compose.foundation.CareTheme
+import com.idle.domain.model.auth.UserType
 import com.idle.domain.model.chatting.ChatRoom
 import com.idle.domain.util.formatRelativeDateTime
 import dagger.hilt.android.AndroidEntryPoint
@@ -125,7 +126,9 @@ internal fun ChatRoomItem(
                 navigateTo(
                     DeepLinkDestination.ChattingDetail(
                         chattingRoomId = chatRoom.id,
-                        userId = chatRoom.receiver,
+                        receiverId = chatRoom.receiver,
+                        receiverUserType = UserType.CENTER.apiValue,
+                        senderId = chatRoom.sender,
                     )
                 )
             },

--- a/feature/center/chatting/src/main/java/com/idle/center/chatting/CenterChattingFragment.kt
+++ b/feature/center/chatting/src/main/java/com/idle/center/chatting/CenterChattingFragment.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -21,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -145,9 +147,11 @@ internal fun ChatRoomItem(
                 error = painterResource(com.idle.designresource.R.drawable.ic_notification_placeholder),
                 onError = { Log.d("test", chatRoom.profileImageUrl) },
                 contentDescription = "",
+                contentScale = ContentScale.Crop,
                 modifier = Modifier
-                    .align(Alignment.CenterVertically)
                     .padding(end = 12.dp)
+                    .align(Alignment.CenterVertically)
+                    .clip(CircleShape)
                     .size(48.dp),
             )
 

--- a/feature/center/home/src/main/java/com/idle/center/home/CenterHomeFragment.kt
+++ b/feature/center/home/src/main/java/com/idle/center/home/CenterHomeFragment.kt
@@ -262,7 +262,7 @@ internal fun CenterHomeScreen(
                                         Spacer(
                                             modifier = Modifier
                                                 .fillMaxWidth()
-                                                .height(28.dp)
+                                                .height(80.dp)
                                         )
                                     }
                                 }

--- a/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ChattingDetailFragment.kt
+++ b/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ChattingDetailFragment.kt
@@ -1,18 +1,20 @@
 package com.idle.chatting_detail
 
-import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -20,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -27,6 +30,9 @@ import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import com.idle.chatting_detail.component.CareChatReceiverTextBubble
+import com.idle.chatting_detail.component.CareChatSenderTextBubble
+import com.idle.chatting_detail.component.CareChatSenderTextBubbleWithImage
 import com.idle.chatting_detail.component.CareChatTextField
 import com.idle.compose.addFocusCleaner
 import com.idle.compose.base.BaseComposeFragment
@@ -34,6 +40,9 @@ import com.idle.designsystem.compose.component.CareSubtitleTopBar
 import com.idle.designsystem.compose.foundation.CareTheme
 import com.idle.domain.model.auth.UserType
 import com.idle.domain.model.chatting.ChatMessage
+import com.idle.domain.model.profile.CenterProfile
+import com.idle.domain.model.profile.WorkerProfile
+import com.idle.domain.util.formatYearMonthDate
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -48,18 +57,23 @@ internal class ChattingDetailFragment : BaseComposeFragment() {
         val receiverId = rememberSaveable { args.receiverId }
         val senderId = rememberSaveable { args.senderId }
 
-        LifecycleEventEffect(Lifecycle.Event.ON_CREATE) {
-            Log.d("test", "$chattingRoomId $receiverId $receiverUserType $senderId")
-            // Todo
-        }
-
         fragmentViewModel.apply {
             val writingText by writingText.collectAsStateWithLifecycle()
             val chatMessages by chatMessages.collectAsStateWithLifecycle()
+            val workerProfile by workerProfile.collectAsStateWithLifecycle()
+            val centerProfile by centerProfile.collectAsStateWithLifecycle()
 
-            if (chatMessages != null) {
+            LifecycleEventEffect(Lifecycle.Event.ON_CREATE) {
+                getUserProfile(receiverUserType = receiverUserType, senderId = senderId)
+                getChatMessages(chattingRoomId)
+            }
+
+            if (chatMessages != null && workerProfile != null && centerProfile != null) {
                 ChattingDetailScreen(
                     receiverId = receiverId,
+                    receiverUserType = receiverUserType,
+                    workerProfile = workerProfile!!,
+                    centerProfile = centerProfile!!,
                     writingText = writingText,
                     chatMessages = chatMessages!!,
                     onWritingTextChange = ::setWritingText,
@@ -77,12 +91,16 @@ internal class ChattingDetailFragment : BaseComposeFragment() {
 @Composable
 internal fun ChattingDetailScreen(
     receiverId: String,
+    receiverUserType: UserType,
+    workerProfile: WorkerProfile,
+    centerProfile: CenterProfile,
     writingText: String,
     chatMessages: List<ChatMessage>,
     onWritingTextChange: (String) -> Unit,
     navigateUp: () -> Unit,
 ) {
     val focusManager = LocalFocusManager.current
+    var lastDate: String? = null
 
     Scaffold(
         topBar = {
@@ -109,11 +127,84 @@ internal fun ChattingDetailScreen(
                     .background(CareTheme.colors.gray050)
                     .padding(horizontal = 20.dp),
             ) {
-                items(
+                item {
+                    Spacer(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(20.dp)
+                    )
+                }
+
+                itemsIndexed(
                     items = chatMessages,
-                    key = { it.id },
-                ) { chatMessage ->
-                    
+                    key = { _, item -> item.id },
+                ) { index, chatMessage ->
+                    val isLast = if (index < chatMessages.size - 1) {
+                        val nextIndex = index + 1
+                        chatMessage.senderId != chatMessages[nextIndex].senderId
+                    } else {
+                        true
+                    }
+
+                    val padding = PaddingValues(bottom = if (isLast) 16.dp else 6.dp)
+
+
+                    val messageDate = chatMessage.createdAt.formatYearMonthDate()
+                    val showDate = lastDate != messageDate
+                    if (showDate) {
+                        lastDate = messageDate
+
+                        Text(
+                            text = messageDate,
+                            style = CareTheme.typography.caption1,
+                            color = CareTheme.colors.gray700,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(
+                                    top = if (index == 0 || isLast) 0.dp else 10.dp,
+                                    bottom = 16.dp
+                                )
+                        )
+                    }
+
+                    val isMyMessage = receiverId == chatMessage.senderId
+                    if (isMyMessage) {
+                        CareChatReceiverTextBubble(
+                            chatMessage = chatMessage,
+                            isLast = isLast,
+                            modifier = Modifier.padding(padding),
+                        )
+                    } else {
+                        val showProfile = if (index > 0) {
+                            val previousIndex = index - 1
+                            chatMessage.senderId != chatMessages[previousIndex].senderId
+                        } else {
+                            true
+                        }
+
+                        if (showProfile) {
+                            CareChatSenderTextBubbleWithImage(
+                                imageUrl = when (receiverUserType) {
+                                    UserType.CENTER -> workerProfile.profileImageUrl
+                                    UserType.WORKER -> centerProfile.profileImageUrl
+                                },
+                                senderName = when (receiverUserType) {
+                                    UserType.CENTER -> workerProfile.workerName
+                                    UserType.WORKER -> centerProfile.centerName
+                                },
+                                chatMessage = chatMessage, isLast = isLast,
+                                modifier = Modifier.padding(padding),
+                            )
+                        } else {
+                            CareChatSenderTextBubble(
+                                chatMessage = chatMessage,
+                                isLast = isLast,
+                                isRead = isLast,
+                                modifier = Modifier.padding(padding),
+                            )
+                        }
+                    }
                 }
             }
 

--- a/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ChattingDetailFragment.kt
+++ b/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ChattingDetailFragment.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
@@ -52,10 +51,10 @@ internal class ChattingDetailFragment : BaseComposeFragment() {
 
     @Composable
     override fun ComposeLayout() {
-        val chattingRoomId = rememberSaveable { args.chattingRoomId }
-        val receiverUserType = rememberSaveable { UserType.create(args.receiverUserType) }
-        val receiverId = rememberSaveable { args.receiverId }
-        val senderId = rememberSaveable { args.senderId }
+        val chattingRoomId = args.chattingRoomId
+        val receiverUserType = UserType.create(args.receiverUserType)
+        val receiverId = args.receiverId
+        val senderId = args.senderId
 
         fragmentViewModel.apply {
             val writingText by writingText.collectAsStateWithLifecycle()

--- a/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ChattingDetailFragment.kt
+++ b/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ChattingDetailFragment.kt
@@ -27,7 +27,6 @@ import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
-import com.idle.chatting_detail.component.CareChatTextBubble
 import com.idle.chatting_detail.component.CareChatTextField
 import com.idle.compose.addFocusCleaner
 import com.idle.compose.base.BaseComposeFragment
@@ -114,10 +113,7 @@ internal fun ChattingDetailScreen(
                     items = chatMessages,
                     key = { it.id },
                 ) { chatMessage ->
-                    CareChatTextBubble(
-                        chatMessage = chatMessage,
-                        isMyChat = chatMessage.senderId == receiverId,
-                    )
+                    
                 }
             }
 

--- a/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ChattingDetailFragment.kt
+++ b/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ChattingDetailFragment.kt
@@ -1,10 +1,8 @@
 package com.idle.chatting_detail
 
-import androidx.compose.foundation.BorderStroke
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -12,34 +10,31 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import com.idle.chatting_detail.component.CareChatTextBubble
+import com.idle.chatting_detail.component.CareChatTextField
 import com.idle.compose.addFocusCleaner
 import com.idle.compose.base.BaseComposeFragment
 import com.idle.designsystem.compose.component.CareSubtitleTopBar
 import com.idle.designsystem.compose.foundation.CareTheme
+import com.idle.domain.model.auth.UserType
+import com.idle.domain.model.chatting.ChatMessage
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -49,23 +44,42 @@ internal class ChattingDetailFragment : BaseComposeFragment() {
 
     @Composable
     override fun ComposeLayout() {
-        fragmentViewModel.apply {
-            val chattingRoomId = args.chattingRoomId
-            val userId = args.userId
-            val writingText by writingText.collectAsStateWithLifecycle()
+        val chattingRoomId = rememberSaveable { args.chattingRoomId }
+        val receiverUserType = rememberSaveable { UserType.create(args.receiverUserType) }
+        val receiverId = rememberSaveable { args.receiverId }
+        val senderId = rememberSaveable { args.senderId }
 
-            ChattingDetailScreen(
-                writingText = writingText,
-                onWritingTextChange = ::setWritingText,
-                navigateUp = { findNavController().navigateUp() },
-            )
+        LifecycleEventEffect(Lifecycle.Event.ON_CREATE) {
+            Log.d("test", "$chattingRoomId $receiverId $receiverUserType $senderId")
+            // Todo
+        }
+
+        fragmentViewModel.apply {
+            val writingText by writingText.collectAsStateWithLifecycle()
+            val chatMessages by chatMessages.collectAsStateWithLifecycle()
+
+            if (chatMessages != null) {
+                ChattingDetailScreen(
+                    receiverId = receiverId,
+                    writingText = writingText,
+                    chatMessages = chatMessages!!,
+                    onWritingTextChange = ::setWritingText,
+                    navigateUp = { findNavController().navigateUp() }
+                )
+            } else {
+                ChattingDetailLoadingScreen(
+                    navigateUp = { findNavController().navigateUp() },
+                )
+            }
         }
     }
 }
 
 @Composable
 internal fun ChattingDetailScreen(
+    receiverId: String,
     writingText: String,
+    chatMessages: List<ChatMessage>,
     onWritingTextChange: (String) -> Unit,
     navigateUp: () -> Unit,
 ) {
@@ -93,9 +107,18 @@ internal fun ChattingDetailScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f)
-                    .background(CareTheme.colors.gray050),
+                    .background(CareTheme.colors.gray050)
+                    .padding(horizontal = 20.dp),
             ) {
-
+                items(
+                    items = chatMessages,
+                    key = { it.id },
+                ) { chatMessage ->
+                    CareChatTextBubble(
+                        chatMessage = chatMessage,
+                        isMyChat = chatMessage.senderId == receiverId,
+                    )
+                }
             }
 
             Row(
@@ -119,62 +142,5 @@ internal fun ChattingDetailScreen(
                 )
             }
         }
-    }
-}
-
-@Composable
-fun CareChatTextField(
-    value: String,
-    onValueChanged: (String) -> Unit,
-    modifier: Modifier = Modifier,
-    hint: String = "",
-    keyboardType: KeyboardType = KeyboardType.Text,
-    visualTransformation: VisualTransformation = VisualTransformation.None,
-    onDone: () -> Unit = {},
-) {
-    val keyboardController = LocalSoftwareKeyboardController.current
-    val interactionSource = remember { MutableInteractionSource() }
-    val boarderStroke = BorderStroke(
-        width = 1.dp,
-        color = CareTheme.colors.gray100,
-    )
-
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier
-            .wrapContentHeight()
-            .border(
-                border = boarderStroke,
-                shape = RoundedCornerShape(50.dp)
-            )
-    ) {
-        BasicTextField(
-            value = value,
-            onValueChange = onValueChanged,
-            interactionSource = interactionSource,
-            visualTransformation = visualTransformation,
-            keyboardOptions = KeyboardOptions(
-                keyboardType = keyboardType,
-                imeAction = ImeAction.Done
-            ),
-            keyboardActions = KeyboardActions(onDone = {
-                keyboardController?.hide()
-                onDone()
-            }),
-            modifier = Modifier
-                .weight(1f)
-                .padding(horizontal = 20.dp, vertical = 7.dp),
-            decorationBox = { innerTextField ->
-                if (value.isEmpty()) {
-                    Text(
-                        text = hint,
-                        style = CareTheme.typography.body3,
-                        color = CareTheme.colors.gray300,
-                    )
-                }
-
-                innerTextField()
-            }
-        )
     }
 }

--- a/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ChattingDetailLoadingScreen.kt
+++ b/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ChattingDetailLoadingScreen.kt
@@ -1,0 +1,38 @@
+package com.idle.chatting_detail
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.idle.designsystem.compose.component.CareSubtitleTopBar
+import com.idle.designsystem.compose.foundation.CareTheme
+
+@Composable
+fun ChattingDetailLoadingScreen(
+    title: String = "세얼간이요양보호센터",
+    navigateUp: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            CareSubtitleTopBar(
+                title = title,
+                onNavigationClick = navigateUp,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 12.dp, top = 48.dp, end = 20.dp, bottom = 12.dp),
+            )
+        },
+        containerColor = CareTheme.colors.white000,
+    ) { paddingValue ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValue),
+        ) {
+        }
+    }
+}

--- a/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ChattingDetailViewModel.kt
+++ b/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ChattingDetailViewModel.kt
@@ -7,6 +7,7 @@ import com.idle.domain.model.chatting.ChatMessage
 import com.idle.domain.model.error.ErrorHandlerHelper
 import com.idle.domain.model.profile.CenterProfile
 import com.idle.domain.model.profile.WorkerProfile
+import com.idle.domain.usecase.chatting.GetChatMessagesUseCase
 import com.idle.domain.usecase.profile.GetCenterProfileUseCase
 import com.idle.domain.usecase.profile.GetLocalMyCenterProfileUseCase
 import com.idle.domain.usecase.profile.GetLocalMyWorkerProfileUseCase
@@ -23,12 +24,13 @@ class ChattingDetailViewModel @Inject constructor(
     private val getLocalMyWorkerProfileUseCase: GetLocalMyWorkerProfileUseCase,
     private val getCenterProfileUseCase: GetCenterProfileUseCase,
     private val getWorkerProfileUseCase: GetWorkerProfileUseCase,
+    private val getChatMessagesUseCase: GetChatMessagesUseCase,
     private val errorHandlerHelper: ErrorHandlerHelper,
 ) : BaseViewModel() {
     private val _writingText = MutableStateFlow<String>("")
     val writingText = _writingText.asStateFlow()
 
-    private val _chatMessages = MutableStateFlow<List<ChatMessage>?>(emptyList())
+    private val _chatMessages = MutableStateFlow<List<ChatMessage>?>(null)
     val chatMessages = _chatMessages.asStateFlow()
 
     private val _workerProfile = MutableStateFlow<WorkerProfile?>(null)
@@ -36,6 +38,10 @@ class ChattingDetailViewModel @Inject constructor(
 
     private val _centerProfile = MutableStateFlow<CenterProfile?>(null)
     val centerProfile = _centerProfile.asStateFlow()
+
+    internal fun setWritingText(text: String) {
+        _writingText.value = text
+    }
 
     internal fun getUserProfile(
         receiverUserType: UserType,
@@ -76,7 +82,9 @@ class ChattingDetailViewModel @Inject constructor(
         }
     }
 
-    internal fun setWritingText(text: String) {
-        _writingText.value = text
+    internal fun getChatMessages(roomId: String) = viewModelScope.launch {
+        getChatMessagesUseCase(roomId).onSuccess {
+            _chatMessages.value = it
+        }
     }
 }

--- a/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ChattingDetailViewModel.kt
+++ b/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ChattingDetailViewModel.kt
@@ -1,7 +1,12 @@
 package com.idle.chatting_detail
 
+import androidx.lifecycle.viewModelScope
 import com.idle.binding.base.BaseViewModel
+import com.idle.domain.model.auth.UserType
 import com.idle.domain.model.chatting.ChatMessage
+import com.idle.domain.model.error.ErrorHandlerHelper
+import com.idle.domain.model.profile.CenterProfile
+import com.idle.domain.model.profile.WorkerProfile
 import com.idle.domain.usecase.profile.GetCenterProfileUseCase
 import com.idle.domain.usecase.profile.GetLocalMyCenterProfileUseCase
 import com.idle.domain.usecase.profile.GetLocalMyWorkerProfileUseCase
@@ -9,6 +14,7 @@ import com.idle.domain.usecase.profile.GetWorkerProfileUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -17,12 +23,58 @@ class ChattingDetailViewModel @Inject constructor(
     private val getLocalMyWorkerProfileUseCase: GetLocalMyWorkerProfileUseCase,
     private val getCenterProfileUseCase: GetCenterProfileUseCase,
     private val getWorkerProfileUseCase: GetWorkerProfileUseCase,
+    private val errorHandlerHelper: ErrorHandlerHelper,
 ) : BaseViewModel() {
     private val _writingText = MutableStateFlow<String>("")
     val writingText = _writingText.asStateFlow()
 
     private val _chatMessages = MutableStateFlow<List<ChatMessage>?>(emptyList())
     val chatMessages = _chatMessages.asStateFlow()
+
+    private val _workerProfile = MutableStateFlow<WorkerProfile?>(null)
+    val workerProfile = _workerProfile.asStateFlow()
+
+    private val _centerProfile = MutableStateFlow<CenterProfile?>(null)
+    val centerProfile = _centerProfile.asStateFlow()
+
+    internal fun getUserProfile(
+        receiverUserType: UserType,
+        senderId: String,
+    ) = viewModelScope.launch {
+        when (receiverUserType) {
+            UserType.CENTER -> {
+                launch {
+                    getWorkerProfileUseCase(senderId).onSuccess {
+                        _workerProfile.value = it
+                    }.onFailure {
+                        errorHandlerHelper.sendError(it)
+                    }
+                }
+
+                getLocalMyCenterProfileUseCase().onSuccess {
+                    _centerProfile.value = it
+                }.onFailure {
+                    errorHandlerHelper.sendError(it)
+                }
+            }
+
+            UserType.WORKER -> {
+                launch {
+                    getCenterProfileUseCase(senderId).onSuccess {
+                        _centerProfile.value = it
+                    }.onFailure {
+                        errorHandlerHelper.sendError(it)
+                    }
+                }
+
+                getLocalMyWorkerProfileUseCase().onSuccess {
+                    _workerProfile.value = it
+                }.onFailure {
+                    errorHandlerHelper.sendError(it)
+                }
+            }
+        }
+    }
 
     internal fun setWritingText(text: String) {
         _writingText.value = text

--- a/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ChattingDetailViewModel.kt
+++ b/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ChattingDetailViewModel.kt
@@ -1,15 +1,28 @@
 package com.idle.chatting_detail
 
 import com.idle.binding.base.BaseViewModel
+import com.idle.domain.model.chatting.ChatMessage
+import com.idle.domain.usecase.profile.GetCenterProfileUseCase
+import com.idle.domain.usecase.profile.GetLocalMyCenterProfileUseCase
+import com.idle.domain.usecase.profile.GetLocalMyWorkerProfileUseCase
+import com.idle.domain.usecase.profile.GetWorkerProfileUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 
 @HiltViewModel
-class ChattingDetailViewModel @Inject constructor() : BaseViewModel() {
+class ChattingDetailViewModel @Inject constructor(
+    private val getLocalMyCenterProfileUseCase: GetLocalMyCenterProfileUseCase,
+    private val getLocalMyWorkerProfileUseCase: GetLocalMyWorkerProfileUseCase,
+    private val getCenterProfileUseCase: GetCenterProfileUseCase,
+    private val getWorkerProfileUseCase: GetWorkerProfileUseCase,
+) : BaseViewModel() {
     private val _writingText = MutableStateFlow<String>("")
     val writingText = _writingText.asStateFlow()
+
+    private val _chatMessages = MutableStateFlow<List<ChatMessage>?>(emptyList())
+    val chatMessages = _chatMessages.asStateFlow()
 
     internal fun setWritingText(text: String) {
         _writingText.value = text

--- a/feature/chatting-detail/src/main/java/com/idle/chatting_detail/component/CareChatTextBubble.kt
+++ b/feature/chatting-detail/src/main/java/com/idle/chatting_detail/component/CareChatTextBubble.kt
@@ -1,6 +1,7 @@
 package com.idle.chatting_detail.component
 
 import android.graphics.Color
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -10,6 +11,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -33,7 +35,7 @@ import java.time.LocalDateTime
 
 @Composable
 fun CareChatSenderTextBubbleWithImage(
-    imageUrl: String,
+    imageUrl: String?,
     senderName: String,
     chatMessage: ChatMessage,
     isLast: Boolean,
@@ -45,20 +47,24 @@ fun CareChatSenderTextBubbleWithImage(
         modifier = modifier.fillMaxWidth()
     ) {
         AsyncImage(
-            model = imageUrl,
-            placeholder = painterResource(com.idle.designresource.R.drawable.ic_notification_placeholder),
+            model = imageUrl
+                ?: painterResource(com.idle.designresource.R.drawable.ic_notification_placeholder),
+            placeholder =
+            painterResource(com.idle.designresource.R.drawable.ic_notification_placeholder),
+            error = painterResource(com.idle.designresource.R.drawable.ic_notification_placeholder),
+            onError = { Log.d("test", imageUrl.toString()) },
             contentDescription = null,
             contentScale = ContentScale.Crop,
             modifier = Modifier
                 .padding(end = 8.dp)
-                .clip(CircleShape)
-                .size(40.dp),
+                .size(40.dp)
+                .clip(CircleShape),
         )
 
         Column(
             verticalArrangement = Arrangement.Top,
             horizontalAlignment = Alignment.Start,
-            modifier = Modifier.weight(1f),
+            modifier = Modifier.weight(1f, false)
         ) {
             Text(
                 text = senderName,
@@ -81,9 +87,7 @@ fun CareChatSenderTextBubbleWithImage(
                     .background(CareTheme.colors.white000)
             ) {
                 Text(
-                    text = chatMessage.contents
-                        .map { it.value }
-                        .joinToString(),
+                    text = chatMessage.contents.joinToString { it.value },
                     style = CareTheme.typography.body3,
                     color = CareTheme.colors.black,
                     modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
@@ -93,11 +97,11 @@ fun CareChatSenderTextBubbleWithImage(
 
         if (isLast) {
             Column(
-                verticalArrangement = Arrangement.Bottom,
                 horizontalAlignment = Alignment.Start,
                 modifier = Modifier
-                    .align(Alignment.Bottom)
-                    .padding(start = 4.dp),
+                    .padding(start = 4.dp)
+                    .width(35.dp)
+                    .align(Alignment.Bottom),
             ) {
                 if (isRead) {
                     Text(
@@ -131,32 +135,25 @@ fun CareChatSenderTextBubble(
                 .size(40.dp),
         )
 
-        Column(
-            horizontalAlignment = Alignment.Start,
-            modifier = Modifier.weight(1f),
-        ) {
-            Box(
-                modifier = Modifier
-                    .wrapContentSize()
-                    .clip(
-                        RoundedCornerShape(
-                            topStart = 0.dp,
-                            topEnd = 12.dp,
-                            bottomStart = 12.dp,
-                            bottomEnd = 12.dp
-                        )
+        Box(
+            modifier = Modifier
+                .weight(1f, false)
+                .clip(
+                    RoundedCornerShape(
+                        topStart = 0.dp,
+                        topEnd = 12.dp,
+                        bottomStart = 12.dp,
+                        bottomEnd = 12.dp
                     )
-                    .background(CareTheme.colors.white000)
-            ) {
-                Text(
-                    text = chatMessage.contents
-                        .map { it.value }
-                        .joinToString(),
-                    style = CareTheme.typography.body3,
-                    color = CareTheme.colors.black,
-                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
                 )
-            }
+                .background(CareTheme.colors.white000)
+        ) {
+            Text(
+                text = chatMessage.contents.joinToString { it.value },
+                style = CareTheme.typography.body3,
+                color = CareTheme.colors.black,
+                modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+            )
         }
 
         if (isLast) {
@@ -234,9 +231,7 @@ fun CareChatReceiverTextBubble(
                 .background(CareTheme.colors.orange500),
         ) {
             Text(
-                text = chatMessage.contents
-                    .map { it.value }
-                    .joinToString(),
+                text = chatMessage.contents.joinToString { it.value },
                 style = CareTheme.typography.body3,
                 color = CareTheme.colors.white000,
                 modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
@@ -279,7 +274,7 @@ fun PreviewCareChatTextBubble() {
         senderId = "user1",
         senderType = SenderType.USER,
         contents = listOf(
-            Content(type = ContentType.TEXT, value = "안녕하세요! 문의드리고 싶어서 연락드렸습니다.")
+            Content(type = ContentType.TEXT, value = "안녕하세요!안녕하세요!안녕하세요!안녕하세요!안녕하세요!안녕하세요!안녕하세요!")
         ),
         createdAt = LocalDateTime.now().minusMinutes(5)
     )

--- a/feature/chatting-detail/src/main/java/com/idle/chatting_detail/component/CareChatTextBubble.kt
+++ b/feature/chatting-detail/src/main/java/com/idle/chatting_detail/component/CareChatTextBubble.kt
@@ -1,0 +1,18 @@
+package com.idle.chatting_detail.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.idle.domain.model.chatting.ChatMessage
+
+@Composable
+fun CareChatTextBubble(
+    chatMessage: ChatMessage,
+    modifier: Modifier = Modifier,
+    isMyChat: Boolean = false,
+) {
+    if (isMyChat) {
+
+    } else {
+
+    }
+}

--- a/feature/chatting-detail/src/main/java/com/idle/chatting_detail/component/CareChatTextBubble.kt
+++ b/feature/chatting-detail/src/main/java/com/idle/chatting_detail/component/CareChatTextBubble.kt
@@ -1,18 +1,412 @@
 package com.idle.chatting_detail.component
 
+import android.graphics.Color
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.idle.designsystem.compose.foundation.CareTheme
 import com.idle.domain.model.chatting.ChatMessage
+import com.idle.domain.model.chatting.Content
+import com.idle.domain.model.chatting.ContentType
+import com.idle.domain.model.chatting.SenderType
+import com.idle.domain.util.formatTimeToHourMinute24
+import java.time.LocalDateTime
 
 @Composable
-fun CareChatTextBubble(
+fun CareChatSenderTextBubbleWithImage(
+    imageUrl: String,
+    senderName: String,
     chatMessage: ChatMessage,
+    isLast: Boolean,
     modifier: Modifier = Modifier,
-    isMyChat: Boolean = false,
+    isRead: Boolean = false,
 ) {
-    if (isMyChat) {
+    Row(
+        verticalAlignment = Alignment.Top,
+        modifier = modifier.fillMaxWidth()
+    ) {
+        AsyncImage(
+            model = imageUrl,
+            placeholder = painterResource(com.idle.designresource.R.drawable.ic_notification_placeholder),
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .padding(end = 8.dp)
+                .clip(CircleShape)
+                .size(40.dp),
+        )
 
-    } else {
+        Column(
+            verticalArrangement = Arrangement.Top,
+            horizontalAlignment = Alignment.Start,
+            modifier = Modifier.weight(1f),
+        ) {
+            Text(
+                text = senderName,
+                style = CareTheme.typography.caption1,
+                color = CareTheme.colors.black,
+                modifier = Modifier.padding(bottom = 4.dp),
+            )
 
+            Box(
+                modifier = Modifier
+                    .wrapContentSize()
+                    .clip(
+                        RoundedCornerShape(
+                            topStart = 0.dp,
+                            topEnd = 12.dp,
+                            bottomStart = 12.dp,
+                            bottomEnd = 12.dp
+                        )
+                    )
+                    .background(CareTheme.colors.white000)
+            ) {
+                Text(
+                    text = chatMessage.contents
+                        .map { it.value }
+                        .joinToString(),
+                    style = CareTheme.typography.body3,
+                    color = CareTheme.colors.black,
+                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+                )
+            }
+        }
+
+        if (isLast) {
+            Column(
+                verticalArrangement = Arrangement.Bottom,
+                horizontalAlignment = Alignment.Start,
+                modifier = Modifier
+                    .align(Alignment.Bottom)
+                    .padding(start = 4.dp),
+            ) {
+                if (isRead) {
+                    Text(
+                        text = "읽음",
+                        style = CareTheme.typography.caption1,
+                        color = CareTheme.colors.orange500,
+                    )
+                }
+
+                Text(
+                    text = chatMessage.createdAt.formatTimeToHourMinute24(),
+                    style = CareTheme.typography.caption1,
+                    color = CareTheme.colors.gray300,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun CareChatSenderTextBubble(
+    chatMessage: ChatMessage,
+    isLast: Boolean,
+    modifier: Modifier = Modifier,
+    isRead: Boolean = false,
+) {
+    Row(modifier = modifier.fillMaxWidth()) {
+        Spacer(
+            modifier = Modifier
+                .padding(end = 8.dp)
+                .size(40.dp),
+        )
+
+        Column(
+            horizontalAlignment = Alignment.Start,
+            modifier = Modifier.weight(1f),
+        ) {
+            Box(
+                modifier = Modifier
+                    .wrapContentSize()
+                    .clip(
+                        RoundedCornerShape(
+                            topStart = 0.dp,
+                            topEnd = 12.dp,
+                            bottomStart = 12.dp,
+                            bottomEnd = 12.dp
+                        )
+                    )
+                    .background(CareTheme.colors.white000)
+            ) {
+                Text(
+                    text = chatMessage.contents
+                        .map { it.value }
+                        .joinToString(),
+                    style = CareTheme.typography.body3,
+                    color = CareTheme.colors.black,
+                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+                )
+            }
+        }
+
+        if (isLast) {
+            Column(
+                verticalArrangement = Arrangement.Bottom,
+                horizontalAlignment = Alignment.Start,
+                modifier = Modifier
+                    .align(Alignment.Bottom)
+                    .padding(start = 4.dp),
+            ) {
+                if (isRead) {
+                    Text(
+                        text = "읽음",
+                        style = CareTheme.typography.caption1,
+                        color = CareTheme.colors.orange500,
+                    )
+                }
+
+                Text(
+                    text = chatMessage.createdAt.formatTimeToHourMinute24(),
+                    style = CareTheme.typography.caption1,
+                    color = CareTheme.colors.gray300,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun CareChatReceiverTextBubble(
+    chatMessage: ChatMessage,
+    isLast: Boolean,
+    modifier: Modifier = Modifier,
+    isRead: Boolean = false,
+) {
+    Row(
+        horizontalArrangement = Arrangement.End,
+        modifier = modifier.fillMaxWidth()
+    ) {
+        if (isLast) {
+            Column(
+                verticalArrangement = Arrangement.Bottom,
+                horizontalAlignment = Alignment.End,
+                modifier = Modifier
+                    .align(Alignment.Bottom)
+                    .padding(end = 4.dp),
+            ) {
+                if (isRead) {
+                    Text(
+                        text = "읽음",
+                        style = CareTheme.typography.caption1,
+                        color = CareTheme.colors.orange500,
+                    )
+                }
+
+                Text(
+                    text = chatMessage.createdAt.formatTimeToHourMinute24(),
+                    style = CareTheme.typography.caption1,
+                    color = CareTheme.colors.gray300,
+                )
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .wrapContentSize()
+                .clip(
+                    RoundedCornerShape(
+                        topStart = 12.dp,
+                        topEnd = 12.dp,
+                        bottomStart = 12.dp,
+                        bottomEnd = 0.dp
+                    )
+                )
+                .background(CareTheme.colors.orange500),
+        ) {
+            Text(
+                text = chatMessage.contents
+                    .map { it.value }
+                    .joinToString(),
+                style = CareTheme.typography.body3,
+                color = CareTheme.colors.white000,
+                modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+            )
+        }
+    }
+}
+
+
+@Preview(showBackground = true, backgroundColor = Color.LTGRAY.toLong())
+@Composable
+fun PreviewCareChatTextBubbleWithImage() {
+    val chatMessage = ChatMessage(
+        id = "1",
+        roomId = "room1",
+        senderId = "user1",
+        senderType = SenderType.USER,
+        contents = listOf(
+            Content(type = ContentType.TEXT, value = "안녕하세요! 문의드리고 싶어서 연락드렸습니다.")
+        ),
+        createdAt = LocalDateTime.now().minusMinutes(5)
+    )
+
+    CareChatSenderTextBubbleWithImage(
+        imageUrl = "https://via.placeholder.com/40", // Placeholder 이미지 URL
+        senderName = "요양센터",
+        chatMessage = chatMessage,
+        isLast = true,
+        isRead = true,
+        modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp)
+    )
+}
+
+@Preview(showBackground = true, backgroundColor = Color.LTGRAY.toLong())
+@Composable
+fun PreviewCareChatTextBubble() {
+    val chatMessage = ChatMessage(
+        id = "1",
+        roomId = "room1",
+        senderId = "user1",
+        senderType = SenderType.USER,
+        contents = listOf(
+            Content(type = ContentType.TEXT, value = "안녕하세요! 문의드리고 싶어서 연락드렸습니다.")
+        ),
+        createdAt = LocalDateTime.now().minusMinutes(5)
+    )
+
+    CareChatSenderTextBubble(
+        chatMessage = chatMessage,
+        isLast = true,
+        isRead = true,
+        modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp)
+    )
+}
+
+@Preview(showBackground = true, backgroundColor = Color.LTGRAY.toLong())
+@Composable
+fun PreviewCareCardChatSender() {
+    val chatMessage = ChatMessage(
+        id = "1",
+        roomId = "room1",
+        senderId = "user1",
+        senderType = SenderType.USER,
+        contents = listOf(
+            Content(type = ContentType.TEXT, value = "안녕하세요! 문의드리고 싶어서 연락드렸습니다.")
+        ),
+        createdAt = LocalDateTime.now().minusMinutes(5)
+    )
+
+    Column(modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp)) {
+        CareChatSenderTextBubbleWithImage(
+            imageUrl = "https://via.placeholder.com/40", // Placeholder 이미지 URL
+            senderName = "요양센터",
+            chatMessage = chatMessage,
+            isLast = false,
+            isRead = false,
+        )
+
+        CareChatSenderTextBubble(
+            chatMessage = chatMessage,
+            isLast = true,
+            isRead = true,
+            modifier = Modifier.padding(top = 6.dp)
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = Color.LTGRAY.toLong())
+@Composable
+fun PreviewCareCardChatReceiver() {
+    val chatMessage = ChatMessage(
+        id = "1",
+        roomId = "room1",
+        senderId = "user1",
+        senderType = SenderType.USER,
+        contents = listOf(
+            Content(type = ContentType.TEXT, value = "안녕하세요! 문의드리고 싶어서 연락드렸습니다.")
+        ),
+        createdAt = LocalDateTime.now().minusMinutes(5)
+    )
+
+    Column(modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp)) {
+        CareChatReceiverTextBubble(
+            chatMessage = chatMessage,
+            isLast = false,
+            isRead = false,
+        )
+
+        CareChatReceiverTextBubble(
+            chatMessage = chatMessage,
+            isLast = true,
+            isRead = true,
+            modifier = Modifier.padding(top = 6.dp)
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = Color.LTGRAY.toLong())
+@Composable
+fun PreviewCareCardChatExample() {
+    val chatMessage1 = ChatMessage(
+        id = "1",
+        roomId = "room1",
+        senderId = "user1",
+        senderType = SenderType.USER,
+        contents = listOf(
+            Content(type = ContentType.TEXT, value = "안녕하세요! 문의드리고 싶어서 연락드렸습니다.")
+        ),
+        createdAt = LocalDateTime.now().minusMinutes(5)
+    )
+    val chatMessage2 = ChatMessage(
+        id = "1",
+        roomId = "room1",
+        senderId = "user1",
+        senderType = SenderType.USER,
+        contents = listOf(
+            Content(type = ContentType.TEXT, value = "안녕하세요! 문의드리고 싶어서 연락드렸습니다.")
+        ),
+        createdAt = LocalDateTime.now().minusMinutes(5)
+    )
+
+
+    Column(modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp)) {
+        CareChatSenderTextBubbleWithImage(
+            imageUrl = "https://via.placeholder.com/40", // Placeholder 이미지 URL
+            senderName = "요양센터",
+            chatMessage = chatMessage1,
+            isLast = false,
+            isRead = false,
+        )
+
+        CareChatSenderTextBubble(
+            chatMessage = chatMessage1,
+            isLast = true,
+            isRead = true,
+            modifier = Modifier.padding(top = 6.dp),
+        )
+
+        CareChatReceiverTextBubble(
+            chatMessage = chatMessage2,
+            isLast = false,
+            isRead = false,
+            modifier = Modifier.padding(top = 16.dp),
+        )
+
+        CareChatReceiverTextBubble(
+            chatMessage = chatMessage2,
+            isLast = true,
+            isRead = true,
+            modifier = Modifier.padding(top = 6.dp)
+        )
     }
 }

--- a/feature/chatting-detail/src/main/java/com/idle/chatting_detail/component/CareChatTextField.kt
+++ b/feature/chatting-detail/src/main/java/com/idle/chatting_detail/component/CareChatTextField.kt
@@ -1,0 +1,80 @@
+package com.idle.chatting_detail.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import com.idle.designsystem.compose.foundation.CareTheme
+
+@Composable
+internal fun CareChatTextField(
+    value: String,
+    onValueChanged: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    hint: String = "",
+    keyboardType: KeyboardType = KeyboardType.Text,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    onDone: () -> Unit = {},
+) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val interactionSource = remember { MutableInteractionSource() }
+    val boarderStroke = BorderStroke(
+        width = 1.dp,
+        color = CareTheme.colors.gray100,
+    )
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .wrapContentHeight()
+            .border(
+                border = boarderStroke,
+                shape = RoundedCornerShape(50.dp)
+            )
+    ) {
+        BasicTextField(
+            value = value,
+            onValueChange = onValueChanged,
+            interactionSource = interactionSource,
+            visualTransformation = visualTransformation,
+            keyboardOptions = KeyboardOptions(
+                keyboardType = keyboardType,
+                imeAction = ImeAction.Done
+            ),
+            keyboardActions = KeyboardActions(onDone = {
+                keyboardController?.hide()
+                onDone()
+            }),
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 20.dp, vertical = 7.dp),
+            decorationBox = { innerTextField ->
+                if (value.isEmpty()) {
+                    Text(
+                        text = hint,
+                        style = CareTheme.typography.body3,
+                        color = CareTheme.colors.gray300,
+                    )
+                }
+
+                innerTextField()
+            }
+        )
+    }
+}

--- a/feature/chatting-detail/src/main/res/navigation/nav_chatting_detail.xml
+++ b/feature/chatting-detail/src/main/res/navigation/nav_chatting_detail.xml
@@ -13,7 +13,13 @@
             android:name="chattingRoomId"
             app:argType="string" />
         <argument
-            android:name="userId"
+            android:name="receiverId"
+            app:argType="string" />
+        <argument
+            android:name="receiverUserType"
+            app:argType="string" />
+        <argument
+            android:name="senderId"
             app:argType="string" />
     </fragment>
 </navigation>

--- a/feature/worker/chatting/src/main/java/com/idle/worker/chatting/WorkerChattingFragment.kt
+++ b/feature/worker/chatting/src/main/java/com/idle/worker/chatting/WorkerChattingFragment.kt
@@ -39,6 +39,7 @@ import com.idle.compose.clickable
 import com.idle.designsystem.compose.component.CareHeadingTopBar
 import com.idle.designsystem.compose.component.LoadingCircle
 import com.idle.designsystem.compose.foundation.CareTheme
+import com.idle.domain.model.auth.UserType
 import com.idle.domain.model.chatting.ChatRoom
 import com.idle.domain.util.formatRelativeDateTime
 import dagger.hilt.android.AndroidEntryPoint
@@ -125,7 +126,9 @@ internal fun ChatRoomItem(
                 navigateTo(
                     DeepLinkDestination.ChattingDetail(
                         chattingRoomId = chatRoom.id,
-                        userId = chatRoom.receiver,
+                        receiverId = chatRoom.receiver,
+                        receiverUserType = UserType.WORKER.apiValue,
+                        senderId = chatRoom.sender,
                     )
                 )
             },

--- a/feature/worker/chatting/src/main/java/com/idle/worker/chatting/WorkerChattingFragment.kt
+++ b/feature/worker/chatting/src/main/java/com/idle/worker/chatting/WorkerChattingFragment.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -21,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -145,9 +147,11 @@ internal fun ChatRoomItem(
                 error = painterResource(com.idle.designresource.R.drawable.ic_notification_placeholder),
                 onError = { Log.d("test", chatRoom.profileImageUrl) },
                 contentDescription = "",
+                contentScale = ContentScale.Crop,
                 modifier = Modifier
-                    .align(Alignment.CenterVertically)
                     .padding(end = 12.dp)
+                    .align(Alignment.CenterVertically)
+                    .clip(CircleShape)
                     .size(48.dp),
             )
 

--- a/feature/worker/home/src/main/java/com/idle/worker/home/WorkerHomeFragment.kt
+++ b/feature/worker/home/src/main/java/com/idle/worker/home/WorkerHomeFragment.kt
@@ -308,7 +308,7 @@ internal fun WorkerHomeScreen(
                             Spacer(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .height(28.dp)
+                                    .height(80.dp)
                             )
                         }
                     }

--- a/feature/worker/home/src/main/java/com/idle/worker/home/WorkerHomeFragment.kt
+++ b/feature/worker/home/src/main/java/com/idle/worker/home/WorkerHomeFragment.kt
@@ -566,7 +566,7 @@ private fun WorkerWorkNetCard(
             )
 
             Row(
-                verticalAlignment = Alignment.CenterVertically,
+                verticalAlignment = Alignment.Top,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(bottom = 2.dp)
@@ -580,11 +580,12 @@ private fun WorkerWorkNetCard(
                     text = "${jobPosting.workingSchedule} | ${jobPosting.workingTime}",
                     style = CareTheme.typography.body3,
                     color = CareTheme.colors.gray500,
+                    modifier = Modifier.padding(top = 1.dp),
                 )
             }
 
             Row(
-                verticalAlignment = Alignment.CenterVertically,
+                verticalAlignment = Alignment.Top,
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Image(
@@ -596,6 +597,7 @@ private fun WorkerWorkNetCard(
                     text = jobPosting.payInfo,
                     style = CareTheme.typography.body3,
                     color = CareTheme.colors.gray500,
+                    modifier = Modifier.padding(top = 1.dp),
                 )
             }
         }


### PR DESCRIPTION
## 1. 🔥 변경된 내용

- **채팅방 말풍선 컴포넌트 구현**
- **채팅방 UI 구현**
- **워크넷 카드 줄바꿈 이슈 해결**

[채팅방 말풍선 UI 요구사항 및 설계](https://grove-maraca-55d.notion.site/a1d67fb51dee4bd7b10f06b1772aad41?pvs=4)

## 2. 📸 스크린샷(선택)

- **채팅방 말풍선 컴포넌트 구현**

<img width="528" alt="image" src="https://github.com/user-attachments/assets/a195af2c-6ab0-45b8-8c29-e04bac1c6f0f">

- **채팅방 UI 구현**

![image](https://github.com/user-attachments/assets/6bbd50c6-e2b4-4e85-975b-819f5f553e04)

- **워크넷 카드 줄바꿈 이슈 해결**

**이전**

![image](https://github.com/user-attachments/assets/ab35443b-be10-412b-a2da-622fc5fabf59)

**이후**

![image](https://github.com/user-attachments/assets/29ad7e8c-8e31-48eb-ad1c-975bee929db0)

## 3. 💡 알게된 부분

## weight()를 쓸 때 false를 주면..

`Modifier.weight(1f, false)` 에서 기본값은 true이지만 false를 주게되면 남은 공간을 모두 차지하는 것이 아니라,
남은 뷰들의 배치를 파괴하지 않는 선에서 배치한다.

즉, false로 두면 Min값은 해당 컴포넌트의 크기, Max 값은 나머지 뷰들을 배치한 뒤의 남은 공간이다.

반면 기본값인 true를 설정하게되면 우선적으로 배치되며 남은 공간을 모두 차지하게 된다.