### PR TITLE
[IDLE-466] 웹소켓 연결 및 해제, 데이터 파이프 라인 연결, 에러가 났을 경우 Crashlytics로 로깅하도록 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     implementation(projects.core.data)
     implementation(projects.core.domain)
     implementation(projects.presentation)
+    implementation(projects.core.analytics)
 
     implementation(libs.firebase.messaging)
 }

--- a/core/analytics/src/main/java/com/idle/analytics/businessmetric/AmplitudeAnalyticsHelper.kt
+++ b/core/analytics/src/main/java/com/idle/analytics/businessmetric/AmplitudeAnalyticsHelper.kt
@@ -1,4 +1,4 @@
-package com.idle.analytics.helper
+package com.idle.analytics.businessmetric
 
 import com.amplitude.android.Amplitude
 import com.amplitude.core.events.BaseEvent

--- a/core/analytics/src/main/java/com/idle/analytics/businessmetric/AnalyticsHelper.kt
+++ b/core/analytics/src/main/java/com/idle/analytics/businessmetric/AnalyticsHelper.kt
@@ -1,4 +1,4 @@
-package com.idle.analytics.helper
+package com.idle.analytics.businessmetric
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect

--- a/core/analytics/src/main/java/com/idle/analytics/businessmetric/DebugAnalyticsHelper.kt
+++ b/core/analytics/src/main/java/com/idle/analytics/businessmetric/DebugAnalyticsHelper.kt
@@ -1,4 +1,4 @@
-package com.idle.analytics.helper
+package com.idle.analytics.businessmetric
 
 import android.util.Log
 import com.idle.analytics.AnalyticsEvent

--- a/core/analytics/src/main/java/com/idle/analytics/businessmetric/LocalAnalyticsHelper.kt
+++ b/core/analytics/src/main/java/com/idle/analytics/businessmetric/LocalAnalyticsHelper.kt
@@ -1,4 +1,4 @@
-package com.idle.analytics.helper
+package com.idle.analytics.businessmetric
 
 import androidx.compose.runtime.staticCompositionLocalOf
 

--- a/core/analytics/src/main/java/com/idle/analytics/businessmetric/NoOpAnalyticsHelper.kt
+++ b/core/analytics/src/main/java/com/idle/analytics/businessmetric/NoOpAnalyticsHelper.kt
@@ -1,4 +1,4 @@
-package com.idle.analytics.helper
+package com.idle.analytics.businessmetric
 
 import com.idle.analytics.AnalyticsEvent
 

--- a/core/analytics/src/main/java/com/idle/analytics/di/AnalyticsModule.kt
+++ b/core/analytics/src/main/java/com/idle/analytics/di/AnalyticsModule.kt
@@ -74,7 +74,7 @@ object AnalyticsModule {
         @DebugErrorHelper debugErrorHelper: ErrorLoggingHelper,
         @ReleaseErrorHelper releaseErrorHelper: ErrorLoggingHelper,
     ): ErrorLoggingHelper {
-        return if (BuildConfig.BUILD_TYPE == "DEBUG") releaseErrorHelper
+        return if (BuildConfig.BUILD_TYPE == "RELEASE") releaseErrorHelper
         else debugErrorHelper
     }
 }

