### PR TITLE
[IDLE-507] 센터 회원가입 프로세스에서 요양 보호사가 어디까지 들어가는 지 알아보는 로깅 추가

### DIFF
--- a/core/domain/src/main/kotlin/com/idle/domain/repositorry/logging/LoggingRepository.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/repositorry/logging/LoggingRepository.kt
@@ -1,0 +1,9 @@
+package com.idle.domain.repositorry.logging
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class LoggingRepository @Inject constructor() {
+    var centerSignUpProcess: Int = 0
+}

--- a/feature/signup/src/main/java/com/idle/signup/AnalyticsExtensions.kt
+++ b/feature/signup/src/main/java/com/idle/signup/AnalyticsExtensions.kt
@@ -8,7 +8,7 @@ import com.idle.analytics.AnalyticsEvent.PropertiesKeys.SCREEN_NAME
 import com.idle.analytics.AnalyticsEvent.Types.SCREEN_VIEW
 import com.idle.analytics.businessmetric.AnalyticsHelper
 import com.idle.analytics.businessmetric.LocalAnalyticsHelper
-import com.idle.signin.worker.WorkerSignUpStep
+import com.idle.signup.worker.WorkerSignUpStep
 import com.idle.signup.center.CenterSignUpStep
 
 @Composable

--- a/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/idle/signup/center/CenterSignUpViewModel.kt
@@ -13,11 +13,13 @@ import com.idle.domain.model.error.ApiErrorCode
 import com.idle.domain.model.error.ErrorHandler
 import com.idle.domain.model.error.HttpResponseException
 import com.idle.domain.model.error.HttpResponseStatus
+import com.idle.domain.repositorry.logging.LoggingRepository
 import com.idle.domain.usecase.auth.ConfirmAuthCodeUseCase
 import com.idle.domain.usecase.auth.SendPhoneNumberUseCase
 import com.idle.domain.usecase.auth.SignUpCenterUseCase
 import com.idle.domain.usecase.auth.ValidateBusinessRegistrationNumberUseCase
 import com.idle.domain.usecase.auth.ValidateIdentifierUseCase
