### PR TITLE
[IDLE-491] 간헐적으로 바텀 네비게이션 뷰가 안보이던 버그 해결

### DIFF
--- a/presentation/src/main/java/com/idle/presentation/MainActivity.kt
+++ b/presentation/src/main/java/com/idle/presentation/MainActivity.kt
@@ -31,6 +31,7 @@ import com.idle.presentation.forceupdate.ForceUpdateFragment
 import com.idle.presentation.network.NetworkObserver
 import com.idle.presentation.network.NetworkState
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.delay
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -139,6 +140,7 @@ class MainActivity : AppCompatActivity() {
             repeatOnStarted {
                 navigationMenuType.collect { menuType ->
                     this@MainActivity.setNavigationMenuType(menuType)
+                    delay(310L)
                 }
             }
 


### PR DESCRIPTION
## 1. 🔥 변경된 내용
- **간헐적으로 바텀 네비게이션 뷰가 안보이던 버그 해결**

## 3. 💡 알게된 부분

아래와 같이 xml 네비게이션 뷰의 애니메이션이 있는데,

slideUp은 애니메이션이 시작됨과 동시에 나타나는 반면,

slideDown은 애니메이션이 종료됨과 동시에 바텀 네비게이션 뷰의 Visible을 Gone으로 처리.

이건 고질적으로 어쩔 수 없는데, 왜냐하면 SlideDown에서 Visible을 시작하자마자 Gone으로 처리하면 내려가는 애니메이션이 아예 안보여지기 때문이고,

SlideUp은 시작하자마자 visible을 켜줘야 올라가는 애니메이션이 보여지기 때문이다.

```kotlin
    private fun slideUp(view: View) {
        view.measure(
            ViewGroup.LayoutParams.WRAP_CONTENT,
            ViewGroup.LayoutParams.WRAP_CONTENT
        )
        val targetHeight = view.measuredHeight
        view.layoutParams.height = 0

        val slide = ValueAnimator.ofInt(0, targetHeight)
        slide.addUpdateListener { valueAnimator ->
            val animatedValue = valueAnimator.animatedValue as Int
            val layoutParams = view.layoutParams
            layoutParams.height = animatedValue
            view.layoutParams = layoutParams
        }
        slide.duration = 300
        slide.addListener(object : Animator.AnimatorListener {
            override fun onAnimationStart(animation: Animator) {
                view.visibility = View.VISIBLE
            }

            override fun onAnimationEnd(animation: Animator) {
                view.isClickable = true
            }

            override fun onAnimationCancel(animation: Animator) {}
            override fun onAnimationRepeat(animation: Animator) {}
        })
        slide.start()
    }

    private fun slideDown(view: View) {
        val initialHeight = view.measuredHeight

        val slide = ValueAnimator.ofInt(initialHeight, 0)
        slide.addUpdateListener { valueAnimator ->
            val animatedValue = valueAnimator.animatedValue as Int
            val layoutParams = view.layoutParams
            layoutParams.height = animatedValue
            view.layoutParams = layoutParams
        }
        slide.duration = 300
        slide.addListener(object : Animator.AnimatorListener {
            override fun onAnimationStart(animation: Animator) {}

            override fun onAnimationEnd(animation: Animator) {
                view.visibility = View.GONE
                view.isClickable = false
            }

            override fun onAnimationCancel(animation: Animator) {}
            override fun onAnimationRepeat(animation: Animator) {}
        })
        slide.start()
    }
```

그렇기 때문에 HIDE 상태에서 빠르게 WORKER 혹은 CENTER 상태가 되어서 BorromNavigationView의

slideDown, slideUp이 300Ms 안으로 따당 호출되면 slideUp이 뒤늦게 시작됨에도 불구하고 Visible.Gone이 더 늦게 호출되어서 씹히는 현상.

그래서 임시적으로 menuType을 collect하는 곳에서 310ms 의 delay를 주고 레이싱현상이 없도록 처리하였다.