### PR TITLE
[IDLE-472] 지수 백오프 -> 지수 백오프 + Equal Jitter로 변경

### DIFF
--- a/core/data/src/main/java/com/idle/data/repository/ChatRepositoryImpl.kt
+++ b/core/data/src/main/java/com/idle/data/repository/ChatRepositoryImpl.kt
@@ -12,7 +12,7 @@ import com.idle.network.model.chat.ReadMessageRequest
 import com.idle.network.model.chat.SendMessageRequest
 import com.idle.network.source.ChatDataSource
 import com.idle.network.util.MAX_RETRY_ATTEMPTS
-import com.idle.network.util.calculateBackoffTime
+import com.idle.network.util.calculateEqualJitter
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -122,7 +122,7 @@ class ChatRepositoryImpl @Inject constructor(
             }.retryWhen { cause, attempt ->
                 if (cause is IOException && attempt < MAX_RETRY_ATTEMPTS) {
                     connectWebSocket()
-                    delay(calculateBackoffTime(attempt.toInt()))
+                    delay(calculateEqualJitter(attempt.toInt()))
                     true
                 } else {
                     false

--- a/core/network/src/main/java/com/idle/network/source/ChatDataSource.kt
+++ b/core/network/src/main/java/com/idle/network/source/ChatDataSource.kt
@@ -13,7 +13,7 @@ import com.idle.network.model.chat.SendMessageRequest
 import com.idle.network.serializer.ChatResponseSerializer
 import com.idle.network.util.MAX_RETRY_ATTEMPTS
 import com.idle.network.util.MAX_WAIT_TIME
-import com.idle.network.util.calculateBackoffTime
+import com.idle.network.util.calculateEqualJitter
 import com.idle.network.util.safeApiCall
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -86,7 +86,7 @@ class ChatDataSource @Inject constructor(
         connectionAttempts = 0
     }.recoverCatching { throwable ->
         if (connectionAttempts < MAX_RETRY_ATTEMPTS) {
-            val waitTime = minOf(calculateBackoffTime(connectionAttempts), MAX_WAIT_TIME)
+            val waitTime = minOf(calculateEqualJitter(connectionAttempts), MAX_WAIT_TIME)
             delay(waitTime)
             connectionAttempts++
             connectWebSocket().getOrThrow()

--- a/core/network/src/main/java/com/idle/network/util/BackOff.kt
+++ b/core/network/src/main/java/com/idle/network/util/BackOff.kt
@@ -2,8 +2,15 @@ package com.idle.network.util
 
 import com.idle.domain.model.CountDownTimer.Companion.TICK_INTERVAL
 import kotlin.math.pow
+import kotlin.random.Random
 
 const val MAX_RETRY_ATTEMPTS = 5
 const val MAX_WAIT_TIME = 10_000L
 
-fun calculateBackoffTime(attempt: Int): Long = (2.0.pow(attempt) * TICK_INTERVAL).toLong()
+fun calculateEqualJitter(attempt: Int): Long {
+    val baseDelay = calculateBackoffTime(attempt)
+    val randomJitter = Random.nextLong(0, baseDelay / 2 + 1)
+    return baseDelay / 2 + randomJitter
+}
+
+private fun calculateBackoffTime(attempt: Int): Long = (2.0.pow(attempt) * TICK_INTERVAL).toLong()


### PR DESCRIPTION
## 1. 🔥 변경된 내용
- **웹소켓 BackOff 전략 단순 지수 백오프 -> 지수 백오프 + Equal Jitter로 변경**

## 2. 💡 알게된 부분

단순 지수 백오프만 사용할 경우, 트래픽이 분산되기는 하지만 특정 시간에 밀집한다는 특성이 있음.

![image](https://github.com/user-attachments/assets/2ca3f6b5-f440-471e-ab42-a50fc829fdae)

_똑같은 백오프 시간을 사용한다면 0 -> 3 -> 6 -> 9 로 리커넥션을 시도하지만, 지수 백오프를 쓰면 0 -> 1 -> 3 -> 7 -> 15 로 더 넓은 범위로 트래픽을 분산시킬 수 있음_

하지만 지수 백오프를 사용한다고 하더라도 단순히 네트워크 트래픽을 넓게 펼친것 뿐이고 Thundering Herd Problem이 발생하면 똑같은 시간에 똑같은 리커넥션을 시도하게 됨.

이를 방지하기 위해 Jitter를 사용하는데, 기존에 지수 백오프를 사용할 때 2, 4, 5, 6, 8, 9, 10, 11 과 같이 사용하지 않는 시간을 사용하기 위해 지수 백오프 + 랜덤 값을 도입하여 리커넥션 대기 시간을 넣어줌.

그렇기 때문에 단순 지수 백오프를 사용하는 것 보다 더 고루고루 트래픽을 분산시킬 수 있음.

https://aws.amazon.com/ko/blogs/architecture/exponential-backoff-and-jitter/

<br><br><br>

주로 사용되는 Jitter의 전략으로는 Equal Jitter, Full Jitter, Decorrelated Jitter가 있는데,

- Full Jitter의 경우는 보통 백오프 시간(예: exponential backoff의 결과인 cap 값) 내에서 0부터 cap 사이의 임의의 값을 선택하는 방식
Full Jitter처럼 0초에 가까운 아주 짧은 대기 시간 대신, 적어도 절반의 시간은 보장하므로 너무 빠른 재시도를 피할 수 있고,
동시에 무작위 요소를 도입함으로써, 여러 클라이언트가 동시에 재시도하는 “thundering herd” 현상을 완화하는 효과가 있음.
하지만 전체 backoff 시간에 대해 항상 일정 부분 고정 값이 더해지므로, 상황에 따라서는 더 많은 대기 시간이 발생할 수 있음.

<br>

- Decorrelated Jitter는 이전 재시도에서 사용된 대기 시간(previousDelay)을 고려하여 다음 대기 시간을 산출하는 방식.
이 방식은 각 재시도 사이의 대기 시간이 이전 대기 시간에 “연동”되기 때문에, 네트워크 상태가 악화되면 대기 시간이 점점 늘어나면서 동시에 재시도하는 클라이언트의 수를 자연스럽게 줄이는 효과가 있음.
전체 백오프 시간은 Full Jitter보다 커질 수 있지만, 네트워크 혼잡 상황에서는 유연하게 반응할 수 있다는 장점이 있음.

<br>

- Equal Jitter는 FullJitter와 다르게 백오프 값(cap)의 절반은 반드시 기다리고, 추가로 0부터 cap/2 사이의 무작위 값을 선택하여 더하는 방식을 사용함.
Full Jitter는 완전한 무작위성을 제공하여 짧은 대기시간이 발생할 위험이 있으나, 평균적으로는 짧은 대기시간을 보일 수도 있으나, Equal Jitter는 일정 정도의 안정성을 보장하면서도 무작위성을 유지하는 전략임.
즉, 짧은 대기시간을 방지하여 너무 빈번한 재시도를 막으면서도 Full Jitter의 무작위성을 유지하여 다수의 클라이언트가 동시에 재시도하는 상황을 완화하는 효과가 있어 대부분의 경우 타협점으로 사용한다고 함.

[레퍼런스](https://jungseob86.tistory.com/12)

<br><br><br>

++ 추가적으로 단순히 트래픽이 동시대에 몰리지 않는 곳에서는 단순 지수 백오프로만으로도 타당할 수 있음.

Jitter의 경우 동시다발적으로 트래픽이 몰리는 곳에서 유용 ex)특정 시간 이벤트 페이지, 티케팅 등등