--- a/core/analytics/src/main/java/com/idle/analytics/di/AnalyticsModule.kt
+++ b/core/analytics/src/main/java/com/idle/analytics/di/AnalyticsModule.kt
@@ -3,10 +3,14 @@ package com.idle.analytics.di
 import android.content.Context
 import com.amplitude.android.Amplitude
 import com.amplitude.android.Configuration
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.idle.analytics.BuildConfig
-import com.idle.analytics.helper.AmplitudeAnalyticsHelper
-import com.idle.analytics.helper.AnalyticsHelper
-import com.idle.analytics.helper.DebugAnalyticsHelper
+import com.idle.analytics.businessmetric.AmplitudeAnalyticsHelper
+import com.idle.analytics.businessmetric.AnalyticsHelper
+import com.idle.analytics.businessmetric.DebugAnalyticsHelper
+import com.idle.analytics.error.CrashlyticsErrorLoggingHelper
+import com.idle.analytics.error.DebugErrorLoggingHelper
+import com.idle.analytics.error.ErrorLoggingHelper
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -21,6 +25,10 @@ object AnalyticsModule {
 
     @Provides
     @Singleton
+    fun provideFirebaseCrashlytics(): FirebaseCrashlytics = FirebaseCrashlytics.getInstance()
+
+    @Provides
+    @Singleton
     fun providesAmplitude(@ApplicationContext context: Context): Amplitude = Amplitude(
         Configuration(
             apiKey = BuildConfig.AMPLITUDE_API_KEY,
@@ -30,34 +38,59 @@ object AnalyticsModule {
 
     @Provides
     @Singleton
-    @DebugLogger
+    @DebugHelper
     fun provideDebugAnalyticsHelper(): AnalyticsHelper = DebugAnalyticsHelper()
 
     @Provides
     @Singleton
-    @ReleaseLogger
-    fun provideReleaseAnalyticsHelper(
-        amplitude: Amplitude
-    ): AnalyticsHelper = AmplitudeAnalyticsHelper(amplitude)
+    @ReleaseHelper
+    fun provideReleaseAnalyticsHelper(amplitude: Amplitude): AnalyticsHelper =
+        AmplitudeAnalyticsHelper(amplitude)
 
     @Provides
     @Singleton
     fun provideAnalyticsHelper(
-        @DebugLogger debugHelper: AnalyticsHelper,
-        @ReleaseLogger releaseHelper: AnalyticsHelper
+        @DebugHelper debugHelper: AnalyticsHelper,
+        @ReleaseHelper releaseHelper: AnalyticsHelper
     ): AnalyticsHelper {
-        return if (BuildConfig.BUILD_TYPE == "RELEASE") {
-            releaseHelper
-        } else {
-            debugHelper
-        }
+        return if (BuildConfig.BUILD_TYPE == "RELEASE") releaseHelper
+        else debugHelper
+    }
+
+    @Provides
+    @Singleton
+    @DebugErrorHelper
+    fun provideDebugErrorLoggingHelper(): ErrorLoggingHelper = DebugErrorLoggingHelper()
+
+    @Provides
+    @Singleton
+    @ReleaseErrorHelper
+    fun provideReleaseErrorLoggingHelper(firebaseCrashlytics: FirebaseCrashlytics): ErrorLoggingHelper =
+        CrashlyticsErrorLoggingHelper(firebaseCrashlytics)
+
+    @Provides
+    @Singleton
+    fun provideErrorLoggingHelper(
+        @DebugErrorHelper debugErrorHelper: ErrorLoggingHelper,
+        @ReleaseErrorHelper releaseErrorHelper: ErrorLoggingHelper,
+    ): ErrorLoggingHelper {
+        return if (BuildConfig.BUILD_TYPE == "DEBUG") releaseErrorHelper
+        else debugErrorHelper
     }
 }
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
-annotation class DebugLogger
+annotation class DebugHelper
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
-annotation class ReleaseLogger
+annotation class ReleaseHelper
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DebugErrorHelper
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ReleaseErrorHelper

--- a/core/analytics/src/main/java/com/idle/analytics/error/CrashlyticsErrorLoggingHelper.kt
+++ b/core/analytics/src/main/java/com/idle/analytics/error/CrashlyticsErrorLoggingHelper.kt
@@ -1,0 +1,12 @@
+package com.idle.analytics.error
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import javax.inject.Inject
+
+class CrashlyticsErrorLoggingHelper @Inject constructor(
+    private val firebaseCrashlytics: FirebaseCrashlytics,
+) : ErrorLoggingHelper {
+    override fun logError(exception: Throwable) {
+        firebaseCrashlytics.recordException(exception)
+    }
+}

--- a/core/analytics/src/main/java/com/idle/analytics/error/DebugErrorLoggingHelper.kt
+++ b/core/analytics/src/main/java/com/idle/analytics/error/DebugErrorLoggingHelper.kt
@@ -1,0 +1,10 @@
+package com.idle.analytics.error
+
+import android.util.Log
+import javax.inject.Inject
+
+class DebugErrorLoggingHelper @Inject constructor() : ErrorLoggingHelper {
+    override fun logError(exception: Throwable) {
+        Log.e("DebugErrorLoggingHelper", exception.stackTraceToString())
+    }
+}

--- a/core/analytics/src/main/java/com/idle/analytics/error/ErrorLoggingHelper.kt
+++ b/core/analytics/src/main/java/com/idle/analytics/error/ErrorLoggingHelper.kt
@@ -1,0 +1,5 @@
+package com.idle.analytics.error
+
+interface ErrorLoggingHelper {
+    fun logError(exception: Throwable)
+}

--- a/core/common-ui/binding/src/main/java/com/idle/binding/base/BaseBindingFragment.kt
+++ b/core/common-ui/binding/src/main/java/com/idle/binding/base/BaseBindingFragment.kt
@@ -6,7 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.Fragment
-import com.idle.analytics.helper.AnalyticsHelper
+import com.idle.analytics.businessmetric.AnalyticsHelper
 import javax.inject.Inject
 
 typealias Inflate<T> = (LayoutInflater, ViewGroup?, Boolean) -> T

--- a/core/common-ui/compose/src/main/java/com/idle/compose/base/BaseComposeFragment.kt
+++ b/core/common-ui/compose/src/main/java/com/idle/compose/base/BaseComposeFragment.kt
@@ -10,8 +10,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
-import com.idle.analytics.helper.AnalyticsHelper
-import com.idle.analytics.helper.LocalAnalyticsHelper
+import com.idle.analytics.businessmetric.AnalyticsHelper
+import com.idle.analytics.businessmetric.LocalAnalyticsHelper
 import com.idle.binding.base.BaseViewModel
 import javax.inject.Inject
 

--- a/core/data/src/main/java/com/idle/data/di/DataModule.kt
+++ b/core/data/src/main/java/com/idle/data/di/DataModule.kt
@@ -3,12 +3,14 @@ package com.idle.data.di
 import com.idle.data.repository.auth.AuthRepositoryImpl
 import com.idle.data.repository.auth.TokenManagerImpl
 import com.idle.data.repository.auth.TokenRepositoryImpl
+import com.idle.data.repository.chatting.ChattingRepositoryImpl
 import com.idle.data.repository.config.ConfigRepositoryImpl
 import com.idle.data.repository.jobposting.JobPostingRepositoryImpl
 import com.idle.data.repository.notification.NotificationRepositoryImpl
 import com.idle.data.repository.profile.ProfileRepositoryImpl
 import com.idle.domain.repositorry.auth.AuthRepository
 import com.idle.domain.repositorry.auth.TokenRepository
+import com.idle.domain.repositorry.chatting.ChattingRepository
 import com.idle.domain.repositorry.config.ConfigRepository
 import com.idle.domain.repositorry.jobposting.JobPostingRepository
 import com.idle.domain.repositorry.notification.NotificationRepository
@@ -58,6 +60,12 @@ abstract class DataModule {
     abstract fun bindsNotificationRepository(
         notificationRepositoryImpl: NotificationRepositoryImpl,
     ): NotificationRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindsChattingRepository(
+        chattingRepositoryImpl: ChattingRepositoryImpl,
+    ): ChattingRepository
 
     @Binds
     @Singleton

--- a/core/data/src/main/java/com/idle/data/repository/chatting/ChattingRepositoryImpl.kt
+++ b/core/data/src/main/java/com/idle/data/repository/chatting/ChattingRepositoryImpl.kt
@@ -1,7 +1,11 @@
 package com.idle.data.repository.chatting
 
+import com.idle.domain.model.chatting.ChatMessage
 import com.idle.domain.repositorry.chatting.ChattingRepository
 import com.idle.network.source.websocket.WebSocketDataSource
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class ChattingRepositoryImpl @Inject constructor(
@@ -11,4 +15,9 @@ class ChattingRepositoryImpl @Inject constructor(
 
     override suspend fun disconnectWebSocket(): Result<Unit> =
         webSocketDataSource.disconnectWebSocket()
+
+    override fun subscribeChatMessage(): Flow<ChatMessage> =
+        webSocketDataSource.getChatMessageFlow()
+            .filterNotNull()
+            .map { it.toVO() }
 }

--- a/core/data/src/main/java/com/idle/data/repository/chatting/ChattingRepositoryImpl.kt
+++ b/core/data/src/main/java/com/idle/data/repository/chatting/ChattingRepositoryImpl.kt
@@ -1,0 +1,14 @@
+package com.idle.data.repository.chatting
+
+import com.idle.domain.repositorry.chatting.ChattingRepository
+import com.idle.network.source.websocket.WebSocketDataSource
+import javax.inject.Inject
+
+class ChattingRepositoryImpl @Inject constructor(
+    private val webSocketDataSource: WebSocketDataSource,
+) : ChattingRepository {
+    override suspend fun connectWebSocket(): Result<Unit> = webSocketDataSource.connectWebSocket()
+
+    override suspend fun disconnectWebSocket(): Result<Unit> =
+        webSocketDataSource.disconnectWebSocket()
+}

--- a/core/data/src/main/java/com/idle/data/repository/profile/ProfileRepositoryImpl.kt
+++ b/core/data/src/main/java/com/idle/data/repository/profile/ProfileRepositoryImpl.kt
@@ -104,6 +104,8 @@ class ProfileRepositoryImpl @Inject constructor(
             }
 
         WorkerProfile(
+            workerId = properties["workerId"]
+                ?: throw IllegalArgumentException("Missing workerId"),
             workerName = properties["workerName"]
                 ?: throw IllegalArgumentException("Missing workerName"),
             age = properties["age"]?.toInt() ?: throw NumberFormatException("Invalid age format"),

--- a/core/data/src/test/java/com/idle/data/repository/profile/ProfileRepositoryImplTest.kt
+++ b/core/data/src/test/java/com/idle/data/repository/profile/ProfileRepositoryImplTest.kt
@@ -41,6 +41,7 @@ class ProfileRepositoryImplTest {
     )
 
     private val workerProfile = WorkerProfile(
+        workerId = "test",
         workerName = "Test Worker",
         age = 30,
         gender = Gender.MAN,

--- a/core/domain/src/main/kotlin/com/idle/domain/model/chatting/ChatMessage.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/model/chatting/ChatMessage.kt
@@ -9,7 +9,9 @@ data class ChatMessage(
     val senderType: SenderType,
     val contents: List<Content>,
     val createdAt: LocalDateTime,
-)
+) {
+    fun printPlainContents(): String = contents.joinToString { it.value }
+}
 
 data class Content(
     val type: ContentType,

--- a/core/domain/src/main/kotlin/com/idle/domain/model/chatting/ChatMessage.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/model/chatting/ChatMessage.kt
@@ -17,9 +17,21 @@ data class Content(
 )
 
 enum class SenderType {
-    USER,
+    USER, UNKNOWN;
+
+    companion object {
+        fun create(value: String?): SenderType {
+            return SenderType.entries.firstOrNull { it.name == value } ?: UNKNOWN
+        }
+    }
 }
 
 enum class ContentType {
-    TEXT, IMAGE;
+    TEXT, IMAGE, UNKNOWN;
+
+    companion object {
+        fun create(value: String?): ContentType {
+            return ContentType.entries.firstOrNull { it.name == value } ?: UNKNOWN
+        }
+    }
 }

--- a/core/domain/src/main/kotlin/com/idle/domain/model/chatting/ChatRoom.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/model/chatting/ChatRoom.kt
@@ -10,5 +10,5 @@ data class ChatRoom(
     val lastMessage: String,
     val lastSentAt: LocalDateTime,
     val unReadMessageCount: Int,
-    val profileImageUrl: String,
+    val profileImageUrl: String?,
 )

--- a/core/domain/src/main/kotlin/com/idle/domain/model/error/ErrorHandler.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/model/error/ErrorHandler.kt
@@ -6,7 +6,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class ErrorHandlerHelper @Inject constructor() {
+class ErrorHandler @Inject constructor() {
     private val _errorEvent = MutableSharedFlow<Throwable>(extraBufferCapacity = 1)
     val errorEvent = _errorEvent.asSharedFlow()
 

--- a/core/domain/src/main/kotlin/com/idle/domain/model/profile/WorkerProfile.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/model/profile/WorkerProfile.kt
@@ -3,6 +3,7 @@ package com.idle.domain.model.profile
 import com.idle.domain.model.auth.Gender
 
 data class WorkerProfile(
+    val workerId: String,
     val workerName: String,
     val age: Int,
     val gender: Gender,

--- a/core/domain/src/main/kotlin/com/idle/domain/repositorry/chatting/ChattingRepository.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/repositorry/chatting/ChattingRepository.kt
@@ -1,0 +1,6 @@
+package com.idle.domain.repositorry.chatting
+
+interface ChattingRepository {
+    suspend fun connectWebSocket(): Result<Unit>
+    suspend fun disconnectWebSocket(): Result<Unit>
+}

--- a/core/domain/src/main/kotlin/com/idle/domain/repositorry/chatting/ChattingRepository.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/repositorry/chatting/ChattingRepository.kt
@@ -1,6 +1,10 @@
 package com.idle.domain.repositorry.chatting
 
+import com.idle.domain.model.chatting.ChatMessage
+import kotlinx.coroutines.flow.Flow
+
 interface ChattingRepository {
     suspend fun connectWebSocket(): Result<Unit>
     suspend fun disconnectWebSocket(): Result<Unit>
+    fun subscribeChatMessage(): Flow<ChatMessage>
 }

--- a/core/domain/src/main/kotlin/com/idle/domain/usecase/chatting/ConnectWebSocketUseCase.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/usecase/chatting/ConnectWebSocketUseCase.kt
@@ -1,0 +1,10 @@
+package com.idle.domain.usecase.chatting
+
+import com.idle.domain.repositorry.chatting.ChattingRepository
+import javax.inject.Inject
+
+class ConnectWebSocketUseCase @Inject constructor(
+    private val chattingRepository: ChattingRepository,
+) {
+    suspend operator fun invoke(): Result<Unit> =  chattingRepository.connectWebSocket()
+}

--- a/core/domain/src/main/kotlin/com/idle/domain/usecase/chatting/DisconnectWebSocketUseCase.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/usecase/chatting/DisconnectWebSocketUseCase.kt
@@ -1,0 +1,10 @@
+package com.idle.domain.usecase.chatting
+
+import com.idle.domain.repositorry.chatting.ChattingRepository
+import javax.inject.Inject
+
+class DisconnectWebSocketUseCase @Inject constructor(
+    private val chattingRepository: ChattingRepository,
+) {
+    suspend operator fun invoke() = chattingRepository.disconnectWebSocket()
+}

--- a/core/domain/src/main/kotlin/com/idle/domain/usecase/chatting/SubscribeChatMessageUseCase.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/usecase/chatting/SubscribeChatMessageUseCase.kt
@@ -1,0 +1,12 @@
+package com.idle.domain.usecase.chatting
+
+import com.idle.domain.model.chatting.ChatMessage
+import com.idle.domain.repositorry.chatting.ChattingRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class SubscribeChatMessageUseCase @Inject constructor(
+    private val chattingRepository: ChattingRepository,
+) {
+    operator fun invoke(): Flow<ChatMessage> = chattingRepository.subscribeChatMessage()
+}

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -19,6 +19,11 @@ android {
                 "CARE_BASE_URL",
                 "\"${properties["CARE_DEV_BASE_URL"]}\"",
             )
+            buildConfigField(
+                "String",
+                "CARE_WEBSOCKET_URL",
+                "\"${properties["CARE_DEV_WEBSOCKET_URL"]}\"",
+            )
         }
         release {
             buildConfigField(
@@ -26,7 +31,11 @@ android {
                 "CARE_BASE_URL",
                 "\"${properties["CARE_PROD_BASE_URL"]}\"",
             )
-
+            buildConfigField(
+                "String",
+                "CARE_WEBSOCKET_URL",
+                "\"${properties["CARE_PROD_WEBSOCKET_URL"]}\"",
+            )
         }
     }
 

--- a/core/network/src/main/java/com/idle/network/di/RetrofitModule.kt
+++ b/core/network/src/main/java/com/idle/network/di/RetrofitModule.kt
@@ -20,6 +20,8 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import java.util.concurrent.TimeUnit
+import javax.inject.Qualifier
 import javax.inject.Singleton
 
 @Module
@@ -39,6 +41,7 @@ object RetrofitModule {
 
     @Singleton
     @Provides
+    @AuthOkHttpClient
     fun provideOkHttpClient(
         authInterceptor: AuthInterceptor,
         careAuthenticator: CareAuthenticator,
@@ -58,9 +61,17 @@ object RetrofitModule {
 
     @Singleton
     @Provides
+    @WebSocketOkHttpClient
+    fun provideWebSocketOkHttpClient(): OkHttpClient = OkHttpClient.Builder()
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(0, TimeUnit.MILLISECONDS)
+        .build()
+
+    @Singleton
+    @Provides
     fun providesAuthApi(
         json: Json,
-        okHttpClient: OkHttpClient,
+        @AuthOkHttpClient okHttpClient: OkHttpClient,
     ): AuthApi = Retrofit.Builder()
         .client(okHttpClient)
         .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
@@ -72,7 +83,7 @@ object RetrofitModule {
     @Provides
     fun providesJobPostingApi(
         json: Json,
-        okHttpClient: OkHttpClient,
+        @AuthOkHttpClient okHttpClient: OkHttpClient,
     ): JobPostingApi = Retrofit.Builder()
         .client(okHttpClient)
         .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
@@ -84,7 +95,7 @@ object RetrofitModule {
     @Provides
     fun providesUserApi(
         json: Json,
-        okHttpClient: OkHttpClient,
+        @AuthOkHttpClient okHttpClient: OkHttpClient,
     ): UserApi = Retrofit.Builder()
         .client(okHttpClient)
         .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
@@ -96,7 +107,7 @@ object RetrofitModule {
     @Provides
     fun providesNotificationApi(
         json: Json,
-        okHttpClient: OkHttpClient,
+        @AuthOkHttpClient okHttpClient: OkHttpClient,
     ): NotificationApi = Retrofit.Builder()
         .client(okHttpClient)
         .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
@@ -104,3 +115,11 @@ object RetrofitModule {
         .build()
         .create(NotificationApi::class.java)
 }
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class AuthOkHttpClient
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class WebSocketOkHttpClient

--- a/core/network/src/main/java/com/idle/network/model/chatting/GetChattingResponse.kt
+++ b/core/network/src/main/java/com/idle/network/model/chatting/GetChattingResponse.kt
@@ -1,3 +1,37 @@
 package com.idle.network.model.chatting
 
-data class GetChattingResponse()
+import com.idle.domain.model.chatting.ChatMessage
+import com.idle.domain.model.chatting.Content
+import com.idle.domain.model.chatting.ContentType
+import com.idle.domain.model.chatting.SenderType
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+data class ChatMessageResponse(
+    val id: String? = null,
+    val roomId: String? = null,
+    val senderId: String? = null,
+    val senderType: String? = null,
+    val contents: List<ContentResponse>? = null,
+    val createdAt: String? = null,
+) {
+    fun toVO() = ChatMessage(
+        id = id ?: "-1",
+        roomId = roomId ?: "-1",
+        senderId = senderId ?: "-1",
+        senderType = SenderType.create(senderType),
+        contents = contents?.map { it.toVO() } ?: emptyList(),
+        createdAt = createdAt?.let { LocalDateTime.parse(it, DateTimeFormatter.ISO_DATE_TIME) }
+            ?: LocalDateTime.MIN,
+    )
+}
+
+data class ContentResponse(
+    val type: String? = null,
+    val value: String? = null,
+) {
+    fun toVO() = Content(
+        type = ContentType.create(type),
+        value = value ?: "",
+    )
+}

--- a/core/network/src/main/java/com/idle/network/model/chatting/GetChattingResponse.kt
+++ b/core/network/src/main/java/com/idle/network/model/chatting/GetChattingResponse.kt
@@ -1,0 +1,3 @@
+package com.idle.network.model.chatting
+
+data class GetChattingResponse()

--- a/core/network/src/main/java/com/idle/network/model/profile/GetWorkerProfileResponse.kt
+++ b/core/network/src/main/java/com/idle/network/model/profile/GetWorkerProfileResponse.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class GetWorkerProfileResponse(
+    @SerialName("carerId") val workerId: String? = null,
     @SerialName("carerName") val workerName: String? = null,
     val age: Int? = null,
     val gender: String? = null,
@@ -23,6 +24,7 @@ data class GetWorkerProfileResponse(
     val profileImageUrl: String? = null,
 ) {
     fun toVo() = WorkerProfile(
+        workerId = workerId ?: "",
         workerName = workerName ?: "",
         age = age ?: -1,
         gender = Gender.create(gender ?: ""),

--- a/core/network/src/main/java/com/idle/network/source/websocket/CareWebSocketListener.kt
+++ b/core/network/src/main/java/com/idle/network/source/websocket/CareWebSocketListener.kt
@@ -1,0 +1,4 @@
+package com.idle.network.source.websocket
+
+class CareWebSocketListener {
+}

--- a/core/network/src/main/java/com/idle/network/source/websocket/CareWebSocketListener.kt
+++ b/core/network/src/main/java/com/idle/network/source/websocket/CareWebSocketListener.kt
@@ -1,4 +1,46 @@
 package com.idle.network.source.websocket
 
-class CareWebSocketListener {
+import android.util.Log
+import com.idle.network.BuildConfig
+import com.idle.network.model.chatting.ChatMessageResponse
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.serialization.json.Json
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ChatMessageListener @Inject constructor(private val json: Json) : WebSocketListener() {
+    private val _chatMessageChannel = Channel<ChatMessageResponse>(Channel.BUFFERED)
+    val chatMessageFlow = _chatMessageChannel.receiveAsFlow()
+
+    override fun onMessage(webSocket: WebSocket, text: String) {
+        super.onMessage(webSocket, text)
+
+        if (BuildConfig.DEBUG) {
+            Log.d("ChatMessageListener onMessage", text)
+        }
+
+        val chatMessageResponse = try {
+            json.decodeFromString<ChatMessageResponse>(text)
+        } catch (e: Exception) {
+            if (BuildConfig.DEBUG) {
+                Log.d("ChatMessageListener DecodeException", e.toString())
+            }
+            return
+        }
+
+        _chatMessageChannel.trySend(chatMessageResponse)
+    }
+
+    override fun onOpen(webSocket: WebSocket, response: Response) {
+        super.onOpen(webSocket, response)
+    }
+
+    override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+        super.onFailure(webSocket, t, response)
+    }
 }

--- a/core/network/src/main/java/com/idle/network/source/websocket/CareWebSocketListener.kt
+++ b/core/network/src/main/java/com/idle/network/source/websocket/CareWebSocketListener.kt
@@ -3,8 +3,8 @@ package com.idle.network.source.websocket
 import android.util.Log
 import com.idle.network.BuildConfig
 import com.idle.network.model.chatting.ChatMessageResponse
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.serialization.json.Json
 import okhttp3.Response
 import okhttp3.WebSocket
@@ -14,8 +14,8 @@ import javax.inject.Singleton
 
 @Singleton
 class ChatMessageListener @Inject constructor(private val json: Json) : WebSocketListener() {
-    private val _chatMessageChannel = Channel<ChatMessageResponse>(Channel.BUFFERED)
-    val chatMessageFlow = _chatMessageChannel.receiveAsFlow()
+    private val _chatMessageChannel = MutableStateFlow<ChatMessageResponse?>(null)
+    val chatMessageFlow = _chatMessageChannel.asStateFlow()
 
     override fun onMessage(webSocket: WebSocket, text: String) {
         super.onMessage(webSocket, text)
@@ -33,7 +33,7 @@ class ChatMessageListener @Inject constructor(private val json: Json) : WebSocke
             return
         }
 
-        _chatMessageChannel.trySend(chatMessageResponse)
+        _chatMessageChannel.value = chatMessageResponse
     }
 
     override fun onOpen(webSocket: WebSocket, response: Response) {

--- a/core/network/src/main/java/com/idle/network/source/websocket/WebSocketDataSource.kt
+++ b/core/network/src/main/java/com/idle/network/source/websocket/WebSocketDataSource.kt
@@ -1,0 +1,4 @@
+package com.idle.network.source.websocket
+
+class WebSocketDataSource {
+}

--- a/core/network/src/main/java/com/idle/network/source/websocket/WebSocketDataSource.kt
+++ b/core/network/src/main/java/com/idle/network/source/websocket/WebSocketDataSource.kt
@@ -1,5 +1,6 @@
 package com.idle.network.source.websocket
 
+import com.idle.domain.model.error.ErrorHandler
 import com.idle.network.BuildConfig
 import com.idle.network.di.WebSocketOkHttpClient
 import okhttp3.OkHttpClient
@@ -12,6 +13,7 @@ import javax.inject.Singleton
 class WebSocketDataSource @Inject constructor(
     @WebSocketOkHttpClient private val client: OkHttpClient,
     private val chatMessageListener: ChatMessageListener,
+    private val errorHandlerHelper: ErrorHandler,
 ) {
     private lateinit var chatMessageWebSocket: WebSocket
 

--- a/core/network/src/main/java/com/idle/network/source/websocket/WebSocketDataSource.kt
+++ b/core/network/src/main/java/com/idle/network/source/websocket/WebSocketDataSource.kt
@@ -1,4 +1,43 @@
 package com.idle.network.source.websocket
 
-class WebSocketDataSource {
+import com.idle.network.BuildConfig
+import com.idle.network.di.WebSocketOkHttpClient
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.WebSocket
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WebSocketDataSource @Inject constructor(
+    @WebSocketOkHttpClient private val client: OkHttpClient,
+    private val chatMessageListener: ChatMessageListener,
+) {
+    private lateinit var chatMessageWebSocket: WebSocket
+
+    fun connectWebSocket(): Result<Unit> {
+        return try {
+            val chatMessageRequest: Request = Request.Builder()
+                .url(BuildConfig.CARE_WEBSOCKET_URL)
+                .build()
+
+            chatMessageWebSocket = client.newWebSocket(chatMessageRequest, chatMessageListener)
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    fun disconnectWebSocket(reason: String? = null): Result<Unit> {
+        return try {
+            chatMessageWebSocket.let { webSocket ->
+                webSocket.close(1000, reason ?: "Normal Closure")
+                Result.success(Unit)
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    fun getChatMessageFlow() = chatMessageListener.chatMessageFlow
 }

--- a/core/network/src/main/java/com/idle/network/source/websocket/WebSocketDataSource.kt
+++ b/core/network/src/main/java/com/idle/network/source/websocket/WebSocketDataSource.kt
@@ -3,6 +3,8 @@ package com.idle.network.source.websocket
 import com.idle.domain.model.error.ErrorHandler
 import com.idle.network.BuildConfig
 import com.idle.network.di.WebSocketOkHttpClient
+import com.idle.network.model.chatting.ChatMessageResponse
+import kotlinx.coroutines.flow.StateFlow
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.WebSocket
@@ -41,5 +43,5 @@ class WebSocketDataSource @Inject constructor(
         }
     }
 
-    fun getChatMessageFlow() = chatMessageListener.chatMessageFlow
+    fun getChatMessageFlow(): StateFlow<ChatMessageResponse?> = chatMessageListener.chatMessageFlow
 }

--- a/feature/auth/src/main/java/com/idle/auth/AuthFragment.kt
+++ b/feature/auth/src/main/java/com/idle/auth/AuthFragment.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.fragment.navArgs
-import com.idle.analytics.helper.TrackScreenViewEvent
+import com.idle.analytics.businessmetric.TrackScreenViewEvent
 import com.idle.binding.DeepLinkDestination
 import com.idle.binding.DeepLinkDestination.CenterSignIn
 import com.idle.binding.DeepLinkDestination.CenterSignUp

--- a/feature/center/applicant-inquiry/src/main/java/com/tgyuu/applicant/inquiry/ApplicantInquiryFragment.kt
+++ b/feature/center/applicant-inquiry/src/main/java/com/tgyuu/applicant/inquiry/ApplicantInquiryFragment.kt
@@ -34,7 +34,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.fragment.navArgs
 import coil.compose.AsyncImage
-import com.idle.analytics.helper.TrackScreenViewEvent
+import com.idle.analytics.businessmetric.TrackScreenViewEvent
 import com.idle.binding.DeepLinkDestination
 import com.idle.binding.NavigationEvent
 import com.idle.compose.base.BaseComposeFragment

--- a/feature/center/applicant-inquiry/src/main/java/com/tgyuu/applicant/inquiry/ApplicantInquiryViewModel.kt
+++ b/feature/center/applicant-inquiry/src/main/java/com/tgyuu/applicant/inquiry/ApplicantInquiryViewModel.kt
@@ -3,7 +3,7 @@ package com.tgyuu.applicant.inquiry
 import androidx.lifecycle.viewModelScope
 import com.idle.binding.NavigationHelper
 import com.idle.binding.base.BaseViewModel
-import com.idle.domain.model.error.ErrorHandlerHelper
+import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.model.jobposting.Applicant
 import com.idle.domain.model.jobposting.JobPostingSummary
 import com.idle.domain.usecase.jobposting.GetApplicantsInfoUseCase
@@ -16,7 +16,7 @@ import javax.inject.Inject
 @HiltViewModel
 class ApplicantInquiryViewModel @Inject constructor(
     private val getApplicantsInfoUseCase: GetApplicantsInfoUseCase,
-    private val errorHandlerHelper: ErrorHandlerHelper,
+    private val errorHandlerHelper: ErrorHandler,
     val navigationHelper: NavigationHelper,
 ) : BaseViewModel() {
     private val _jobPostingSummary = MutableStateFlow<JobPostingSummary?>(null)

--- a/feature/center/chatting/src/main/java/com/idle/center/chatting/CenterChattingFragment.kt
+++ b/feature/center/chatting/src/main/java/com/idle/center/chatting/CenterChattingFragment.kt
@@ -57,6 +57,7 @@ internal class CenterChattingFragment : BaseComposeFragment() {
 
             LifecycleEventEffect(Lifecycle.Event.ON_CREATE) {
                 getChatRoomList()
+                subscribeChatMessage()
             }
 
             CenterChattingScreen(

--- a/feature/center/chatting/src/main/java/com/idle/center/chatting/CenterChattingFragment.kt
+++ b/feature/center/chatting/src/main/java/com/idle/center/chatting/CenterChattingFragment.kt
@@ -1,6 +1,5 @@
 package com.idle.center.chatting
 
-import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -173,7 +172,6 @@ internal fun ChatRoomItem(
                 model = chatRoom.profileImageUrl,
                 placeholder = painterResource(com.idle.designresource.R.drawable.ic_notification_placeholder),
                 error = painterResource(com.idle.designresource.R.drawable.ic_notification_placeholder),
-                onError = { Log.d("test", chatRoom.profileImageUrl) },
                 contentDescription = "",
                 contentScale = ContentScale.Crop,
                 modifier = Modifier

--- a/feature/center/chatting/src/main/java/com/idle/center/chatting/CenterChattingViewModel.kt
+++ b/feature/center/chatting/src/main/java/com/idle/center/chatting/CenterChattingViewModel.kt
@@ -5,25 +5,76 @@ import com.idle.binding.NavigationHelper
 import com.idle.binding.base.BaseViewModel
 import com.idle.domain.model.chatting.ChatRoom
 import com.idle.domain.model.error.ErrorHandler
+import com.idle.domain.model.profile.WorkerProfile
 import com.idle.domain.usecase.chatting.GetChatRoomListUseCase
+import com.idle.domain.usecase.chatting.SubscribeChatMessageUseCase
+import com.idle.domain.usecase.profile.GetCenterProfileUseCase
+import com.idle.domain.usecase.profile.GetLocalMyWorkerProfileUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class CenterChattingViewModel @Inject constructor(
+    private val getCenterProfileUseCase: GetCenterProfileUseCase,
     private val getChatRoomListUseCase: GetChatRoomListUseCase,
-    private val errorHandlerHelper: ErrorHandler,
+    private val subscribeChatMessageUseCase: SubscribeChatMessageUseCase,
+    private val errorHandler: ErrorHandler,
     val navigationHelper: NavigationHelper,
 ) : BaseViewModel() {
-    private val _chatRoomList = MutableStateFlow<List<ChatRoom>?>(emptyList())
-    val chatRoomList = _chatRoomList.asStateFlow()
+    private val _chatRoomMap = MutableStateFlow<LinkedHashMap<String, ChatRoom>>(LinkedHashMap())
+    val chatRoomList = _chatRoomMap
+        .map { it.values.toList() }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Lazily,
+            initialValue = null,
+        )
+
+    internal fun subscribeChatMessage() = viewModelScope.launch {
+        subscribeChatMessageUseCase().collect { chatMessage ->
+            val updatedMap = LinkedHashMap(_chatRoomMap.value) // 기존 맵을 복사
+            val roomId = chatMessage.roomId
+            val chatRoom = updatedMap[roomId]
+
+            if (chatRoom != null) {
+                // 기존 방이 있으면 업데이트 후 최상단으로 올리기 위해 제거 후 다시 추가
+                updatedMap.remove(roomId)
+                updatedMap[roomId] = chatRoom.copy(
+                    lastMessage = chatMessage.printPlainContents(),
+                    unReadMessageCount = chatRoom.unReadMessageCount + 1,
+                )
+            } else {
+                // 새로운 방이면 새로 생성 후 최상단에 추가
+                val newChatRoom = ChatRoom(
+                    id = roomId,
+                    lastMessage = chatMessage.printPlainContents(),
+                    sender = chatMessage.senderId,
+                    receiver = "", // Todo 센터 ID를 얻을 방법 서버와 의논
+                    createdAt = chatMessage.createdAt,
+                    lastSentAt = chatMessage.createdAt,
+                    unReadMessageCount = 1,
+                    profileImageUrl = getCenterProfileUseCase(chatMessage.senderId)
+                        .map { it.profileImageUrl }
+                        .getOrNull(),
+                )
+                updatedMap[roomId] = newChatRoom
+            }
+
+            _chatRoomMap.value = updatedMap
+        }
+    }
 
     internal fun getChatRoomList() = viewModelScope.launch {
         getChatRoomListUseCase().onSuccess {
-            _chatRoomList.value = it
-        }.onFailure { errorHandlerHelper.sendError(it) }
+            _chatRoomMap.value = LinkedHashMap<String, ChatRoom>().apply {
+                it.forEach { chatRoom -> put(chatRoom.id, chatRoom) }
+            }
+        }.onFailure { errorHandler.sendError(it) }
     }
 }

--- a/feature/center/chatting/src/main/java/com/idle/center/chatting/CenterChattingViewModel.kt
+++ b/feature/center/chatting/src/main/java/com/idle/center/chatting/CenterChattingViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.viewModelScope
 import com.idle.binding.NavigationHelper
 import com.idle.binding.base.BaseViewModel
 import com.idle.domain.model.chatting.ChatRoom
-import com.idle.domain.model.error.ErrorHandlerHelper
+import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.usecase.chatting.GetChatRoomListUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -15,7 +15,7 @@ import javax.inject.Inject
 @HiltViewModel
 class CenterChattingViewModel @Inject constructor(
     private val getChatRoomListUseCase: GetChatRoomListUseCase,
-    private val errorHandlerHelper: ErrorHandlerHelper,
+    private val errorHandlerHelper: ErrorHandler,
     val navigationHelper: NavigationHelper,
 ) : BaseViewModel() {
     private val _chatRoomList = MutableStateFlow<List<ChatRoom>?>(emptyList())

--- a/feature/center/home/src/main/java/com/idle/center/home/CenterHomeFragment.kt
+++ b/feature/center/home/src/main/java/com/idle/center/home/CenterHomeFragment.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.idle.analytics.helper.TrackScreenViewEvent
+import com.idle.analytics.businessmetric.TrackScreenViewEvent
 import com.idle.binding.DeepLinkDestination
 import com.idle.binding.DeepLinkDestination.CenterApplicantInquiry
 import com.idle.binding.NavigationEvent

--- a/feature/center/home/src/main/java/com/idle/center/home/CenterHomeViewModel.kt
+++ b/feature/center/home/src/main/java/com/idle/center/home/CenterHomeViewModel.kt
@@ -6,7 +6,7 @@ import com.idle.binding.MainEvent
 import com.idle.binding.NavigationHelper
 import com.idle.binding.ToastType.SUCCESS
 import com.idle.binding.base.BaseViewModel
-import com.idle.domain.model.error.ErrorHandlerHelper
+import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.model.jobposting.CenterJobPosting
 import com.idle.domain.usecase.config.ShowNotificationCenterUseCase
 import com.idle.domain.usecase.jobposting.EndJobPostingUseCase
@@ -26,7 +26,7 @@ class CenterHomeViewModel @Inject constructor(
     private val endJobPostingUseCase: EndJobPostingUseCase,
     private val showNotificationCenterUseCase: ShowNotificationCenterUseCase,
     private val getUnreadNotificationCountUseCase: GetUnreadNotificationCountUseCase,
-    private val errorHandlerHelper: ErrorHandlerHelper,
+    private val errorHandlerHelper: ErrorHandler,
     private val eventHandlerHelper: EventHandlerHelper,
     val navigationHelper: NavigationHelper,
 ) : BaseViewModel() {

--- a/feature/center/job-posting-edit/src/main/java/com/idle/center/job/edit/JobEditScreen.kt
+++ b/feature/center/job-posting-edit/src/main/java/com/idle/center/job/edit/JobEditScreen.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.FragmentManager
 import androidx.navigation.fragment.findNavController
-import com.idle.analytics.helper.TrackScreenViewEvent
+import com.idle.analytics.businessmetric.TrackScreenViewEvent
 import com.idle.compose.JobPostingBottomSheetType
 import com.idle.compose.JobPostingBottomSheetType.POST_DEAD_LINE
 import com.idle.compose.JobPostingBottomSheetType.WORK_END_TIME

--- a/feature/center/job-posting-post/src/main/java/com/idle/center/jobposting/AnalyticsExtensions.kt
+++ b/feature/center/job-posting-post/src/main/java/com/idle/center/jobposting/AnalyticsExtensions.kt
@@ -6,8 +6,8 @@ import com.idle.analytics.AnalyticsEvent
 import com.idle.analytics.AnalyticsEvent.PropertiesKeys.ACTION_NAME
 import com.idle.analytics.AnalyticsEvent.PropertiesKeys.SCREEN_NAME
 import com.idle.analytics.AnalyticsEvent.Types.SCREEN_VIEW
-import com.idle.analytics.helper.AnalyticsHelper
-import com.idle.analytics.helper.LocalAnalyticsHelper
+import com.idle.analytics.businessmetric.AnalyticsHelper
+import com.idle.analytics.businessmetric.LocalAnalyticsHelper
 
 @Composable
 internal fun LogJobPostingStep(

--- a/feature/center/job-posting-post/src/main/java/com/idle/center/jobposting/JobPostingFragment.kt
+++ b/feature/center/job-posting-post/src/main/java/com/idle/center/jobposting/JobPostingFragment.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.fragment.findNavController
-import com.idle.analytics.helper.LocalAnalyticsHelper
+import com.idle.analytics.businessmetric.LocalAnalyticsHelper
 import com.idle.binding.DeepLinkDestination
 import com.idle.binding.MainEvent
 import com.idle.binding.NavigationEvent

--- a/feature/center/job-posting-post/src/main/java/com/idle/center/jobposting/JobPostingViewModel.kt
+++ b/feature/center/job-posting-post/src/main/java/com/idle/center/jobposting/JobPostingViewModel.kt
@@ -11,7 +11,7 @@ import com.idle.binding.base.BaseViewModel
 import com.idle.center.job.posting.post.R
 import com.idle.compose.JobPostingBottomSheetType
 import com.idle.domain.model.auth.Gender
-import com.idle.domain.model.error.ErrorHandlerHelper
+import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.model.jobposting.ApplyDeadlineType
 import com.idle.domain.model.jobposting.ApplyMethod
 import com.idle.domain.model.jobposting.DayOfWeek
@@ -39,7 +39,7 @@ import javax.inject.Inject
 class JobPostingViewModel @Inject constructor(
     private val getLocalMyCenterProfileUseCase: GetLocalMyCenterProfileUseCase,
     private val postJobPostingUseCase: PostJobPostingUseCase,
-    private val errorHandlerHelper: ErrorHandlerHelper,
+    private val errorHandlerHelper: ErrorHandler,
     val eventHandlerHelper: EventHandlerHelper,
     val navigationHelper: NavigationHelper,
 ) : BaseViewModel() {

--- a/feature/center/job-posting-post/src/main/java/com/idle/center/jobposting/complete/JobPostingCompleteFragment.kt
+++ b/feature/center/job-posting-post/src/main/java/com/idle/center/jobposting/complete/JobPostingCompleteFragment.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
-import com.idle.analytics.helper.TrackScreenViewEvent
+import com.idle.analytics.businessmetric.TrackScreenViewEvent
 import com.idle.compose.base.BaseComposeFragment
 import com.idle.designresource.R
 import com.idle.designsystem.compose.component.CareButtonLarge

--- a/feature/center/pending/src/main/java/com/idle/pending/CenterPendingViewModel.kt
+++ b/feature/center/pending/src/main/java/com/idle/pending/CenterPendingViewModel.kt
@@ -7,7 +7,7 @@ import com.idle.binding.NavigationEvent
 import com.idle.binding.NavigationHelper
 import com.idle.binding.ToastType.SUCCESS
 import com.idle.binding.base.BaseViewModel
-import com.idle.domain.model.error.ErrorHandlerHelper
+import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.model.profile.CenterManagerAccountStatus
 import com.idle.domain.usecase.auth.LogoutCenterUseCase
 import com.idle.domain.usecase.auth.SendCenterVerificationRequestUseCase
@@ -21,7 +21,7 @@ import javax.inject.Inject
 class CenterPendingViewModel @Inject constructor(
     private val logoutCenterUseCase: LogoutCenterUseCase,
     private val sendCenterVerificationRequestUseCase: SendCenterVerificationRequestUseCase,
-    private val errorHandlerHelper: ErrorHandlerHelper,
+    private val errorHandlerHelper: ErrorHandler,
     private val eventHandlerHelper: EventHandlerHelper,
     private val navigationHelper: NavigationHelper,
 ) : BaseViewModel() {

--- a/feature/center/profile/src/main/java/com/idle/center/profile/CenterProfileFragment.kt
+++ b/feature/center/profile/src/main/java/com/idle/center/profile/CenterProfileFragment.kt
@@ -39,7 +39,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.fragment.navArgs
 import coil.compose.AsyncImage
-import com.idle.analytics.helper.TrackScreenViewEvent
+import com.idle.analytics.businessmetric.TrackScreenViewEvent
 import com.idle.compose.addFocusCleaner
 import com.idle.compose.base.BaseComposeFragment
 import com.idle.compose.clickable

--- a/feature/center/profile/src/main/java/com/idle/center/profile/CenterProfileViewModel.kt
+++ b/feature/center/profile/src/main/java/com/idle/center/profile/CenterProfileViewModel.kt
@@ -6,7 +6,7 @@ import com.idle.binding.EventHandlerHelper
 import com.idle.binding.MainEvent
 import com.idle.binding.ToastType.SUCCESS
 import com.idle.binding.base.BaseViewModel
-import com.idle.domain.model.error.ErrorHandlerHelper
+import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.model.profile.CenterProfile
 import com.idle.domain.usecase.profile.GetCenterProfileUseCase
 import com.idle.domain.usecase.profile.GetLocalMyCenterProfileUseCase
@@ -22,7 +22,7 @@ class CenterProfileViewModel @Inject constructor(
     private val getLocalMyCenterProfileUseCase: GetLocalMyCenterProfileUseCase,
     private val getCenterProfileUseCase: GetCenterProfileUseCase,
     private val updateCenterProfileUseCase: UpdateCenterProfileUseCase,
-    private val errorHandlerHelper: ErrorHandlerHelper,
+    private val errorHandlerHelper: ErrorHandler,
     private val eventHandlerHelper: EventHandlerHelper,
 ) : BaseViewModel() {
     private val _centerProfile = MutableStateFlow<CenterProfile?>(null)

--- a/feature/center/register-info/src/main/java/com/idle/center/register/AnalyticsExtensions.kt
+++ b/feature/center/register-info/src/main/java/com/idle/center/register/AnalyticsExtensions.kt
@@ -6,8 +6,8 @@ import com.idle.analytics.AnalyticsEvent
 import com.idle.analytics.AnalyticsEvent.PropertiesKeys.ACTION_NAME
 import com.idle.analytics.AnalyticsEvent.PropertiesKeys.SCREEN_NAME
 import com.idle.analytics.AnalyticsEvent.Types.SCREEN_VIEW
-import com.idle.analytics.helper.AnalyticsHelper
-import com.idle.analytics.helper.LocalAnalyticsHelper
+import com.idle.analytics.businessmetric.AnalyticsHelper
+import com.idle.analytics.businessmetric.LocalAnalyticsHelper
 
 @Composable
 internal fun LogRegistrationStep(

--- a/feature/center/register-info/src/main/java/com/idle/center/register/RegisterCenterInfoViewModel.kt
+++ b/feature/center/register-info/src/main/java/com/idle/center/register/RegisterCenterInfoViewModel.kt
@@ -8,7 +8,7 @@ import com.idle.binding.NavigationEvent
 import com.idle.binding.NavigationHelper
 import com.idle.binding.base.BaseViewModel
 import com.idle.center.register.info.R
-import com.idle.domain.model.error.ErrorHandlerHelper
+import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.usecase.profile.RegisterCenterProfileUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,7 +19,7 @@ import javax.inject.Inject
 @HiltViewModel
 class RegisterCenterInfoViewModel @Inject constructor(
     private val registerCenterProfileUseCase: RegisterCenterProfileUseCase,
-    private val errorHandlerHelper: ErrorHandlerHelper,
+    private val errorHandlerHelper: ErrorHandler,
     val navigationHelper: NavigationHelper,
 ) : BaseViewModel() {
 

--- a/feature/center/register-info/src/main/java/com/idle/center/register/complete/RegisterCenterInfoCompleteFragment.kt
+++ b/feature/center/register-info/src/main/java/com/idle/center/register/complete/RegisterCenterInfoCompleteFragment.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.idle.analytics.helper.TrackScreenViewEvent
+import com.idle.analytics.businessmetric.TrackScreenViewEvent
 import com.idle.binding.DeepLinkDestination.CenterHome
 import com.idle.binding.NavigationEvent
 import com.idle.center.register.info.R

--- a/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ChattingDetailFragment.kt
+++ b/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ChattingDetailFragment.kt
@@ -65,6 +65,7 @@ internal class ChattingDetailFragment : BaseComposeFragment() {
             LifecycleEventEffect(Lifecycle.Event.ON_CREATE) {
                 getUserProfile(receiverUserType = receiverUserType, senderId = senderId)
                 getChatMessages(chattingRoomId)
+                subscribeChatMessage()
             }
 
             if (chatMessages != null && workerProfile != null && centerProfile != null) {
@@ -124,7 +125,7 @@ internal fun ChattingDetailScreen(
                     .fillMaxWidth()
                     .weight(1f)
                     .background(CareTheme.colors.gray050)
-                    .padding(horizontal = 20.dp),
+                    .padding(horizontal = 18.dp),
             ) {
                 item {
                     Spacer(

--- a/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ChattingDetailViewModel.kt
+++ b/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ChattingDetailViewModel.kt
@@ -8,6 +8,7 @@ import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.model.profile.CenterProfile
 import com.idle.domain.model.profile.WorkerProfile
 import com.idle.domain.usecase.chatting.GetChatMessagesUseCase
+import com.idle.domain.usecase.chatting.SubscribeChatMessageUseCase
 import com.idle.domain.usecase.profile.GetCenterProfileUseCase
 import com.idle.domain.usecase.profile.GetLocalMyCenterProfileUseCase
 import com.idle.domain.usecase.profile.GetLocalMyWorkerProfileUseCase
@@ -25,6 +26,7 @@ class ChattingDetailViewModel @Inject constructor(
     private val getCenterProfileUseCase: GetCenterProfileUseCase,
     private val getWorkerProfileUseCase: GetWorkerProfileUseCase,
     private val getChatMessagesUseCase: GetChatMessagesUseCase,
+    private val subscribeChatMessageUseCase: SubscribeChatMessageUseCase,
     private val errorHandlerHelper: ErrorHandler,
 ) : BaseViewModel() {
     private val _writingText = MutableStateFlow<String>("")
@@ -85,6 +87,12 @@ class ChattingDetailViewModel @Inject constructor(
     internal fun getChatMessages(roomId: String) = viewModelScope.launch {
         getChatMessagesUseCase(roomId).onSuccess {
             _chatMessages.value = it
+        }
+    }
+
+    internal fun subscribeChatMessage() = viewModelScope.launch {
+        subscribeChatMessageUseCase().collect { chatMessage ->
+            _chatMessages.value = (_chatMessages.value ?: emptyList()) + chatMessage
         }
     }
 }

--- a/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ChattingDetailViewModel.kt
+++ b/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ChattingDetailViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.viewModelScope
 import com.idle.binding.base.BaseViewModel
 import com.idle.domain.model.auth.UserType
 import com.idle.domain.model.chatting.ChatMessage
-import com.idle.domain.model.error.ErrorHandlerHelper
+import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.model.profile.CenterProfile
 import com.idle.domain.model.profile.WorkerProfile
 import com.idle.domain.usecase.chatting.GetChatMessagesUseCase
@@ -25,7 +25,7 @@ class ChattingDetailViewModel @Inject constructor(
     private val getCenterProfileUseCase: GetCenterProfileUseCase,
     private val getWorkerProfileUseCase: GetWorkerProfileUseCase,
     private val getChatMessagesUseCase: GetChatMessagesUseCase,
-    private val errorHandlerHelper: ErrorHandlerHelper,
+    private val errorHandlerHelper: ErrorHandler,
 ) : BaseViewModel() {
     private val _writingText = MutableStateFlow<String>("")
     val writingText = _writingText.asStateFlow()

--- a/feature/chatting-detail/src/main/java/com/idle/chatting_detail/component/CareChatTextBubble.kt
+++ b/feature/chatting-detail/src/main/java/com/idle/chatting_detail/component/CareChatTextBubble.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.CircleShape
@@ -257,7 +256,7 @@ fun PreviewCareChatTextBubbleWithImage() {
     )
 
     CareChatSenderTextBubbleWithImage(
-        imageUrl = "https://via.placeholder.com/40", // Placeholder 이미지 URL
+        imageUrl = "https://via.placeholder.com/40",
         senderName = "요양센터",
         chatMessage = chatMessage,
         isLast = true,

--- a/feature/chatting-detail/src/main/java/com/idle/chatting_detail/component/CareChatTextBubble.kt
+++ b/feature/chatting-detail/src/main/java/com/idle/chatting_detail/component/CareChatTextBubble.kt
@@ -99,7 +99,7 @@ fun CareChatSenderTextBubbleWithImage(
             Column(
                 horizontalAlignment = Alignment.Start,
                 modifier = Modifier
-                    .padding(start = 4.dp)
+                    .padding(start = 6.dp)
                     .wrapContentWidth()
                     .align(Alignment.Bottom),
             ) {
@@ -162,7 +162,7 @@ fun CareChatSenderTextBubble(
                 horizontalAlignment = Alignment.Start,
                 modifier = Modifier
                     .align(Alignment.Bottom)
-                    .padding(start = 4.dp),
+                    .padding(start = 6.dp),
             ) {
                 if (isRead) {
                     Text(
@@ -199,7 +199,7 @@ fun CareChatReceiverTextBubble(
                 horizontalAlignment = Alignment.End,
                 modifier = Modifier
                     .align(Alignment.Bottom)
-                    .padding(end = 4.dp),
+                    .padding(end = 6.dp),
             ) {
                 if (isRead) {
                     Text(

--- a/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/LoadingJobPostingDetailScreen.kt
+++ b/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/LoadingJobPostingDetailScreen.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.idle.analytics.helper.TrackScreenViewEvent
+import com.idle.analytics.businessmetric.TrackScreenViewEvent
 import com.idle.designresource.R
 import com.idle.designsystem.compose.component.CareButtonLine
 import com.idle.designsystem.compose.component.CareButtonMedium

--- a/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/center/CenterJobPostingDetailFragement.kt
+++ b/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/center/CenterJobPostingDetailFragement.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.fragment.navArgs
-import com.idle.analytics.helper.TrackScreenViewEvent
+import com.idle.analytics.businessmetric.TrackScreenViewEvent
 import com.idle.binding.DeepLinkDestination
 import com.idle.binding.MainEvent
 import com.idle.binding.NavigationEvent

--- a/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/center/CenterJobPostingDetailViewModel.kt
+++ b/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/center/CenterJobPostingDetailViewModel.kt
@@ -8,7 +8,7 @@ import com.idle.binding.MainEvent
 import com.idle.binding.NavigationEvent
 import com.idle.binding.NavigationHelper
 import com.idle.binding.ToastType
-import com.idle.domain.model.error.ErrorHandlerHelper
+import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.model.jobposting.CenterJobPostingDetail
 import com.idle.domain.model.jobposting.EditJobPostingDetail
 import com.idle.domain.model.jobposting.JobPostingStatus
@@ -35,7 +35,7 @@ class CenterJobPostingDetailViewModel @Inject constructor(
     private val updateJobPostingUseCase: UpdateJobPostingUseCase,
     private val endJobPostingUseCase: EndJobPostingUseCase,
     private val deleteJobPostingUseCase: DeleteJobPostingUseCase,
-    private val errorHandlerHelper: ErrorHandlerHelper,
+    private val errorHandlerHelper: ErrorHandler,
     val eventHandlerHelper: EventHandlerHelper,
     val navigationHelper: NavigationHelper,
 ) : BaseViewModel() {

--- a/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/center/JobPostingPreviewScreen.kt
+++ b/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/center/JobPostingPreviewScreen.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.idle.analytics.helper.TrackScreenViewEvent
+import com.idle.analytics.businessmetric.TrackScreenViewEvent
 import com.idle.designresource.R
 import com.idle.designsystem.compose.component.CareButtonLine
 import com.idle.designsystem.compose.component.CareCard

--- a/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/worker/WorkerJobPostingDetailViewModel.kt
+++ b/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/worker/WorkerJobPostingDetailViewModel.kt
@@ -5,13 +5,13 @@ import com.idle.analytics.AnalyticsEvent
 import com.idle.analytics.AnalyticsEvent.PropertiesKeys.ACTION_NAME
 import com.idle.analytics.AnalyticsEvent.PropertiesKeys.SCREEN_NAME
 import com.idle.analytics.AnalyticsEvent.Types.ACTION
-import com.idle.analytics.helper.AnalyticsHelper
+import com.idle.analytics.businessmetric.AnalyticsHelper
 import com.idle.binding.EventHandlerHelper
 import com.idle.binding.MainEvent
 import com.idle.binding.NavigationHelper
 import com.idle.binding.ToastType.SUCCESS
 import com.idle.binding.base.BaseViewModel
-import com.idle.domain.model.error.ErrorHandlerHelper
+import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.model.jobposting.ApplyMethod
 import com.idle.domain.model.jobposting.CrawlingJobPostingDetail
 import com.idle.domain.model.jobposting.JobPosting
@@ -40,7 +40,7 @@ class WorkerJobPostingDetailViewModel @Inject constructor(
     private val addFavoriteJobPostingUseCase: AddFavoriteJobPostingUseCase,
     private val removeFavoriteJobPostingUseCase: RemoveFavoriteJobPostingUseCase,
     private val analyticsHelper: AnalyticsHelper,
-    private val errorHandlerHelper: ErrorHandlerHelper,
+    private val errorHandlerHelper: ErrorHandler,
     val eventHandlerHelper: EventHandlerHelper,
     val navigationHelper: NavigationHelper,
 ) : BaseViewModel() {

--- a/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/worker/map/PlaceDetailScreen.kt
+++ b/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/worker/map/PlaceDetailScreen.kt
@@ -7,7 +7,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.idle.analytics.helper.TrackScreenViewEvent
+import com.idle.analytics.businessmetric.TrackScreenViewEvent
 import com.idle.designsystem.compose.component.CareMap
 import com.idle.designsystem.compose.component.CareSubtitleTopBar
 import com.idle.designsystem.compose.foundation.CareTheme

--- a/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/worker/screen/CrawlingJobPostingDetailScreen.kt
+++ b/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/worker/screen/CrawlingJobPostingDetailScreen.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat.startActivity
 import androidx.core.net.toUri
-import com.idle.analytics.helper.TrackScreenViewEvent
+import com.idle.analytics.businessmetric.TrackScreenViewEvent
 import com.idle.compose.clickable
 import com.idle.designresource.R
 import com.idle.designsystem.compose.component.CareCard

--- a/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/worker/screen/WorkerJobPostingDetailScreen.kt
+++ b/feature/job-posting-detail/src/main/java/com/idle/worker/job/posting/detail/worker/screen/WorkerJobPostingDetailScreen.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import com.idle.analytics.helper.TrackScreenViewEvent
+import com.idle.analytics.businessmetric.TrackScreenViewEvent
 import com.idle.binding.DeepLinkDestination
 import com.idle.binding.DeepLinkDestination.CenterProfile
 import com.idle.compose.clickable

--- a/feature/notification/src/main/java/com/idle/notification/NotificationViewModel.kt
+++ b/feature/notification/src/main/java/com/idle/notification/NotificationViewModel.kt
@@ -3,16 +3,13 @@ package com.idle.notification
 import androidx.lifecycle.viewModelScope
 import com.idle.binding.NavigationHelper
 import com.idle.binding.base.BaseViewModel
-import com.idle.domain.model.error.ErrorHandlerHelper
+import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.model.notification.Notification
 import com.idle.domain.usecase.notification.GetMyNotificationUseCase
 import com.idle.domain.usecase.notification.ReadNotificationUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -20,7 +17,7 @@ import javax.inject.Inject
 class NotificationViewModel @Inject constructor(
     private val getMyNotificationUseCase: GetMyNotificationUseCase,
     private val readNotificationUseCase: ReadNotificationUseCase,
-    private val errorHandlerHelper: ErrorHandlerHelper,
+    private val errorHandlerHelper: ErrorHandler,
     private val navigationHelper: NavigationHelper,
 ) : BaseViewModel() {
     private val next = MutableStateFlow<String?>(null)

--- a/feature/postcode/src/main/java/com/idle/post/code/PostCodeFragment.kt
+++ b/feature/postcode/src/main/java/com/idle/post/code/PostCodeFragment.kt
@@ -18,7 +18,7 @@ import android.webkit.WebViewClient
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
-import com.idle.analytics.helper.AnalyticsHelper
+import com.idle.analytics.businessmetric.AnalyticsHelper
 import com.idle.postcode.databinding.FragmentPostCodeBinding
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers

--- a/feature/setting/src/main/java/com/idle/setting/center/CenterSettingViewModel.kt
+++ b/feature/setting/src/main/java/com/idle/setting/center/CenterSettingViewModel.kt
@@ -1,11 +1,11 @@
 package com.idle.setting.center
 
 import androidx.lifecycle.viewModelScope
-import com.idle.analytics.helper.AnalyticsHelper
+import com.idle.analytics.businessmetric.AnalyticsHelper
 import com.idle.binding.NavigationEvent
 import com.idle.binding.NavigationHelper
 import com.idle.binding.base.BaseViewModel
-import com.idle.domain.model.error.ErrorHandlerHelper
+import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.model.profile.CenterProfile
 import com.idle.domain.usecase.auth.LogoutCenterUseCase
 import com.idle.domain.usecase.profile.GetLocalMyCenterProfileUseCase
@@ -23,7 +23,7 @@ class CenterSettingViewModel @Inject constructor(
     private val getLocalMyCenterProfileUseCase: GetLocalMyCenterProfileUseCase,
     private val logoutCenterUseCase: LogoutCenterUseCase,
     private val analyticsHelper: AnalyticsHelper,
-    private val errorHandlerHelper: ErrorHandlerHelper,
+    private val errorHandlerHelper: ErrorHandler,
     val navigationHelper: NavigationHelper,
 ) : BaseViewModel() {
     private val _centerProfile =

--- a/feature/setting/src/main/java/com/idle/setting/worker/WorkerSettingViewModel.kt
+++ b/feature/setting/src/main/java/com/idle/setting/worker/WorkerSettingViewModel.kt
@@ -1,11 +1,11 @@
 package com.idle.setting.worker
 
 import androidx.lifecycle.viewModelScope
-import com.idle.analytics.helper.AnalyticsHelper
+import com.idle.analytics.businessmetric.AnalyticsHelper
 import com.idle.binding.NavigationEvent
 import com.idle.binding.NavigationHelper
 import com.idle.binding.base.BaseViewModel
-import com.idle.domain.model.error.ErrorHandlerHelper
+import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.model.profile.WorkerProfile
 import com.idle.domain.usecase.auth.LogoutWorkerUseCase
 import com.idle.domain.usecase.profile.GetLocalMyWorkerProfileUseCase
@@ -22,7 +22,7 @@ class WorkerSettingViewModel @Inject constructor(
     private val getLocalMyWorkerProfileUseCase: GetLocalMyWorkerProfileUseCase,
     private val logoutWorkerUseCase: LogoutWorkerUseCase,
     private val analyticsHelper: AnalyticsHelper,
-    private val errorHandlerHelper: ErrorHandlerHelper,
+    private val errorHandlerHelper: ErrorHandler,
     val navigationHelper: NavigationHelper,
 ) : BaseViewModel() {
     private val _workerProfile = MutableStateFlow<WorkerProfile?>(null)

--- a/feature/signin/src/main/java/com/idle/signin/center/CenterSignInFragment.kt
+++ b/feature/signin/src/main/java/com/idle/signin/center/CenterSignInFragment.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.fragment.navArgs
-import com.idle.analytics.helper.TrackScreenViewEvent
+import com.idle.analytics.businessmetric.TrackScreenViewEvent
 import com.idle.binding.DeepLinkDestination.Auth
 import com.idle.binding.DeepLinkDestination.NewPassword
 import com.idle.binding.MainEvent

--- a/feature/signin/src/main/java/com/idle/signin/center/CenterSignInViewModel.kt
+++ b/feature/signin/src/main/java/com/idle/signin/center/CenterSignInViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.viewModelScope
 import com.idle.analytics.AnalyticsEvent
 import com.idle.analytics.AnalyticsEvent.PropertiesKeys.ACTION_NAME
 import com.idle.analytics.AnalyticsEvent.PropertiesKeys.ACTION_RESULT
-import com.idle.analytics.helper.AnalyticsHelper
+import com.idle.analytics.businessmetric.AnalyticsHelper
 import com.idle.binding.DeepLinkDestination.CenterHome
 import com.idle.binding.DeepLinkDestination.CenterPending
 import com.idle.binding.DeepLinkDestination.CenterRegister
@@ -13,7 +13,7 @@ import com.idle.binding.NavigationEvent.NavigateTo
 import com.idle.binding.NavigationHelper
 import com.idle.binding.base.BaseViewModel
 import com.idle.domain.model.error.ApiErrorCode
-import com.idle.domain.model.error.ErrorHandlerHelper
+import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.model.error.HttpResponseException
 import com.idle.domain.model.error.HttpResponseStatus
 import com.idle.domain.model.profile.CenterManagerAccountStatus
@@ -33,7 +33,7 @@ class CenterSignInViewModel @Inject constructor(
     private val getCenterStatusUseCase: GetCenterStatusUseCase,
     private val getMyCenterProfileUseCase: GetMyCenterProfileUseCase,
     private val analyticsHelper: AnalyticsHelper,
-    private val errorHandlerHelper: ErrorHandlerHelper,
+    private val errorHandlerHelper: ErrorHandler,
     val eventHandlerHelper: EventHandlerHelper,
     val navigationHelper: NavigationHelper,
 ) : BaseViewModel() {

--- a/feature/signin/src/main/java/com/idle/signin/center/newpassword/NewPasswordViewModel.kt
+++ b/feature/signin/src/main/java/com/idle/signin/center/newpassword/NewPasswordViewModel.kt
@@ -11,7 +11,7 @@ import com.idle.binding.base.BaseViewModel
 import com.idle.domain.model.CountDownTimer
 import com.idle.domain.model.CountDownTimer.Companion.SECONDS_PER_MINUTE
 import com.idle.domain.model.CountDownTimer.Companion.TICK_INTERVAL
-import com.idle.domain.model.error.ErrorHandlerHelper
+import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.model.error.HttpResponseException
 import com.idle.domain.model.error.HttpResponseStatus
 import com.idle.domain.usecase.auth.ConfirmAuthCodeUseCase
@@ -21,7 +21,6 @@ import com.idle.signin.R
 import com.idle.signin.center.newpassword.NewPasswordStep.GENERATE_NEW_PASSWORD
 import com.idle.signin.center.newpassword.NewPasswordStep.PHONE_NUMBER
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -39,7 +38,7 @@ class NewPasswordViewModel @Inject constructor(
     private val confirmAuthCodeUseCase: ConfirmAuthCodeUseCase,
     private val generateNewPasswordUseCase: GenerateNewPasswordUseCase,
     private val countDownTimer: CountDownTimer,
-    private val errorHandlerHelper: ErrorHandlerHelper,
+    private val errorHandlerHelper: ErrorHandler,
     private val eventHandlerHelper: EventHandlerHelper,
     private val navigationHelper: NavigationHelper,
 ) : BaseViewModel() {

--- a/feature/signin/src/test/java/com/idle/signin/center/newpassword/NewPasswordViewModelTest.kt
+++ b/feature/signin/src/test/java/com/idle/signin/center/newpassword/NewPasswordViewModelTest.kt
@@ -3,7 +3,7 @@ package com.idle.signin.center.newpassword
 import com.idle.binding.EventHandlerHelper
 import com.idle.binding.NavigationHelper
 import com.idle.domain.model.CountDownTimer
-import com.idle.domain.model.error.ErrorHandlerHelper
+import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.usecase.auth.ConfirmAuthCodeUseCase
 import com.idle.domain.usecase.auth.GenerateNewPasswordUseCase
 import com.idle.domain.usecase.auth.SendPhoneNumberUseCase
@@ -26,7 +26,7 @@ class NewPasswordViewModelTest {
     private lateinit var confirmAuthCodeUseCase: ConfirmAuthCodeUseCase
     private lateinit var generateNewPasswordUseCase: GenerateNewPasswordUseCase
     private lateinit var countDownTimer: CountDownTimer
-    private lateinit var errorHandlerHelper: ErrorHandlerHelper
+    private lateinit var errorHandlerHelper: ErrorHandler
     private lateinit var eventHandlerHelper: EventHandlerHelper
     private lateinit var navigationHelper: NavigationHelper
     private lateinit var viewModel: NewPasswordViewModel

--- a/feature/signup/src/main/java/com/idle/signup/AnalyticsExtensions.kt
+++ b/feature/signup/src/main/java/com/idle/signup/AnalyticsExtensions.kt
@@ -6,8 +6,8 @@ import com.idle.analytics.AnalyticsEvent
 import com.idle.analytics.AnalyticsEvent.PropertiesKeys.ACTION_NAME
 import com.idle.analytics.AnalyticsEvent.PropertiesKeys.SCREEN_NAME
 import com.idle.analytics.AnalyticsEvent.Types.SCREEN_VIEW
-import com.idle.analytics.helper.AnalyticsHelper
-import com.idle.analytics.helper.LocalAnalyticsHelper
+import com.idle.analytics.businessmetric.AnalyticsHelper
+import com.idle.analytics.businessmetric.LocalAnalyticsHelper
 import com.idle.signin.worker.WorkerSignUpStep
 import com.idle.signup.center.CenterSignUpStep
 

--- a/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpViewModel.kt
@@ -13,7 +13,7 @@ import com.idle.domain.model.CountDownTimer.Companion.SECONDS_PER_MINUTE
 import com.idle.domain.model.CountDownTimer.Companion.TICK_INTERVAL
 import com.idle.domain.model.auth.BusinessRegistrationInfo
 import com.idle.domain.model.error.ApiErrorCode
-import com.idle.domain.model.error.ErrorHandlerHelper
+import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.model.error.HttpResponseException
 import com.idle.domain.model.error.HttpResponseStatus
 import com.idle.domain.usecase.auth.ConfirmAuthCodeUseCase
@@ -43,7 +43,7 @@ class CenterSignUpViewModel @Inject constructor(
     private val validateIdentifierUseCase: ValidateIdentifierUseCase,
     private val validateBusinessRegistrationNumberUseCase: ValidateBusinessRegistrationNumberUseCase,
     private val countDownTimer: CountDownTimer,
-    private val errorHandlerHelper: ErrorHandlerHelper,
+    private val errorHandlerHelper: ErrorHandler,
     private val eventHandlerHelper: EventHandlerHelper,
     val navigationHelper: NavigationHelper,
 ) : BaseViewModel() {

--- a/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpViewModel.kt
@@ -2,7 +2,7 @@ package com.idle.signin.worker
 
 import androidx.core.text.isDigitsOnly
 import androidx.lifecycle.viewModelScope
-import com.idle.analytics.helper.AnalyticsHelper
+import com.idle.analytics.businessmetric.AnalyticsHelper
 import com.idle.binding.DeepLinkDestination.SignUpComplete
 import com.idle.binding.DeepLinkDestination.WorkerHome
 import com.idle.binding.EventHandlerHelper
@@ -13,7 +13,7 @@ import com.idle.domain.model.CountDownTimer
 import com.idle.domain.model.CountDownTimer.Companion.SECONDS_PER_MINUTE
 import com.idle.domain.model.CountDownTimer.Companion.TICK_INTERVAL
 import com.idle.domain.model.auth.Gender
-import com.idle.domain.model.error.ErrorHandlerHelper
+import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.model.error.HttpResponseException
 import com.idle.domain.model.error.HttpResponseStatus
 import com.idle.domain.usecase.auth.ConfirmAuthCodeUseCase
@@ -39,7 +39,7 @@ class WorkerSignUpViewModel @Inject constructor(
     private val confirmAuthCodeUseCase: ConfirmAuthCodeUseCase,
     private val countDownTimer: CountDownTimer,
     private val analyticsHelper: AnalyticsHelper,
-    private val errorHandlerHelper: ErrorHandlerHelper,
+    private val errorHandlerHelper: ErrorHandler,
     val eventHandlerHelper: EventHandlerHelper,
     val navigationHelper: NavigationHelper,
 ) : BaseViewModel() {

--- a/feature/signup/src/main/java/com/idle/signup/worker/complete/SignUpCompleteFragment.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/complete/SignUpCompleteFragment.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
-import com.idle.analytics.helper.TrackScreenViewEvent
+import com.idle.analytics.businessmetric.TrackScreenViewEvent
 import com.idle.binding.DeepLinkDestination
 import com.idle.binding.NavigationEvent
 import com.idle.center.jobposting.complete.SignUpCompleteViewModel

--- a/feature/withdrawal/src/main/java/com/idle/withdrawal/AnalyticsExtensions.kt
+++ b/feature/withdrawal/src/main/java/com/idle/withdrawal/AnalyticsExtensions.kt
@@ -6,8 +6,8 @@ import com.idle.analytics.AnalyticsEvent
 import com.idle.analytics.AnalyticsEvent.PropertiesKeys.ACTION_NAME
 import com.idle.analytics.AnalyticsEvent.PropertiesKeys.SCREEN_NAME
 import com.idle.analytics.AnalyticsEvent.Types.SCREEN_VIEW
-import com.idle.analytics.helper.AnalyticsHelper
-import com.idle.analytics.helper.LocalAnalyticsHelper
+import com.idle.analytics.businessmetric.AnalyticsHelper
+import com.idle.analytics.businessmetric.LocalAnalyticsHelper
 
 @Composable
 internal fun LogWithdrawalStep(

--- a/feature/withdrawal/src/main/java/com/idle/withdrawal/WithdrawalViewModel.kt
+++ b/feature/withdrawal/src/main/java/com/idle/withdrawal/WithdrawalViewModel.kt
@@ -1,7 +1,7 @@
 package com.idle.withdrawal
 
 import androidx.lifecycle.viewModelScope
-import com.idle.analytics.helper.AnalyticsHelper
+import com.idle.analytics.businessmetric.AnalyticsHelper
 import com.idle.binding.EventHandlerHelper
 import com.idle.binding.MainEvent
 import com.idle.binding.NavigationEvent
@@ -12,7 +12,7 @@ import com.idle.domain.model.CountDownTimer.Companion.SECONDS_PER_MINUTE
 import com.idle.domain.model.CountDownTimer.Companion.TICK_INTERVAL
 import com.idle.domain.model.auth.UserType
 import com.idle.domain.model.error.ApiErrorCode
-import com.idle.domain.model.error.ErrorHandlerHelper
+import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.model.error.HttpResponseException
 import com.idle.domain.usecase.auth.ConfirmAuthCodeUseCase
 import com.idle.domain.usecase.auth.SendPhoneNumberUseCase
@@ -33,7 +33,7 @@ class WithdrawalViewModel @Inject constructor(
     private val withdrawalWorkerUseCase: WithdrawalWorkerUseCase,
     private val countDownTimer: CountDownTimer,
     private val analyticsHelper: AnalyticsHelper,
-    private val errorHandlerHelper: ErrorHandlerHelper,
+    private val errorHandlerHelper: ErrorHandler,
     private val eventHandlerHelper: EventHandlerHelper,
     val navigationHelper: NavigationHelper,
 ) : BaseViewModel() {

--- a/feature/worker/chatting/src/main/java/com/idle/worker/chatting/WorkerChattingFragment.kt
+++ b/feature/worker/chatting/src/main/java/com/idle/worker/chatting/WorkerChattingFragment.kt
@@ -60,12 +60,17 @@ internal class WorkerChattingFragment : BaseComposeFragment() {
 
             LifecycleEventEffect(Lifecycle.Event.ON_CREATE) {
                 getChatRoomList()
+                subscribeChatMessage()
             }
 
-            WorkerChattingScreen(
-                chatRoomList = chatRoomList,
-                navigateTo = { navigationHelper.navigateTo(NavigationEvent.NavigateTo(it)) },
-            )
+            if(chatRoomList != null) {
+                WorkerChattingScreen(
+                    chatRoomList = chatRoomList,
+                    navigateTo = { navigationHelper.navigateTo(NavigationEvent.NavigateTo(it)) },
+                )
+            } else {
+                // Todo : 스켈레톤 UI 혹은 스피너 로딩
+            }
         }
     }
 }

--- a/feature/worker/chatting/src/main/java/com/idle/worker/chatting/WorkerChattingFragment.kt
+++ b/feature/worker/chatting/src/main/java/com/idle/worker/chatting/WorkerChattingFragment.kt
@@ -1,6 +1,5 @@
 package com.idle.worker.chatting
 
-import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -176,7 +175,6 @@ internal fun ChatRoomItem(
                 model = chatRoom.profileImageUrl,
                 placeholder = painterResource(com.idle.designresource.R.drawable.ic_notification_placeholder),
                 error = painterResource(com.idle.designresource.R.drawable.ic_notification_placeholder),
-                onError = { Log.d("test", chatRoom.profileImageUrl) },
                 contentDescription = "",
                 contentScale = ContentScale.Crop,
                 modifier = Modifier

--- a/feature/worker/chatting/src/main/java/com/idle/worker/chatting/WorkerChattingViewModel.kt
+++ b/feature/worker/chatting/src/main/java/com/idle/worker/chatting/WorkerChattingViewModel.kt
@@ -5,25 +5,85 @@ import com.idle.binding.NavigationHelper
 import com.idle.binding.base.BaseViewModel
 import com.idle.domain.model.chatting.ChatRoom
 import com.idle.domain.model.error.ErrorHandler
+import com.idle.domain.model.profile.WorkerProfile
 import com.idle.domain.usecase.chatting.GetChatRoomListUseCase
+import com.idle.domain.usecase.chatting.SubscribeChatMessageUseCase
+import com.idle.domain.usecase.profile.GetCenterProfileUseCase
+import com.idle.domain.usecase.profile.GetLocalMyWorkerProfileUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class WorkerChattingViewModel @Inject constructor(
+    private val getLocalMyWorkerProfileUseCase: GetLocalMyWorkerProfileUseCase,
+    private val getCenterProfileUseCase: GetCenterProfileUseCase,
     private val getChatRoomListUseCase: GetChatRoomListUseCase,
-    private val errorHandlerHelper: ErrorHandler,
+    private val subscribeChatMessageUseCase: SubscribeChatMessageUseCase,
+    private val errorHandler: ErrorHandler,
     val navigationHelper: NavigationHelper,
 ) : BaseViewModel() {
-    private val _chatRoomList = MutableStateFlow<List<ChatRoom>?>(emptyList())
-    val chatRoomList = _chatRoomList.asStateFlow()
+    private var myProfile: WorkerProfile? = null
+
+    private val _chatRoomMap = MutableStateFlow<LinkedHashMap<String, ChatRoom>>(LinkedHashMap())
+    val chatRoomList = _chatRoomMap
+        .map { it.values.toList() }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Lazily,
+            initialValue = null,
+        )
+
+    init {
+        viewModelScope.launch {
+            getLocalMyWorkerProfileUseCase().onSuccess {
+                myProfile = it
+            }.onFailure { errorHandler.sendError(it) }
+        }
+    }
+
+    internal fun subscribeChatMessage() = viewModelScope.launch {
+        subscribeChatMessageUseCase().collect { chatMessage ->
+            val updatedMap = LinkedHashMap(_chatRoomMap.value) // 기존 맵을 복사
+            val roomId = chatMessage.roomId
+            val chatRoom = updatedMap[roomId]
+
+            if (chatRoom != null) {
+                // 기존 방이 있으면 업데이트 후 최상단으로 올리기 위해 제거 후 다시 추가
+                updatedMap.remove(roomId)
+                updatedMap[roomId] = chatRoom.copy(
+                    lastMessage = chatMessage.printPlainContents(),
+                    unReadMessageCount = chatRoom.unReadMessageCount + 1,
+                )
+            } else {
+                // 새로운 방이면 새로 생성 후 최상단에 추가
+                val newChatRoom = ChatRoom(
+                    id = roomId,
+                    lastMessage = chatMessage.printPlainContents(),
+                    sender = chatMessage.senderId,
+                    receiver = myProfile?.workerId ?: "",
+                    createdAt = chatMessage.createdAt,
+                    lastSentAt = chatMessage.createdAt,
+                    unReadMessageCount = 1,
+                    profileImageUrl = getCenterProfileUseCase(chatMessage.senderId)
+                        .map { it.profileImageUrl }
+                        .getOrNull(),
+                )
+                updatedMap[roomId] = newChatRoom
+            }
+            _chatRoomMap.value = updatedMap // StateFlow에 갱신된 맵 할당
+        }
+    }
 
     internal fun getChatRoomList() = viewModelScope.launch {
         getChatRoomListUseCase().onSuccess {
-            _chatRoomList.value = it
-        }.onFailure { errorHandlerHelper.sendError(it) }
+            _chatRoomMap.value = LinkedHashMap<String, ChatRoom>().apply {
+                it.forEach { chatRoom -> put(chatRoom.id, chatRoom) }
+            }
+        }.onFailure { errorHandler.sendError(it) }
     }
 }

--- a/feature/worker/chatting/src/main/java/com/idle/worker/chatting/WorkerChattingViewModel.kt
+++ b/feature/worker/chatting/src/main/java/com/idle/worker/chatting/WorkerChattingViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.viewModelScope
 import com.idle.binding.NavigationHelper
 import com.idle.binding.base.BaseViewModel
 import com.idle.domain.model.chatting.ChatRoom
-import com.idle.domain.model.error.ErrorHandlerHelper
+import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.usecase.chatting.GetChatRoomListUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -15,7 +15,7 @@ import javax.inject.Inject
 @HiltViewModel
 class WorkerChattingViewModel @Inject constructor(
     private val getChatRoomListUseCase: GetChatRoomListUseCase,
-    private val errorHandlerHelper: ErrorHandlerHelper,
+    private val errorHandlerHelper: ErrorHandler,
     val navigationHelper: NavigationHelper,
 ) : BaseViewModel() {
     private val _chatRoomList = MutableStateFlow<List<ChatRoom>?>(emptyList())

--- a/feature/worker/home/src/main/java/com/idle/worker/home/WorkerHomeFragment.kt
+++ b/feature/worker/home/src/main/java/com/idle/worker/home/WorkerHomeFragment.kt
@@ -44,8 +44,8 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.idle.analytics.helper.LocalAnalyticsHelper
-import com.idle.analytics.helper.TrackScreenViewEvent
+import com.idle.analytics.businessmetric.LocalAnalyticsHelper
+import com.idle.analytics.businessmetric.TrackScreenViewEvent
 import com.idle.binding.DeepLinkDestination
 import com.idle.binding.DeepLinkDestination.WorkerJobDetail
 import com.idle.binding.NavigationEvent

--- a/feature/worker/home/src/main/java/com/idle/worker/home/WorkerHomeViewModel.kt
+++ b/feature/worker/home/src/main/java/com/idle/worker/home/WorkerHomeViewModel.kt
@@ -6,7 +6,7 @@ import com.idle.binding.MainEvent
 import com.idle.binding.NavigationHelper
 import com.idle.binding.ToastType
 import com.idle.binding.base.BaseViewModel
-import com.idle.domain.model.error.ErrorHandlerHelper
+import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.model.jobposting.ApplyMethod
 import com.idle.domain.model.jobposting.CrawlingJobPosting
 import com.idle.domain.model.jobposting.JobPosting
@@ -38,7 +38,7 @@ class WorkerHomeViewModel @Inject constructor(
     private val removeFavoriteJobPostingUseCase: RemoveFavoriteJobPostingUseCase,
     private val showNotificationCenterUseCase: ShowNotificationCenterUseCase,
     private val getUnreadNotificationCountUseCase: GetUnreadNotificationCountUseCase,
-    private val errorHandlerHelper: ErrorHandlerHelper,
+    private val errorHandlerHelper: ErrorHandler,
     private val eventHandlerHelper: EventHandlerHelper,
     val navigationHelper: NavigationHelper,
 ) : BaseViewModel() {

--- a/feature/worker/job-posting/src/main/java/com/idle/worker/job/posting/WorkerJobPostingFragment.kt
+++ b/feature/worker/job-posting/src/main/java/com/idle/worker/job/posting/WorkerJobPostingFragment.kt
@@ -37,8 +37,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.idle.analytics.helper.LocalAnalyticsHelper
-import com.idle.analytics.helper.TrackScreenViewEvent
+import com.idle.analytics.businessmetric.LocalAnalyticsHelper
+import com.idle.analytics.businessmetric.TrackScreenViewEvent
 import com.idle.binding.DeepLinkDestination
 import com.idle.binding.DeepLinkDestination.WorkerJobDetail
 import com.idle.binding.NavigationEvent

--- a/feature/worker/job-posting/src/main/java/com/idle/worker/job/posting/WorkerJobPostingViewModel.kt
+++ b/feature/worker/job-posting/src/main/java/com/idle/worker/job/posting/WorkerJobPostingViewModel.kt
@@ -6,7 +6,7 @@ import com.idle.binding.MainEvent
 import com.idle.binding.NavigationHelper
 import com.idle.binding.ToastType
 import com.idle.binding.base.BaseViewModel
-import com.idle.domain.model.error.ErrorHandlerHelper
+import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.model.jobposting.ApplyMethod
 import com.idle.domain.model.jobposting.CrawlingJobPosting
 import com.idle.domain.model.jobposting.JobPosting
@@ -36,7 +36,7 @@ class WorkerJobPostingViewModel @Inject constructor(
     private val applyJobPostingUseCase: ApplyJobPostingUseCase,
     private val addFavoriteJobPostingUseCase: AddFavoriteJobPostingUseCase,
     private val removeFavoriteJobPostingUseCase: RemoveFavoriteJobPostingUseCase,
-    private val errorHandlerHelper: ErrorHandlerHelper,
+    private val errorHandlerHelper: ErrorHandler,
     private val eventHandlerHelper: EventHandlerHelper,
     val navigationHelper: NavigationHelper,
 ) : BaseViewModel() {

--- a/feature/worker/profile/src/main/java/com/idle/worker/profile/WorkerProfileFragment.kt
+++ b/feature/worker/profile/src/main/java/com/idle/worker/profile/WorkerProfileFragment.kt
@@ -345,6 +345,8 @@ internal fun WorkerProfileScreen(
                             ) {
                                 AsyncImage(
                                     model = profileImageUri ?: R.drawable.ic_worker_photo_default,
+                                    error = painterResource(R.drawable.ic_worker_photo_default),
+                                    placeholder = painterResource(R.drawable.ic_worker_photo_default),
                                     contentDescription = null,
                                     contentScale = ContentScale.Crop,
                                     modifier = Modifier

--- a/feature/worker/profile/src/main/java/com/idle/worker/profile/WorkerProfileFragment.kt
+++ b/feature/worker/profile/src/main/java/com/idle/worker/profile/WorkerProfileFragment.kt
@@ -52,7 +52,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import coil.compose.AsyncImage
-import com.idle.analytics.helper.TrackScreenViewEvent
+import com.idle.analytics.businessmetric.TrackScreenViewEvent
 import com.idle.compose.addFocusCleaner
 import com.idle.compose.base.BaseComposeFragment
 import com.idle.compose.clickable

--- a/feature/worker/profile/src/main/java/com/idle/worker/profile/WorkerProfileViewModel.kt
+++ b/feature/worker/profile/src/main/java/com/idle/worker/profile/WorkerProfileViewModel.kt
@@ -7,7 +7,7 @@ import com.idle.binding.base.BaseViewModel
 import com.idle.binding.EventHandlerHelper
 import com.idle.binding.MainEvent
 import com.idle.binding.ToastType
-import com.idle.domain.model.error.ErrorHandlerHelper
+import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.model.profile.JobSearchStatus
 import com.idle.domain.model.profile.WorkerProfile
 import com.idle.domain.usecase.profile.GetLocalMyWorkerProfileUseCase
@@ -24,7 +24,7 @@ class WorkerProfileViewModel @Inject constructor(
     private val getLocalMyWorkerProfileUseCase: GetLocalMyWorkerProfileUseCase,
     private val getWorkerProfileUseCase: GetWorkerProfileUseCase,
     private val updateWorkerProfileUseCase: UpdateWorkerProfileUseCase,
-    private val errorHandlerHelper: ErrorHandlerHelper,
+    private val errorHandlerHelper: ErrorHandler,
     private val eventHandlerHelper: EventHandlerHelper,
 ) : BaseViewModel() {
     private val _workerProfile = MutableStateFlow<WorkerProfile?>(null)

--- a/feature/worker/profile/src/main/java/com/idle/worker/profile/WorkerProfileViewModel.kt
+++ b/feature/worker/profile/src/main/java/com/idle/worker/profile/WorkerProfileViewModel.kt
@@ -3,10 +3,10 @@ package com.idle.worker.profile
 import android.net.Uri
 import androidx.core.net.toUri
 import androidx.lifecycle.viewModelScope
-import com.idle.binding.base.BaseViewModel
 import com.idle.binding.EventHandlerHelper
 import com.idle.binding.MainEvent
 import com.idle.binding.ToastType
+import com.idle.binding.base.BaseViewModel
 import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.model.profile.JobSearchStatus
 import com.idle.domain.model.profile.WorkerProfile
@@ -55,7 +55,7 @@ class WorkerProfileViewModel @Inject constructor(
 
     private val _isUpdateLoading = MutableStateFlow(false)
     val isUpdateLoading = _isUpdateLoading.asStateFlow()
-    
+
     internal fun setSpecialty(number: String) {
         _specialty.value = number
     }
@@ -144,6 +144,6 @@ class WorkerProfileViewModel @Inject constructor(
             )
             setEditState(false)
         }.onFailure { errorHandlerHelper.sendError(it) }
-        .also { _isUpdateLoading.value = false }
+            .also { _isUpdateLoading.value = false }
     }
 }

--- a/presentation/src/main/java/com/idle/presentation/MainActivity.kt
+++ b/presentation/src/main/java/com/idle/presentation/MainActivity.kt
@@ -205,21 +205,26 @@ class MainActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         networkObserver.checkNetworkState()
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        networkObserver.unsubscribeNetworkCallback()
+        if (networkObserver.networkState.value == NetworkState.CONNECTED) {
+            viewModel.connectWebSocket()
+        }
     }
 
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
-
         viewModel.navigationHelper.handleFCMNavigate(
             isColdStart = false,
             extras = intent?.extras ?: return,
             onInit = viewModel::initializeUserSession,
         )
+    }
+
+    override fun onPause() {
+        super.onPause()
+        networkObserver.unsubscribeNetworkCallback()
+        if (networkObserver.networkState.value == NetworkState.CONNECTED) {
+            viewModel.disconnectWebSocket()
+        }
     }
 
     private fun showNetworkDialog() {

--- a/presentation/src/main/java/com/idle/presentation/MainViewModel.kt
+++ b/presentation/src/main/java/com/idle/presentation/MainViewModel.kt
@@ -2,6 +2,7 @@ package com.idle.presentation
 
 import android.util.Log
 import androidx.lifecycle.viewModelScope
+import com.idle.analytics.error.ErrorLoggingHelper
 import com.idle.auth.R
 import com.idle.binding.DeepLinkDestination.CenterHome
 import com.idle.binding.DeepLinkDestination.CenterPending
@@ -15,7 +16,7 @@ import com.idle.binding.base.BaseViewModel
 import com.idle.domain.model.auth.UserType
 import com.idle.domain.model.config.ForceUpdate
 import com.idle.domain.model.error.ApiErrorCode
-import com.idle.domain.model.error.ErrorHandlerHelper
+import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.model.error.HttpResponseException
 import com.idle.domain.model.profile.CenterManagerAccountStatus
 import com.idle.domain.usecase.auth.GetAccessTokenUseCase
@@ -48,8 +49,9 @@ class MainViewModel @Inject constructor(
     private val getCenterStatusUseCase: GetCenterStatusUseCase,
     private val connectWebSocketUseCase: ConnectWebSocketUseCase,
     private val disconnectWebSocketUseCase: DisconnectWebSocketUseCase,
-    private val errorHandlerHelper: ErrorHandlerHelper,
+    private val errorHandlerHelper: ErrorHandler,
     private val eventHandlerHelper: EventHandlerHelper,
+    val errorLoggingHelper: ErrorLoggingHelper,
     val navigationHelper: NavigationHelper,
 ) : BaseViewModel() {
     private val _navigationMenuType = MutableStateFlow(NavigationMenuType.HIDE)
@@ -158,6 +160,8 @@ class MainViewModel @Inject constructor(
 
     private fun handleError() = viewModelScope.launch {
         errorHandlerHelper.errorEvent.collect { exception ->
+            errorLoggingHelper.logError(exception)
+
             when (exception) {
                 is HttpResponseException -> {
                     when (exception.apiErrorCode) {
@@ -167,13 +171,12 @@ class MainViewModel @Inject constructor(
                         ApiErrorCode.TokenNotFound,
                         ApiErrorCode.NotSupportUserTokenType ->
                             navigationHelper.navigateTo(
-                                NavigationEvent.NavigateToAuthWithClearBackStack(
-                                    exception.print()
-                                )
+                                NavigationEvent.NavigateToAuthWithClearBackStack(exception.print())
                             )
 
                         else -> eventHandlerHelper.sendEvent(ShowToast(exception.print()))
                     }
+                    return@collect
                 }
 
                 is SocketTimeoutException -> eventHandlerHelper.sendEvent(ShowToast("서버 응답 시간이 초과되었습니다. 잠시 후 다시 시도해 주세요."))

--- a/presentation/src/main/java/com/idle/presentation/MainViewModel.kt
+++ b/presentation/src/main/java/com/idle/presentation/MainViewModel.kt
@@ -1,5 +1,6 @@
 package com.idle.presentation
 
+import android.util.Log
 import androidx.lifecycle.viewModelScope
 import com.idle.auth.R
 import com.idle.binding.DeepLinkDestination.CenterHome
@@ -19,6 +20,8 @@ import com.idle.domain.model.error.HttpResponseException
 import com.idle.domain.model.profile.CenterManagerAccountStatus
 import com.idle.domain.usecase.auth.GetAccessTokenUseCase
 import com.idle.domain.usecase.auth.GetUserTypeUseCase
+import com.idle.domain.usecase.chatting.ConnectWebSocketUseCase
+import com.idle.domain.usecase.chatting.DisconnectWebSocketUseCase
 import com.idle.domain.usecase.config.GetForceUpdateInfoUseCase
 import com.idle.domain.usecase.profile.GetCenterStatusUseCase
 import com.idle.domain.usecase.profile.GetMyCenterProfileUseCase
@@ -43,6 +46,8 @@ class MainViewModel @Inject constructor(
     private val getMyCenterProfileUseCase: GetMyCenterProfileUseCase,
     private val getMyWorkerProfileUseCase: GetMyWorkerProfileUseCase,
     private val getCenterStatusUseCase: GetCenterStatusUseCase,
+    private val connectWebSocketUseCase: ConnectWebSocketUseCase,
+    private val disconnectWebSocketUseCase: DisconnectWebSocketUseCase,
     private val errorHandlerHelper: ErrorHandlerHelper,
     private val eventHandlerHelper: EventHandlerHelper,
     val navigationHelper: NavigationHelper,
@@ -61,6 +66,18 @@ class MainViewModel @Inject constructor(
 
     init {
         handleError()
+    }
+
+    internal fun connectWebSocket() = viewModelScope.launch {
+        Log.d("test", "웹소켓 연결")
+        connectWebSocketUseCase().onSuccess { }
+            .onFailure { }
+    }
+
+    internal fun disconnectWebSocket() = viewModelScope.launch {
+        Log.d("test", "웹소켓 연결해제")
+        disconnectWebSocketUseCase().onSuccess { }
+            .onFailure { }
     }
 
     internal fun setNavigationMenuType(navigationMenuType: NavigationMenuType) {

--- a/presentation/src/main/java/com/idle/presentation/forceupdate/ForceUpdateFragment.kt
+++ b/presentation/src/main/java/com/idle/presentation/forceupdate/ForceUpdateFragment.kt
@@ -12,7 +12,7 @@ import android.view.WindowManager
 import androidx.core.net.toUri
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
-import com.idle.analytics.helper.AnalyticsHelper
+import com.idle.analytics.businessmetric.AnalyticsHelper
 import com.idle.binding.repeatOnStarted
 import com.idle.domain.model.config.ForceUpdate
 import com.idle.presentation.databinding.FragmentForceUpdateBinding


### PR DESCRIPTION
## 1. 🔥 변경된 내용
- **웹소켓 연결 및 해제**
- **웹소켓 채팅 데이터 파이프라인 연결**
- **에러가 났을 경우 Firebase Crashlytics로 에러를 로깅하도록 구현**

<img width="1013" alt="image" src="https://github.com/user-attachments/assets/f739a5dc-9a5a-4cf9-9521-bae34d5d87c5">

**PR을 쨋어야했는데.... 하다보니.... ㅠㅠ**

## 2. 📌 고민했던 부분

### 요구사항 정리
- 새로운 채팅 메시지 수신: roomId를 확인하여 채팅방 목록에 해당 roomId가 있는지 찾는다.
- 기존 채팅방이 있을 경우: 해당 채팅방을 목록에서 최상단으로 올리고, 채팅방 정보를 업데이트한다.
- 새로운 채팅방일 경우: 새로운 채팅방을 생성하여 목록의 최상단에 추가한다.

<br><br>

### 고려했던 자료구조
- List, LinkedHashMap

<br><br>

### 1. List
- 구조: 단순한 순차 배열로, 각 채팅방을 List의 요소로 관리
- 장점: 배열 형태로 접근이 간단하며, List 자체가 MutableStateFlow와 잘 어울림
- 단점: 특정 roomId를 찾을 때 O(n)의 시간 복잡도가 발생합니다. 채팅방을 최상단으로 옮기려면, 요소를 삭제하고 다시 삽입해야 하므로 비효율적일 수 있음.

### 2. LinkedHashMap
- 구조: roomId를 키로 하고, 채팅방 데이터를 값으로 가지는 LinkedHashMap을 사용.
- 장점: 키를 통해 O(1) 시간 복잡도로 특정 채팅방을 찾을 수 있음. 새로운 채팅방을 추가하거나 기존 채팅방을 최상단으로 이동할 때도 remove 후 put하면 효율적으로 순서를 조정할 수 있음.
- 단점: LinkedHashMap은 순서가 있지만, 이를 MutableStateFlow로 사용하려면 List로 변환해야 함.

<br><br>

결론 : O(1)로 특정 채팅방을 찾을 수 있고, LinkedList의 특성상 remove와 put의 시간복잡도는 O(1) 이기 때문에 매우 적합할 것이라고 판단.