### PR TITLE
[IDLE-000] 크롤링 공고 커서 페이징에 distance 파라미터 추가

### DIFF
--- a/core/data/src/main/java/com/idle/data/repository/JobPostingRepositoryImpl.kt
+++ b/core/data/src/main/java/com/idle/data/repository/JobPostingRepositoryImpl.kt
@@ -8,6 +8,7 @@ import com.idle.domain.model.jobposting.CenterJobPosting
 import com.idle.domain.model.jobposting.CenterJobPostingDetail
 import com.idle.domain.model.jobposting.CrawlingJobPosting
 import com.idle.domain.model.jobposting.CrawlingJobPostingDetail
+import com.idle.domain.model.jobposting.CrawlingJobPostingPage
 import com.idle.domain.model.jobposting.DayOfWeek
 import com.idle.domain.model.jobposting.JobPostingSummary
 import com.idle.domain.model.jobposting.JobPostingType
@@ -17,6 +18,7 @@ import com.idle.domain.model.jobposting.PayType
 import com.idle.domain.model.jobposting.SharedJobPostingInfo
 import com.idle.domain.model.jobposting.WorkerJobPosting
 import com.idle.domain.model.jobposting.WorkerJobPostingDetail
+import com.idle.domain.model.jobposting.WorkerJobPostingPage
 import com.idle.domain.repositorry.JobPostingRepository
 import com.idle.network.model.jobposting.ApplyJobPostingRequest
 import com.idle.network.model.jobposting.FavoriteJobPostingRequest