+import com.idle.navigation.NavigationHelper
 import com.idle.signup.R
 import com.idle.signup.center.CenterSignUpStep.NAME
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -39,10 +41,11 @@ class CenterSignUpViewModel @Inject constructor(
     private val signUpCenterUseCase: SignUpCenterUseCase,
     private val validateIdentifierUseCase: ValidateIdentifierUseCase,
     private val validateBusinessRegistrationNumberUseCase: ValidateBusinessRegistrationNumberUseCase,
+    private val loggingRepository: LoggingRepository,
     private val countDownTimer: CountDownTimer,
     private val errorHandlerHelper: ErrorHandler,
     private val eventHandlerHelper: EventHandlerHelper,
-    val navigationHelper: com.idle.navigation.NavigationHelper,
+    val navigationHelper: NavigationHelper,
 ) : ViewModel() {
     private val _signUpStep = MutableStateFlow(NAME)
     val signUpStep = _signUpStep.asStateFlow()
@@ -151,6 +154,11 @@ class CenterSignUpViewModel @Inject constructor(
     )
 
     internal fun setCenterSignUpStep(step: CenterSignUpStep) {
+        // for Logging
+        if (step.step > _signUpStep.value.step) {
+            loggingRepository.centerSignUpProcess = step.step
+        }
+
         _signUpStep.value = step
     }
 
@@ -217,7 +225,7 @@ class CenterSignUpViewModel @Inject constructor(
                 cancelTimer()
                 _isConfirmAuthCode.value = true
 
-                _signUpStep.value = CenterSignUpStep.BUSINESS_REGISTRATION
+                setCenterSignUpStep(CenterSignUpStep.BUSINESS_REGISTRATION)
             }.onFailure {
                 if (it is HttpResponseException && it.status == HttpResponseStatus.BadRequest) {
                     _isAuthCodeError.value = true
@@ -309,6 +317,10 @@ class CenterSignUpViewModel @Inject constructor(
             }
         }
         return false
+    }
+
+    private fun setCenterSignUpStep(step: Int) {
+        loggingRepository.centerSignUpProcess = step
     }
 
     companion object {

--- a/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpFragment.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpFragment.kt
@@ -28,6 +28,8 @@ import com.idle.designsystem.compose.component.CareSubtitleTopBar
 import com.idle.domain.model.auth.Gender
 import com.idle.navigation.DeepLinkDestination.Auth
 import com.idle.post.code.PostCodeFragment
+import com.idle.signup.worker.WorkerSignUpStep
+import com.idle.signup.worker.WorkerSignUpViewModel
 import com.idle.signup.worker.step.AddressScreen
 import com.idle.signup.worker.step.WorkerInformationScreen
 import com.idle.signup.worker.step.WorkerPhoneNumberScreen

--- a/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/WorkerSignUpViewModel.kt
@@ -1,4 +1,4 @@
-package com.idle.signin.worker
+package com.idle.signup.worker
 
 import androidx.core.text.isDigitsOnly
 import androidx.lifecycle.ViewModel
@@ -19,8 +19,9 @@ import com.idle.domain.usecase.auth.SignUpWorkerUseCase
 import com.idle.domain.usecase.profile.GetWorkerIdUseCase
 import com.idle.navigation.DeepLinkDestination.SignUpComplete
 import com.idle.navigation.DeepLinkDestination.WorkerHome
-import com.idle.signin.worker.WorkerSignUpStep.PHONE_NUMBER
+import com.idle.navigation.NavigationHelper
 import com.idle.signup.R
+import com.idle.signup.worker.WorkerSignUpStep.PHONE_NUMBER
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -39,7 +40,7 @@ class WorkerSignUpViewModel @Inject constructor(
     private val analyticsHelper: AnalyticsHelper,
     private val errorHandlerHelper: ErrorHandler,
     val eventHandlerHelper: EventHandlerHelper,
-    val navigationHelper: com.idle.navigation.NavigationHelper,
+    val navigationHelper: NavigationHelper,
 ) : ViewModel() {
 
     private val _signUpStep = MutableStateFlow<WorkerSignUpStep>(PHONE_NUMBER)

--- a/feature/signup/src/main/java/com/idle/signup/worker/complete/SignUpCompleteFragment.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/complete/SignUpCompleteFragment.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
+import com.idle.analytics.AnalyticsEvent
+import com.idle.analytics.businessmetric.LocalAnalyticsHelper
 import com.idle.analytics.businessmetric.TrackScreenViewEvent
 import com.idle.center.jobposting.complete.SignUpCompleteViewModel
 import com.idle.compose.base.BaseComposeFragment
@@ -31,7 +33,10 @@ class SignUpCompleteFragment : BaseComposeFragment() {
     @Composable
     override fun ComposeLayout() {
         fragmentViewModel.apply {
+            val centerSignUpProcessStep = getCenterSignUpProcessStep()
+
             SignUpCompleteScreen(
+                centerSignUpProcessStep = centerSignUpProcessStep,
                 navigateTo = {
                     navigationHelper.navigateTo(
                         com.idle.navigation.NavigationEvent.NavigateTo(
@@ -47,6 +52,7 @@ class SignUpCompleteFragment : BaseComposeFragment() {
 
 @Composable
 internal fun SignUpCompleteScreen(
+    centerSignUpProcessStep: Int,
     navigateTo: (com.idle.navigation.DeepLinkDestination) -> Unit,
 ) {
     Column(
@@ -90,5 +96,12 @@ internal fun SignUpCompleteScreen(
         )
     }
 
-    TrackScreenViewEvent(screenName = "signup_complete_screen")
+    LocalAnalyticsHelper.current.logEvent(
+        AnalyticsEvent(
+            type = "carer_signup_complete",
+            properties = mutableMapOf("center_signup_step" to centerSignUpProcessStep),
+        )
+    )
+
+    TrackScreenViewEvent(screenName = "carer_signup_complete_screen")
 }

--- a/feature/signup/src/main/java/com/idle/signup/worker/complete/SignUpCompleteViewModel.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/complete/SignUpCompleteViewModel.kt
@@ -1,9 +1,14 @@
 package com.idle.center.jobposting.complete
 
 import androidx.lifecycle.ViewModel
+import com.idle.domain.repositorry.logging.LoggingRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 @HiltViewModel
-class SignUpCompleteViewModel @Inject constructor(val navigationHelper: com.idle.navigation.NavigationHelper) :
-    ViewModel()
+class SignUpCompleteViewModel @Inject constructor(
+    private val loggingRepository: LoggingRepository,
+    val navigationHelper: com.idle.navigation.NavigationHelper
+) : ViewModel() {
+    fun getCenterSignUpProcessStep() = loggingRepository.centerSignUpProcess
+}

--- a/feature/signup/src/main/java/com/idle/signup/worker/step/AddressScreen.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/step/AddressScreen.kt
@@ -20,8 +20,8 @@ import com.idle.designsystem.compose.component.CareButtonMedium
 import com.idle.designsystem.compose.component.CareClickableTextField
 import com.idle.designsystem.compose.component.LabeledContent
 import com.idle.designsystem.compose.foundation.CareTheme
-import com.idle.signin.worker.WorkerSignUpStep
-import com.idle.signin.worker.WorkerSignUpStep.ADDRESS
+import com.idle.signup.worker.WorkerSignUpStep
+import com.idle.signup.worker.WorkerSignUpStep.ADDRESS
 import com.idle.signup.LogWorkerSignUpStep
 
 @Composable

--- a/feature/signup/src/main/java/com/idle/signup/worker/step/WorkeInfoScreen.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/step/WorkeInfoScreen.kt
@@ -31,8 +31,8 @@ import com.idle.designsystem.compose.component.CareTextField
 import com.idle.designsystem.compose.component.LabeledContent
 import com.idle.designsystem.compose.foundation.CareTheme
 import com.idle.domain.model.auth.Gender
-import com.idle.signin.worker.WorkerSignUpStep
-import com.idle.signin.worker.WorkerSignUpStep.INFO
+import com.idle.signup.worker.WorkerSignUpStep
+import com.idle.signup.worker.WorkerSignUpStep.INFO
 import com.idle.signup.LogWorkerSignUpStep
 
 @Composable

--- a/feature/signup/src/main/java/com/idle/signup/worker/step/WorkerPhoneNumberScreen.kt
+++ b/feature/signup/src/main/java/com/idle/signup/worker/step/WorkerPhoneNumberScreen.kt
@@ -23,8 +23,8 @@ import com.idle.designsystem.compose.component.CareButtonSmall
 import com.idle.designsystem.compose.component.CareTextField
 import com.idle.designsystem.compose.component.LabeledContent
 import com.idle.designsystem.compose.foundation.CareTheme
-import com.idle.signin.worker.WorkerSignUpStep
-import com.idle.signin.worker.WorkerSignUpStep.PHONE_NUMBER
+import com.idle.signup.worker.WorkerSignUpStep
+import com.idle.signup.worker.WorkerSignUpStep.PHONE_NUMBER
 import com.idle.signup.LogWorkerSignUpStep
 
 @Composable


### PR DESCRIPTION
## 1. 🔥 변경된 내용
- **센터 회원가입 프로세스에서 요양 보호사가 어디까지 들어가는 지 알아보는 로깅 추가**

## 2. 🫡 궁금한 부분

[센터 관리자 가입 프로세스에 호기심으로 눌러본 요양 보호사는 얼마나 될까? - 비즈니스 로깅](https://www.notion.so/958f1e1b89f640cdbe4fab26d920743e)

## 5. 📌 이 부분은 꼭 봐주세요!

굳이 **DataStore**까지 데이터를 보낼 필요도 없을 것 같아서 **LoggingRepository**를 만들고 메모리 케싱을 하도록 하였습니다!