### PR TITLE
[IDLE-500] 다중 디바이스 지원을 위해 FCM Token을 제거할 때 Device Token을 Body에 담도록 변경

### DIFF
--- a/core/data/src/main/java/com/idle/data/repository/auth/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/idle/data/repository/auth/AuthRepositoryImpl.kt
@@ -18,7 +18,6 @@ import com.idle.network.model.auth.WithdrawalWorkerRequest
 import com.idle.network.model.token.TokenResponse
 import com.idle.network.source.auth.AuthDataSource
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -116,21 +115,21 @@ class AuthRepositoryImpl @Inject constructor(
     )
 
     override suspend fun logoutWorker(): Result<Unit> {
-        tokenRepository.deleteDeviceToken()
+        tokenRepository.deleteDeviceToken(getDeviceToken())
 
         return authDataSource.logoutWorker()
             .onSuccess { clearUserData() }
     }
 
     override suspend fun logoutCenter(): Result<Unit> {
-        tokenRepository.deleteDeviceToken()
+        tokenRepository.deleteDeviceToken(getDeviceToken())
 
         return authDataSource.logoutCenter()
             .onSuccess { clearUserData() }
     }
 
     override suspend fun withdrawalCenter(reason: String, password: String): Result<Unit> {
-        tokenRepository.deleteDeviceToken()
+        tokenRepository.deleteDeviceToken(getDeviceToken())
 
         return authDataSource.withdrawalCenter(
             WithdrawalCenterRequest(reason = reason, password = password)
@@ -138,7 +137,7 @@ class AuthRepositoryImpl @Inject constructor(
     }
 
     override suspend fun withdrawalWorker(reason: String): Result<Unit> {
-        tokenRepository.deleteDeviceToken()
+        tokenRepository.deleteDeviceToken(getDeviceToken())
 
         return authDataSource.withdrawalWorker(WithdrawalWorkerRequest(reason))
             .onSuccess { clearUserData() }
@@ -163,10 +162,10 @@ class AuthRepositoryImpl @Inject constructor(
     ) = withContext(Dispatchers.IO) {
         launch { tokenDataSource.setRefreshToken(tokenResponse.refreshToken) }
         launch { userInfoDataSource.setUserType(userType) }
-        launch { tokenDataSource.setAccessToken(tokenResponse.accessToken) }
+        launch { tokenDataSource.setAccessToken(tokenResponse.accessToken) }.join()
 
-        val deviceToken = async { getDeviceToken() }
-        tokenRepository.postDeviceToken(deviceToken.await(), userType = userType)
+        val deviceToken = getDeviceToken()
+        tokenRepository.postDeviceToken(deviceToken, userType = userType)
     }
 
     private suspend fun clearUserData() = withContext(Dispatchers.IO) {

--- a/core/data/src/main/java/com/idle/data/repository/auth/TokenRepositoryImpl.kt
+++ b/core/data/src/main/java/com/idle/data/repository/auth/TokenRepositoryImpl.kt
@@ -2,7 +2,8 @@ package com.idle.data.repository.auth
 
 import com.idle.datastore.datasource.TokenDataSource
 import com.idle.domain.repositorry.auth.TokenRepository
-import com.idle.network.model.auth.FCMTokenRequest
+import com.idle.network.model.notification.DeleteFcmTokenRequest
+import com.idle.network.model.notification.PostFcmTokenRequest
 import com.idle.network.source.notification.NotificationDataSource
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -19,11 +20,12 @@ class TokenRepositoryImpl @Inject constructor(
 
     override suspend fun postDeviceToken(deviceToken: String, userType: String): Result<Unit> =
         notificationDataSource.postFCMToken(
-            FCMTokenRequest(
+            PostFcmTokenRequest(
                 deviceToken = deviceToken,
                 userType = userType,
             )
         )
 
-    override suspend fun deleteDeviceToken(): Result<Unit> = notificationDataSource.deleteFCMToken()
+    override suspend fun deleteDeviceToken(deviceToken: String): Result<Unit> =
+        notificationDataSource.deleteFCMToken(DeleteFcmTokenRequest(deviceToken))
 }

--- a/core/data/src/test/java/com/idle/data/repository/auth/AuthRepositoryImplTest.kt
+++ b/core/data/src/test/java/com/idle/data/repository/auth/AuthRepositoryImplTest.kt
@@ -44,7 +44,7 @@ class AuthRepositoryImplTest {
         coEvery { userInfoDataSource.clearUserInfo() } just Runs
         coEvery { authDataSource.getDeviceToken() } returns "testToken"
         coEvery { tokenRepository.postDeviceToken(any(), any()) } returns Result.success(Unit)
-        coEvery { tokenRepository.deleteDeviceToken() } returns Result.success(Unit)
+        coEvery { tokenRepository.deleteDeviceToken(any()) } returns Result.success(Unit)
     }
 
     @Test
@@ -109,7 +109,7 @@ class AuthRepositoryImplTest {
         // Then
         assertTrue(result.isSuccess)
         coVerify { tokenDataSource.clearToken() }
-        coVerify { tokenRepository.deleteDeviceToken() }
+        coVerify { tokenRepository.deleteDeviceToken(any()) }
         coVerify { userInfoDataSource.clearUserType() }
         coVerify { userInfoDataSource.clearUserInfo() }
     }
@@ -125,7 +125,7 @@ class AuthRepositoryImplTest {
         // Then
         assertTrue(result.isSuccess)
         coVerify { tokenDataSource.clearToken() }
-        coVerify { tokenRepository.deleteDeviceToken() }
+        coVerify { tokenRepository.deleteDeviceToken(any()) }
         coVerify { userInfoDataSource.clearUserType() }
         coVerify { userInfoDataSource.clearUserInfo() }
     }
@@ -141,7 +141,7 @@ class AuthRepositoryImplTest {
         // Then
         assertTrue(result.isSuccess)
         coVerify { tokenDataSource.clearToken() }
-        coVerify { tokenRepository.deleteDeviceToken() }
+        coVerify { tokenRepository.deleteDeviceToken(any()) }
         coVerify { userInfoDataSource.clearUserType() }
         coVerify { userInfoDataSource.clearUserInfo() }
     }
@@ -157,7 +157,7 @@ class AuthRepositoryImplTest {
         // Then
         assertTrue(result.isSuccess)
         coVerify { tokenDataSource.clearToken() }
-        coVerify { tokenRepository.deleteDeviceToken() }
+        coVerify { tokenRepository.deleteDeviceToken(any()) }
         coVerify { userInfoDataSource.clearUserType() }
         coVerify { userInfoDataSource.clearUserInfo() }
     }

--- a/core/domain/src/main/kotlin/com/idle/domain/repositorry/auth/TokenRepository.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/repositorry/auth/TokenRepository.kt
@@ -2,7 +2,6 @@ package com.idle.domain.repositorry.auth
 
 interface TokenRepository {
     suspend fun getAccessToken(): String
-
     suspend fun postDeviceToken(deviceToken: String, userType: String): Result<Unit>
-    suspend fun deleteDeviceToken(): Result<Unit>
+    suspend fun deleteDeviceToken(deviceToken: String): Result<Unit>
 }

--- a/core/network/src/main/java/com/idle/network/api/NotificationApi.kt
+++ b/core/network/src/main/java/com/idle/network/api/NotificationApi.kt
@@ -1,12 +1,13 @@
 package com.idle.network.api
 
-import com.idle.network.model.auth.FCMTokenRequest
+import com.idle.network.model.notification.DeleteFcmTokenRequest
 import com.idle.network.model.notification.GetMyNotificationResponse
 import com.idle.network.model.notification.GetUnreadNotificationCountResponse
+import com.idle.network.model.notification.PostFcmTokenRequest
 import retrofit2.Response
 import retrofit2.http.Body
-import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.HTTP
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
@@ -14,13 +15,10 @@ import retrofit2.http.Query
 
 interface NotificationApi {
     @POST("/api/v1/fcm/token")
-    suspend fun postFCMToken(@Body fcmTokenRequest: FCMTokenRequest): Response<Unit>
+    suspend fun postFCMToken(@Body postFcmTokenRequest: PostFcmTokenRequest): Response<Unit>
 
-    @PATCH("/api/v1/fcm/token")
-    suspend fun patchFCMToken(@Body fcmTokenRequest: FCMTokenRequest): Response<Unit>
-
-    @DELETE("/api/v1/fcm/token")
-    suspend fun deleteFCMToken(): Response<Unit>
+    @HTTP(method = "DELETE", path = "/api/v1/fcm/token", hasBody = true)
+    suspend fun deleteFCMToken(@Body deleteFcmTokenRequest: DeleteFcmTokenRequest): Response<Unit>
 
     @GET("/api/v1/notifications/my")
     suspend fun getMyNotifications(

--- a/core/network/src/main/java/com/idle/network/model/notification/DeleteFcmTokenRequest.kt
+++ b/core/network/src/main/java/com/idle/network/model/notification/DeleteFcmTokenRequest.kt
@@ -1,0 +1,8 @@
+package com.idle.network.model.notification
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DeleteFcmTokenRequest(
+    val deviceToken: String,
+)

--- a/core/network/src/main/java/com/idle/network/model/notification/PostFcmTokenRequest.kt
+++ b/core/network/src/main/java/com/idle/network/model/notification/PostFcmTokenRequest.kt
@@ -1,9 +1,9 @@
-package com.idle.network.model.auth
+package com.idle.network.model.notification
 
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class FCMTokenRequest(
+data class PostFcmTokenRequest(
     val deviceToken: String,
     val userType: String,
 )

--- a/core/network/src/main/java/com/idle/network/source/notification/NotificationDataSource.kt
+++ b/core/network/src/main/java/com/idle/network/source/notification/NotificationDataSource.kt
@@ -1,7 +1,8 @@
 package com.idle.network.source.notification
 
 import com.idle.network.api.NotificationApi
-import com.idle.network.model.auth.FCMTokenRequest
+import com.idle.network.model.notification.DeleteFcmTokenRequest
+import com.idle.network.model.notification.PostFcmTokenRequest
 import com.idle.network.model.notification.GetMyNotificationResponse
 import com.idle.network.model.notification.GetUnreadNotificationCountResponse
 import com.idle.network.util.safeApiCall
@@ -12,10 +13,11 @@ import javax.inject.Singleton
 class NotificationDataSource @Inject constructor(
     private val notificationApi: NotificationApi
 ) {
-    suspend fun postFCMToken(fcmTokenRequest: FCMTokenRequest): Result<Unit> =
-        safeApiCall { notificationApi.postFCMToken(fcmTokenRequest) }
+    suspend fun postFCMToken(postFcmTokenRequest: PostFcmTokenRequest): Result<Unit> =
+        safeApiCall { notificationApi.postFCMToken(postFcmTokenRequest) }
 
-    suspend fun deleteFCMToken(): Result<Unit> = safeApiCall { notificationApi.deleteFCMToken() }
+    suspend fun deleteFCMToken(deleteFcmTokenRequest: DeleteFcmTokenRequest): Result<Unit> =
+        safeApiCall { notificationApi.deleteFCMToken(deleteFcmTokenRequest) }
 
     suspend fun getMyNotifications(
         next: String?,


### PR DESCRIPTION
## 1. 🔥 변경된 내용
- **다중 디바이스 지원을 위해 FCM Token을 제거할 때 Device TOken을 Body에 담도록 변경**

## 2. 💡 알게된 부분

Retrofit2를 사용하여 GET, DELETE, HEAD 를 사용할 때에는 일반적으로 Body를 사용할 수 없는데,

이 때 아래와 같이 `@HTTP 어노테이션`을 사용하여 강제적으로 `@Body`를 달아줄 수 있음.

```kotlin
@HTTP(method = "DELETE", path = "/api/v1/fcm/token", hasBody = true)
suspend fun deleteFCMToken(@Body deleteFcmTokenRequest: DeleteFcmTokenRequest): Response<Unit>
```

[레퍼런스](https://amuru.tistory.com/298)