@@ -151,7 +153,7 @@ class JobPostingRepositoryImpl @Inject constructor(
     override suspend fun getJobPostings(
         next: String?,
         limit: Int
-    ): Result<Pair<String?, List<WorkerJobPosting>>> = jobPostingDataSource.getJobPostings(
+    ): Result<WorkerJobPostingPage> = jobPostingDataSource.getJobPostings(
         next = next,
         limit = limit
     ).mapCatching { it.toVO() }
@@ -159,7 +161,7 @@ class JobPostingRepositoryImpl @Inject constructor(
     override suspend fun getJobPostingsApplied(
         next: String?,
         limit: Int
-    ): Result<Pair<String?, List<WorkerJobPosting>>> = jobPostingDataSource.getJobPostingsApplied(
+    ): Result<WorkerJobPostingPage> = jobPostingDataSource.getJobPostingsApplied(
         next = next,
         limit = limit
     ).mapCatching { it.toVO() }
@@ -213,8 +215,9 @@ class JobPostingRepositoryImpl @Inject constructor(
     override suspend fun getCrawlingJobPostings(
         next: String?,
         limit: Int,
-    ): Result<Pair<String?, List<CrawlingJobPosting>>> =
-        jobPostingDataSource.getCrawlingJobPostings(next, limit).mapCatching { it.toVO() }
+        distance: Int,
+    ): Result<CrawlingJobPostingPage> =
+        jobPostingDataSource.getCrawlingJobPostings(next, limit, distance).mapCatching { it.toVO() }
 
     override suspend fun getCrawlingJobPostingDetail(jobPostingId: String): Result<CrawlingJobPostingDetail> =
         jobPostingDataSource.getCrawlingJobPostingsDetail(jobPostingId).mapCatching { it.toVO() }

--- a/core/domain/src/main/kotlin/com/idle/domain/model/jobposting/CrawlingJobPosting.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/model/jobposting/CrawlingJobPosting.kt
@@ -11,3 +11,9 @@ data class CrawlingJobPosting(
     val payInfo: String,
     val applyDeadline: String,
 ) : JobPosting(id, distance, jobPostingType, isFavorite)
+
+data class CrawlingJobPostingPage(
+    val nextCursor: String?,
+    val items: List<CrawlingJobPosting>,
+    val nextDistance: Int,
+)

--- a/core/domain/src/main/kotlin/com/idle/domain/model/jobposting/WorkerJobPosting.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/model/jobposting/WorkerJobPosting.kt
@@ -24,3 +24,8 @@ data class WorkerJobPosting(
     val applyDeadline: LocalDate,
     val applyTime: LocalDateTime?,
 ) : JobPosting(id, distance, jobPostingType, isFavorite)
+
+data class WorkerJobPostingPage(
+    val nextCursor: String?,
+    val items: List<WorkerJobPosting>,
+)

--- a/core/domain/src/main/kotlin/com/idle/domain/repositorry/JobPostingRepository.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/repositorry/JobPostingRepository.kt
@@ -8,6 +8,7 @@ import com.idle.domain.model.jobposting.CenterJobPosting
 import com.idle.domain.model.jobposting.CenterJobPostingDetail
 import com.idle.domain.model.jobposting.CrawlingJobPosting
 import com.idle.domain.model.jobposting.CrawlingJobPostingDetail
+import com.idle.domain.model.jobposting.CrawlingJobPostingPage
 import com.idle.domain.model.jobposting.DayOfWeek
 import com.idle.domain.model.jobposting.JobPostingSummary
 import com.idle.domain.model.jobposting.JobPostingType
@@ -17,6 +18,7 @@ import com.idle.domain.model.jobposting.PayType
 import com.idle.domain.model.jobposting.SharedJobPostingInfo
 import com.idle.domain.model.jobposting.WorkerJobPosting
 import com.idle.domain.model.jobposting.WorkerJobPostingDetail
+import com.idle.domain.model.jobposting.WorkerJobPostingPage
 
 interface JobPostingRepository {
     var sharedJobPostingInfo: SharedJobPostingInfo?
@@ -81,12 +83,12 @@ interface JobPostingRepository {
     suspend fun getJobPostings(
         next: String?,
         limit: Int = 10,
-    ): Result<Pair<String?, List<WorkerJobPosting>>>
+    ): Result<WorkerJobPostingPage>
 
     suspend fun getJobPostingsApplied(
         next: String?,
         limit: Int = 10,
-    ): Result<Pair<String?, List<WorkerJobPosting>>>
+    ): Result<WorkerJobPostingPage>
 
     suspend fun getMyFavoritesJobPostings(): Result<List<WorkerJobPosting>>
 
@@ -116,7 +118,8 @@ interface JobPostingRepository {
     suspend fun getCrawlingJobPostings(
         next: String?,
         limit: Int = 10,
-    ): Result<Pair<String?, List<CrawlingJobPosting>>>
+        distance: Int = 15,
+    ): Result<CrawlingJobPostingPage>
 
     suspend fun getCrawlingJobPostingDetail(jobPostingId: String): Result<CrawlingJobPostingDetail>
 }

--- a/core/network/src/main/java/com/idle/network/api/JobPostingApi.kt
+++ b/core/network/src/main/java/com/idle/network/api/JobPostingApi.kt
@@ -98,6 +98,7 @@ interface JobPostingApi {
     suspend fun getCrawlingJobPostings(
         @Query("next") next: String?,
         @Query("limit") limit: Int,
+        @Query("distance") distance: Int,
     ): Response<GetCrawlingJobPostingsResponse>
 
     @GET("api/v1/crawling-job-postings/{crawling-job-posting-id}")

--- a/core/network/src/main/java/com/idle/network/model/jobposting/GetCrawlingJobPostingsResponse.kt
+++ b/core/network/src/main/java/com/idle/network/model/jobposting/GetCrawlingJobPostingsResponse.kt
@@ -1,6 +1,7 @@
 package com.idle.network.model.jobposting
 
 import com.idle.domain.model.jobposting.CrawlingJobPosting
+import com.idle.domain.model.jobposting.CrawlingJobPostingPage
 import com.idle.domain.model.jobposting.JobPostingType
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -10,9 +11,13 @@ data class GetCrawlingJobPostingsResponse(
     @SerialName("items") val crawlingJobPostingResponses: List<CrawlingJobPostingResponse> = listOf(),
     val next: String? = null,
     val total: Int = 0,
+    val nextDistance: Int = 15,
 ) {
-    fun toVO(): Pair<String?, List<CrawlingJobPosting>> =
-        next to crawlingJobPostingResponses.map { it.toVO() }
+    fun toVO(): CrawlingJobPostingPage = CrawlingJobPostingPage(
+        nextCursor = next,
+        items = crawlingJobPostingResponses.map { it.toVO() },
+        nextDistance = nextDistance,
+    )
 }
 
 @Serializable

--- a/core/network/src/main/java/com/idle/network/model/jobposting/GetJobPostingsResponse.kt
+++ b/core/network/src/main/java/com/idle/network/model/jobposting/GetJobPostingsResponse.kt
@@ -6,6 +6,7 @@ import com.idle.domain.model.jobposting.DayOfWeek
 import com.idle.domain.model.jobposting.JobPostingType
 import com.idle.domain.model.jobposting.PayType
 import com.idle.domain.model.jobposting.WorkerJobPosting
+import com.idle.domain.model.jobposting.WorkerJobPostingPage
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.time.LocalDate
@@ -18,8 +19,11 @@ data class GetJobPostingsResponse(
     val next: String?,
     val total: Int
 ) {
-    fun toVO(): Pair<String?, List<WorkerJobPosting>> =
-        next to workerJobPostingResponses.map { it.toVO() }
+    fun toVO(): WorkerJobPostingPage =
+        WorkerJobPostingPage(
+            nextCursor = next,
+            items = workerJobPostingResponses.map { it.toVO() },
+        )
 }
 
 @Serializable

--- a/core/network/src/main/java/com/idle/network/source/JobPostingDataSource.kt
+++ b/core/network/src/main/java/com/idle/network/source/JobPostingDataSource.kt
@@ -93,9 +93,10 @@ class JobPostingDataSource @Inject constructor(
 
     suspend fun getCrawlingJobPostings(
         next: String?,
-        limit: Int
+        limit: Int,
+        distance: Int,
     ): Result<GetCrawlingJobPostingsResponse> =
-        safeApiCall { jobPostingApi.getCrawlingJobPostings(next = next, limit = limit) }
+        safeApiCall { jobPostingApi.getCrawlingJobPostings(next = next, limit = limit, distance = distance) }
 
     suspend fun getCrawlingJobPostingsDetail(
         jobPostingId: String

--- a/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ui/component/CareChatTextBubble.kt
+++ b/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ui/component/CareChatTextBubble.kt
@@ -157,7 +157,6 @@ fun CareChatSenderTextBubble(
     chatMessage: ChatMessage,
     isLast: Boolean,
     modifier: Modifier = Modifier,
-    isRead: Boolean = false,
     onSeeAllChatClicked: (String) -> Unit = {},
 ) {
     Row(modifier = modifier.fillMaxWidth()) {
@@ -225,7 +224,7 @@ fun CareChatSenderTextBubble(
                     .align(Alignment.Bottom)
                     .padding(start = 6.dp),
             ) {
-                if (isRead) {
+                if (chatMessage.isRead) {
                     Text(
                         text = "읽음",
                         style = CareTheme.typography.caption1,
@@ -248,7 +247,6 @@ fun CareChatReceiverTextBubble(
     chatMessage: ChatMessage,
     isLast: Boolean,
     modifier: Modifier = Modifier,
-    isRead: Boolean = false,
     onSeeAllChatClicked: (String) -> Unit = {},
 ) {
     Row(
@@ -263,7 +261,7 @@ fun CareChatReceiverTextBubble(
                     .align(Alignment.Bottom)
                     .padding(end = 6.dp),
             ) {
-                if (isRead) {
+                if (chatMessage.isRead) {
                     Text(
                         text = "읽음",
                         style = CareTheme.typography.caption1,

--- a/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ui/component/ChattingBody.kt
+++ b/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ui/component/ChattingBody.kt
@@ -106,7 +106,6 @@ fun ChattingBody(
                     CareChatSenderTextBubble(
                         chatMessage = chatMessage,
                         isLast = isLast,
-                        isRead = isLast,
                         onSeeAllChatClicked = { navigateTo(DeepLinkDestination.SeeAllChat(it)) },
                         modifier = Modifier.padding(itemPadding),
                     )

--- a/feature/worker-home/src/main/java/com/idle/worker/home/WorkerHomeViewModel.kt
+++ b/feature/worker-home/src/main/java/com/idle/worker/home/WorkerHomeViewModel.kt
@@ -37,7 +37,8 @@ class WorkerHomeViewModel @Inject constructor(
     private val _profile = MutableStateFlow<WorkerProfile?>(null)
     val profile = _profile.asStateFlow()
 
-    private val next = MutableStateFlow<String?>(null)
+    private var nextCursorId: String? = null
+    private var nextDistance: Int = 15
 
     private val _jobPostings = MutableStateFlow<List<JobPosting>?>(null)
     val jobPostings = _jobPostings.asStateFlow()
@@ -153,28 +154,33 @@ class WorkerHomeViewModel @Inject constructor(
     }
 
     private suspend fun fetchInAppJobPostings() {
-        jobPostingRepository.getJobPostings(next = next.value).onSuccess { (nextId, postings) ->
-            next.value = nextId
-            if (nextId == null) {
-                _callType.value = JobPostingCallType.CRAWLING
-            }
-            _jobPostings.value = _jobPostings.value?.plus(postings) ?: postings
+        jobPostingRepository.getJobPostings(next = nextCursorId)
+            .onSuccess { (nextId, postings) ->
+                nextCursorId = nextId
+                if (nextId == null) {
+                    _callType.value = JobPostingCallType.CRAWLING
+                }
+                _jobPostings.value = _jobPostings.value?.plus(postings) ?: postings
 
-            if (_jobPostings.value?.isEmpty() != false) {
-                getJobPostings()
-            }
-        }.onFailure { errorHelper.sendError(it) }
+                if (_jobPostings.value?.isEmpty() != false) {
+                    getJobPostings()
+                }
+            }.onFailure { errorHelper.sendError(it) }
     }
 
     private suspend fun fetchCrawlingJobPostings() {
-        jobPostingRepository.getCrawlingJobPostings(next = next.value)
-            .onSuccess { (nextId, postings) ->
-                next.value = nextId
-                if (nextId == null) {
-                    _callType.value = JobPostingCallType.END
-                }
-                _jobPostings.value = _jobPostings.value?.plus(postings) ?: postings
-            }.onFailure { errorHelper.sendError(it) }
+        jobPostingRepository.getCrawlingJobPostings(
+            next = nextCursorId,
+            distance = nextDistance,
+        ).onSuccess { pageInfo ->
+            nextCursorId = pageInfo.nextCursor
+            nextDistance = pageInfo.nextDistance
+
+            if (pageInfo.nextCursor == null) {
+                _callType.value = JobPostingCallType.END
+            }
+            _jobPostings.value = _jobPostings.value?.plus(pageInfo.items) ?: pageInfo.items
+        }.onFailure { errorHelper.sendError(it) }
     }
 }
 

--- a/feature/worker-job-posting/src/main/java/com/idle/worker/job/posting/WorkerJobPostingViewModel.kt
+++ b/feature/worker-job-posting/src/main/java/com/idle/worker/job/posting/WorkerJobPostingViewModel.kt
@@ -35,7 +35,7 @@ class WorkerJobPostingViewModel @Inject constructor(
     private val _recruitmentPostStatus = MutableStateFlow(RecruitmentPostStatus.APPLY)
     val recruitmentPostStatus = _recruitmentPostStatus.asStateFlow()
 
-    private val next = MutableStateFlow<String?>(null)
+    private var nextCursorId: String? = null
 
     private val _appliedJobPostings = MutableStateFlow<List<JobPosting>?>(null)
     val appliedJobPostings = _appliedJobPostings.asStateFlow()
@@ -66,9 +66,7 @@ class WorkerJobPostingViewModel @Inject constructor(
     }
 
     internal fun getAppliedJobPostings() = viewModelScope.launch {
-        if (isLoading) {
-            return@launch
-        }
+        if (isLoading) return@launch
         isLoading = true
 
         try {
@@ -76,16 +74,16 @@ class WorkerJobPostingViewModel @Inject constructor(
                 return@launch
             }
 
-            jobPostingRepository.getJobPostingsApplied(next = next.value)
-                .onSuccess { (nextId, postings) ->
-                    next.value = nextId
+            jobPostingRepository.getJobPostingsApplied(next = nextCursorId)
+                .onSuccess { nextPage ->
+                    nextCursorId = nextPage.nextCursor
 
-                    if (nextId == null) {
+                    if (nextPage.nextCursor == null) {
                         appliedJobPostingCallType = JobPostingCallType.END
                     }
 
                     _appliedJobPostings.value =
-                        _appliedJobPostings.value?.plus(postings) ?: postings
+                        _appliedJobPostings.value?.plus(nextPage.items) ?: nextPage.items
                 }.onFailure { errorHelper.sendError(it) }
         } finally {
             isLoading = false
@@ -213,5 +211,5 @@ enum class RecruitmentPostStatus(val displayName: String) {
 }
 
 enum class JobPostingCallType {
-    IN_APP, CRAWLING, END
+    IN_APP, END
 }


### PR DESCRIPTION
## 1. 🔥 변경된 내용
- **크롤링 공고 커서 페이징에 distance 파라미터 추가**

특정 지역에서는 공고가 없는 경우가 있어서 distance를 3km -> 15km로 완전 확장하고, 거리 순으로 정렬된 공고를 내려줍니다.

페이지네이션에 distance인자를 추가해서 해당 거리안에 공고가 더이상 없을경우 점진적으로 거리가 증가해서 탐색하게 합니다.

## 2. 📸 스크린샷(선택)

https://github.com/user-attachments/assets/5c314013-6f54-475b-896f-e22b241abf1a
