### PR TITLE
[IDLE-587] 채팅 메시지에 Sequence 추가

### DIFF
--- a/app/src/main/java/com/idle/care/notification/NotificationService.kt
+++ b/app/src/main/java/com/idle/care/notification/NotificationService.kt
@@ -3,8 +3,8 @@ package com.idle.care.notification
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.idle.domain.model.error.ErrorHelper
-import com.idle.domain.repositorry.TokenRepository
 import com.idle.domain.repositorry.ProfileRepository
+import com.idle.domain.repositorry.TokenRepository
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
@@ -40,10 +40,12 @@ class NotificationService : FirebaseMessagingService() {
         scope.launch {
             val userType = profileRepository.getMyUserType()
 
-            tokenRepository.postDeviceToken(
-                deviceToken = token,
-                userType = userType,
-            )
+            if (userType.isNotEmpty()) {
+                tokenRepository.postDeviceToken(
+                    deviceToken = token,
+                    userType = userType,
+                )
+            }
         }
     }
 

--- a/core/data/src/main/java/com/idle/data/repository/ChatRepositoryImpl.kt
+++ b/core/data/src/main/java/com/idle/data/repository/ChatRepositoryImpl.kt
@@ -95,7 +95,18 @@ class ChatRepositoryImpl @Inject constructor(
                     messageId = messageId,
                 )
             }.mapCatching { response ->
-                response.map {
+                val messages = response.chatMessageResponse
+                val readSequence = response.opponentSequence
+                messages.lastOrNull()?.let {
+                    localChatDataSource.readMessages(
+                        roomId = roomId,
+                        myId = myId,
+                        senderId = it.senderId ?: return@let,
+                        sequence = readSequence,
+                    )
+                }
+
+                messages.map {
                     val message = it.toVO()
                     if (!localChatDataSource.isChatRoomExist(message.roomId, myId)) {
                         localChatDataSource.insertChatRoom(
@@ -109,7 +120,15 @@ class ChatRepositoryImpl @Inject constructor(
                             )
                         )
                     }
-                    localChatDataSource.insertMessage(message, myId)
+
+                    if (!localChatDataSource.hasMessagesAfterSequence(
+                            roomId = message.roomId,
+                            myId = myId,
+                            sequence = message.sequence,
+                        )
+                    ) {
+                        localChatDataSource.insertMessage(message, myId)
+                    }
                 }
             }.getOrThrow()
         }
@@ -138,6 +157,7 @@ class ChatRepositoryImpl @Inject constructor(
         chatDataSource.subscribeChatMessage(userId)
             .map {
                 val message = it.toVO()
+
                 when (message) {
                     is ChatMessage -> {
                         if (!localChatDataSource.isChatRoomExist(
@@ -165,9 +185,11 @@ class ChatRepositoryImpl @Inject constructor(
                             roomId = message.chatroomId,
                             myId = userId,
                             senderId = message.opponentId,
+                            sequence = message.sequence,
                         )
                     }
                 }
+
                 message
             }.retryWhen { cause, attempt ->
                 if (cause is IOException && attempt < MAX_RETRY_ATTEMPTS) {
@@ -201,18 +223,21 @@ class ChatRepositoryImpl @Inject constructor(
         myId: String,
         opponentId: String,
         userType: UserType,
+        sequence: Int,
     ): Result<Unit> =
         chatDataSource.readMessage(
             userType = userType,
             readMessageRequest = ReadMessageRequest(
                 chatroomId = chatroomId,
                 opponentId = opponentId,
+                messageSequence = sequence,
             )
         ).onSuccess {
             localChatDataSource.readMessages(
                 roomId = chatroomId,
                 myId = myId,
                 senderId = opponentId,
+                sequence = sequence,
             )
         }
 }

--- a/core/data/src/main/java/com/idle/data/repository/ChatRepositoryImpl.kt
+++ b/core/data/src/main/java/com/idle/data/repository/ChatRepositoryImpl.kt
@@ -96,7 +96,7 @@ class ChatRepositoryImpl @Inject constructor(
                 )
             }.mapCatching { response ->
                 val messages = response.chatMessageResponse
-                val readSequence = response.opponentSequence
+                val readSequence = response.sequence
                 messages.lastOrNull()?.let {
                     localChatDataSource.readMessages(
                         roomId = roomId,
@@ -230,7 +230,7 @@ class ChatRepositoryImpl @Inject constructor(
             readMessageRequest = ReadMessageRequest(
                 chatroomId = chatroomId,
                 opponentId = opponentId,
-                messageSequence = sequence,
+                sequence = sequence,
             )
         ).onSuccess {
             localChatDataSource.readMessages(

--- a/core/data/src/main/java/com/idle/data/repository/ChatRepositoryImpl.kt
+++ b/core/data/src/main/java/com/idle/data/repository/ChatRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package com.idle.data.repository
 
-import android.util.Log
 import com.idle.database.source.LocalChatDataSource
 import com.idle.domain.model.auth.UserType
 import com.idle.domain.model.chat.ChatMessage
@@ -96,8 +95,9 @@ class ChatRepositoryImpl @Inject constructor(
                     messageId = messageId,
                 )
             }.mapCatching { response ->
-                val messages = response.chatMessageResponse
+                val messages = response.chatMessageInfos
                 val readSequence = response.sequence
+
                 messages.lastOrNull()?.let {
                     localChatDataSource.readMessages(
                         roomId = roomId,
@@ -109,8 +109,6 @@ class ChatRepositoryImpl @Inject constructor(
 
                 messages.map {
                     val message = it.toVO()
-
-                    Log.d("test1", message.toString())
 
                     if (!localChatDataSource.isChatRoomExist(message.roomId, myId)) {
                         localChatDataSource.insertChatRoom(
@@ -125,14 +123,9 @@ class ChatRepositoryImpl @Inject constructor(
                         )
                     }
 
-                    Log.d("test2", message.toString())
-
-                    if (!localChatDataSource.hasMessagesAfterSequence(
-                            roomId = roomId,
-                            myId = myId,
-                            sequence = message.sequence,
-                        )
-                    ) {
+                    val maxSeq =
+                        localChatDataSource.getMaxLocalSequence(roomId, myId) ?: Int.MIN_VALUE
+                    if (message.sequence > maxSeq) {
                         localChatDataSource.insertMessage(message, myId)
                     }
                 }

--- a/core/data/src/main/java/com/idle/data/repository/ChatRepositoryImpl.kt
+++ b/core/data/src/main/java/com/idle/data/repository/ChatRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.idle.data.repository
 
+import android.util.Log
 import com.idle.database.source.LocalChatDataSource
 import com.idle.domain.model.auth.UserType
 import com.idle.domain.model.chat.ChatMessage
@@ -108,6 +109,9 @@ class ChatRepositoryImpl @Inject constructor(
 
                 messages.map {
                     val message = it.toVO()
+
+                    Log.d("test1", message.toString())
+
                     if (!localChatDataSource.isChatRoomExist(message.roomId, myId)) {
                         localChatDataSource.insertChatRoom(
                             myId = myId,
@@ -121,8 +125,10 @@ class ChatRepositoryImpl @Inject constructor(
                         )
                     }
 
+                    Log.d("test2", message.toString())
+
                     if (!localChatDataSource.hasMessagesAfterSequence(
-                            roomId = message.roomId,
+                            roomId = roomId,
                             myId = myId,
                             sequence = message.sequence,
                         )

--- a/core/data/src/main/java/com/idle/data/repository/ChatRepositoryImpl.kt
+++ b/core/data/src/main/java/com/idle/data/repository/ChatRepositoryImpl.kt
@@ -107,28 +107,30 @@ class ChatRepositoryImpl @Inject constructor(
                     )
                 }
 
-                messages.map {
-                    val message = it.toVO()
+                messages
+                    .sortedBy { it.sequence }
+                    .map {
+                        val message = it.toVO()
 
-                    if (!localChatDataSource.isChatRoomExist(message.roomId, myId)) {
-                        localChatDataSource.insertChatRoom(
-                            myId = myId,
-                            chatRoom = ChatRoom(
-                                id = message.roomId,
-                                opponentId = if (myId == message.senderId) message.receiverId else message.senderId,
-                                lastMessage = message.content,
-                                lastMessageTime = message.createdAt,
-                                unReadMessageCount = 1,
+                        if (!localChatDataSource.isChatRoomExist(message.roomId, myId)) {
+                            localChatDataSource.insertChatRoom(
+                                myId = myId,
+                                chatRoom = ChatRoom(
+                                    id = message.roomId,
+                                    opponentId = if (myId == message.senderId) message.receiverId else message.senderId,
+                                    lastMessage = message.content,
+                                    lastMessageTime = message.createdAt,
+                                    unReadMessageCount = 1,
+                                )
                             )
-                        )
-                    }
+                        }
 
-                    val maxSeq =
-                        localChatDataSource.getMaxLocalSequence(roomId, myId) ?: Int.MIN_VALUE
-                    if (message.sequence > maxSeq) {
-                        localChatDataSource.insertMessage(message, myId)
+                        val maxSeq =
+                            localChatDataSource.getMaxLocalSequence(roomId, myId) ?: Int.MIN_VALUE
+                        if (message.sequence > maxSeq) {
+                            localChatDataSource.insertMessage(message, myId)
+                        }
                     }
-                }
             }.getOrThrow()
         }
 

--- a/core/database/src/main/java/com/idle/database/dao/MessagesDao.kt
+++ b/core/database/src/main/java/com/idle/database/dao/MessagesDao.kt
@@ -1,15 +1,14 @@
 package com.idle.database.dao
 
 import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Upsert
 import com.idle.database.model.MessageEntity
 
 @Dao
 interface MessagesDao {
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertMessage(messages: MessageEntity)
+    @Upsert
+    suspend fun upsertMessage(messages: MessageEntity)
 
     @Query(
         """
@@ -25,7 +24,7 @@ interface MessagesDao {
         roomId: String,
         myId: String,
         lastMessageId: String?,
-        limit: Int = 50
+        limit: Int = 50,
     ): List<MessageEntity>
 
     @Query(
@@ -36,12 +35,14 @@ interface MessagesDao {
                 AND myId = :myId
                 AND senderId = :opponentId
                 AND isRead = 0
+                AND sequence <= :sequence
         """
     )
     suspend fun readMessages(
         roomId: String,
         myId: String,
         opponentId: String,
+        sequence: Int,
     )
 
     @Query(
@@ -59,5 +60,22 @@ interface MessagesDao {
         myId: String,
         roomId: String,
         messageId: String,
+    ): Boolean
+
+    @Query(
+        """
+        SELECT EXISTS(
+            SELECT 1
+            FROM message
+            WHERE roomId = :roomId
+              AND myId   = :myId
+              AND sequence > :sequence
+        )
+        """
+    )
+    suspend fun hasMessagesAfterSequence(
+        roomId: String,
+        myId: String,
+        sequence: Int
     ): Boolean
 }

--- a/core/database/src/main/java/com/idle/database/dao/MessagesDao.kt
+++ b/core/database/src/main/java/com/idle/database/dao/MessagesDao.kt
@@ -64,18 +64,11 @@ interface MessagesDao {
 
     @Query(
         """
-        SELECT EXISTS(
-            SELECT 1
+            SELECT MAX(sequence)
             FROM message
             WHERE roomId = :roomId
-              AND myId   = :myId
-              AND sequence > :sequence
-        )
+            AND myId   = :myId
         """
     )
-    suspend fun hasMessagesAfterSequence(
-        roomId: String,
-        myId: String,
-        sequence: Int
-    ): Boolean
+    suspend fun getMaxLocalSequence(roomId: String, myId: String): Int?
 }

--- a/core/database/src/main/java/com/idle/database/model/MessageEntity.kt
+++ b/core/database/src/main/java/com/idle/database/model/MessageEntity.kt
@@ -3,23 +3,23 @@ package com.idle.database.model
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
-import androidx.room.PrimaryKey
 import com.idle.domain.model.chat.ChatMessage
 import java.time.LocalDateTime
 
 @Entity(
     tableName = "message",
-    indices = [Index(value = ["roomId", "id", "sequence"], unique = true)],
-    foreignKeys = arrayOf(
+    primaryKeys = ["myId", "id"],
+    indices = [Index(value = ["roomId", "sequence"])],
+    foreignKeys = [
         ForeignKey(
             entity = ChatRoomEntity::class,
             parentColumns = ["id", "myId"],
             childColumns = ["roomId", "myId"],
         )
-    )
+    ]
 )
 data class MessageEntity(
-    @PrimaryKey val id: String,
+    val id: String,
     val roomId: String,
     val myId: String,
     val senderId: String,

--- a/core/database/src/main/java/com/idle/database/model/MessageEntity.kt
+++ b/core/database/src/main/java/com/idle/database/model/MessageEntity.kt
@@ -9,7 +9,7 @@ import java.time.LocalDateTime
 
 @Entity(
     tableName = "message",
-    indices = [Index(value = ["roomId", "id"], unique = false)],
+    indices = [Index(value = ["roomId", "id", "sequence"], unique = true)],
     foreignKeys = arrayOf(
         ForeignKey(
             entity = ChatRoomEntity::class,
@@ -27,6 +27,7 @@ data class MessageEntity(
     val content: String,
     val createdAt: LocalDateTime,
     val isRead: Boolean,
+    val sequence: Int,
 ) {
     internal fun toDomain() = ChatMessage(
         id = id,
@@ -36,6 +37,7 @@ data class MessageEntity(
         content = content,
         createdAt = createdAt,
         isRead = isRead,
+        sequence = sequence,
     )
 }
 
@@ -48,4 +50,5 @@ internal fun ChatMessage.toMessageEntity(myId: String) = MessageEntity(
     content = content,
     createdAt = createdAt,
     isRead = isRead,
+    sequence = sequence,
 )

--- a/core/database/src/main/java/com/idle/database/source/LocalChatDataSource.kt
+++ b/core/database/src/main/java/com/idle/database/source/LocalChatDataSource.kt
@@ -15,7 +15,7 @@ class LocalChatDataSource @Inject constructor(
     private val chatRoomsDao: ChatRoomsDao,
 ) {
     suspend fun insertMessage(message: ChatMessage, myId: String) =
-        messagesDao.insertMessage(message.toMessageEntity(myId))
+        messagesDao.upsertMessage(message.toMessageEntity(myId))
 
     suspend fun getMessages(
         roomId: String,
@@ -32,13 +32,21 @@ class LocalChatDataSource @Inject constructor(
         roomId: String,
         myId: String,
         senderId: String,
-    ): Unit = messagesDao.readMessages(roomId, myId, senderId)
+        sequence: Int,
+    ): Unit = messagesDao.readMessages(roomId, myId, senderId, sequence)
 
     suspend fun isMessageExist(roomId: String, myId: String, messageId: String): Boolean =
         messagesDao.isMessageExist(
             roomId = roomId,
             myId = myId,
             messageId = messageId,
+        )
+
+    suspend fun hasMessagesAfterSequence(roomId: String, myId: String, sequence: Int): Boolean =
+        messagesDao.hasMessagesAfterSequence(
+            roomId = roomId,
+            myId = myId,
+            sequence = sequence,
         )
 
     suspend fun insertChatRoom(myId: String, chatRoom: ChatRoom) =

--- a/core/database/src/main/java/com/idle/database/source/LocalChatDataSource.kt
+++ b/core/database/src/main/java/com/idle/database/source/LocalChatDataSource.kt
@@ -42,11 +42,10 @@ class LocalChatDataSource @Inject constructor(
             messageId = messageId,
         )
 
-    suspend fun hasMessagesAfterSequence(roomId: String, myId: String, sequence: Int): Boolean =
-        messagesDao.hasMessagesAfterSequence(
+    suspend fun getMaxLocalSequence(roomId: String, myId: String): Int? =
+        messagesDao.getMaxLocalSequence(
             roomId = roomId,
             myId = myId,
-            sequence = sequence,
         )
 
     suspend fun insertChatRoom(myId: String, chatRoom: ChatRoom) =

--- a/core/domain/src/main/kotlin/com/idle/domain/model/chat/Message.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/model/chat/Message.kt
@@ -2,7 +2,7 @@ package com.idle.domain.model.chat
 
 import java.time.LocalDateTime
 
-sealed class Message
+sealed class Message(open val sequence: Int)
 
 data class ChatMessage(
     val id: String,
@@ -12,9 +12,11 @@ data class ChatMessage(
     val content: String,
     val createdAt: LocalDateTime,
     val isRead: Boolean,
-) : Message()
+    override val sequence: Int,
+) : Message(sequence)
 
 data class ReadMessage(
     val opponentId: String,
     val chatroomId: String,
-) : Message()
+    override val sequence: Int,
+) : Message(sequence)

--- a/core/domain/src/main/kotlin/com/idle/domain/repositorry/ChatRepository.kt
+++ b/core/domain/src/main/kotlin/com/idle/domain/repositorry/ChatRepository.kt
@@ -54,5 +54,6 @@ interface ChatRepository {
         myId: String,
         opponentId: String,
         userType: UserType,
+        sequence: Int,
     ): Result<Unit>
 }

--- a/core/network/src/main/java/com/idle/network/api/ChatApi.kt
+++ b/core/network/src/main/java/com/idle/network/api/ChatApi.kt
@@ -1,7 +1,7 @@
 package com.idle.network.api
 
-import com.idle.network.model.chat.ChatMessageResponse
 import com.idle.network.model.chat.GenerateChatRoomResponse
+import com.idle.network.model.chat.GetChatMessageResponse
 import com.idle.network.model.chat.GetChatRoomResponse
 import retrofit2.Response
 import retrofit2.http.GET
@@ -26,11 +26,11 @@ interface ChatApi {
     suspend fun getWorkerChatRoomMessages(
         @Path("chatroom-id") chatRoomId: String,
         @Query("message-id") messageId: String?,
-    ): Response<List<ChatMessageResponse>>
+    ): Response<GetChatMessageResponse>
 
     @GET("api/v2/chat/center/chatrooms/{chatroom-id}/messages")
     suspend fun getCenterChatRoomMessages(
         @Path("chatroom-id") chatRoomId: String,
         @Query("message-id") messageId: String?,
-    ): Response<List<ChatMessageResponse>>
+    ): Response<GetChatMessageResponse>
 }

--- a/core/network/src/main/java/com/idle/network/model/chat/ChatMessageResponse.kt
+++ b/core/network/src/main/java/com/idle/network/model/chat/ChatMessageResponse.kt
@@ -13,7 +13,7 @@ data class ChatMessageResponse(
     val receiverId: String?,
     val content: String?,
     val createdAt: String?,
-    val messageSequence: Int?,
+    val sequence: Int?,
     override val type: String = MESSAGE_TYPE,
 ) : ChatResponse() {
     override fun toVO() = ChatMessage(
@@ -25,7 +25,7 @@ data class ChatMessageResponse(
         createdAt = createdAt?.let { LocalDateTime.parse(it, DateTimeFormatter.ISO_DATE_TIME) }
             ?: LocalDateTime.MIN,
         isRead = false,
-        sequence = messageSequence ?: -1
+        sequence = sequence ?: -1
     )
 }
 

--- a/core/network/src/main/java/com/idle/network/model/chat/ChatMessageResponse.kt
+++ b/core/network/src/main/java/com/idle/network/model/chat/ChatMessageResponse.kt
@@ -13,6 +13,7 @@ data class ChatMessageResponse(
     val receiverId: String?,
     val content: String?,
     val createdAt: String?,
+    val messageSequence: Int?,
     override val type: String = MESSAGE_TYPE,
 ) : ChatResponse() {
     override fun toVO() = ChatMessage(
@@ -24,6 +25,7 @@ data class ChatMessageResponse(
         createdAt = createdAt?.let { LocalDateTime.parse(it, DateTimeFormatter.ISO_DATE_TIME) }
             ?: LocalDateTime.MIN,
         isRead = false,
+        sequence = messageSequence ?: -1
     )
 }
 

--- a/core/network/src/main/java/com/idle/network/model/chat/GetChatMessageResponse.kt
+++ b/core/network/src/main/java/com/idle/network/model/chat/GetChatMessageResponse.kt
@@ -6,8 +6,8 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class GetChatMessageResponse(
     val chatMessageResponse: List<ChatMessageResponse> = emptyList(),
-    val opponentSequence: Int = 0,
+    val sequence: Int = 0,
 ) {
     fun toVO(): Pair<List<ChatMessage>, Int> =
-        chatMessageResponse.map(ChatMessageResponse::toVO) to opponentSequence
+        chatMessageResponse.map(ChatMessageResponse::toVO) to sequence
 }

--- a/core/network/src/main/java/com/idle/network/model/chat/GetChatMessageResponse.kt
+++ b/core/network/src/main/java/com/idle/network/model/chat/GetChatMessageResponse.kt
@@ -1,0 +1,13 @@
+package com.idle.network.model.chat
+
+import com.idle.domain.model.chat.ChatMessage
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GetChatMessageResponse(
+    val chatMessageResponse: List<ChatMessageResponse> = emptyList(),
+    val opponentSequence: Int = 0,
+) {
+    fun toVO(): Pair<List<ChatMessage>, Int> =
+        chatMessageResponse.map(ChatMessageResponse::toVO) to opponentSequence
+}

--- a/core/network/src/main/java/com/idle/network/model/chat/GetChatMessageResponse.kt
+++ b/core/network/src/main/java/com/idle/network/model/chat/GetChatMessageResponse.kt
@@ -5,9 +5,9 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class GetChatMessageResponse(
-    val chatMessageResponse: List<ChatMessageResponse> = emptyList(),
+    val chatMessageInfos: List<ChatMessageResponse> = emptyList(),
     val sequence: Int = 0,
 ) {
     fun toVO(): Pair<List<ChatMessage>, Int> =
-        chatMessageResponse.map(ChatMessageResponse::toVO) to sequence
+        chatMessageInfos.map(ChatMessageResponse::toVO) to sequence
 }

--- a/core/network/src/main/java/com/idle/network/model/chat/ReadMessageRequest.kt
+++ b/core/network/src/main/java/com/idle/network/model/chat/ReadMessageRequest.kt
@@ -6,5 +6,5 @@ import kotlinx.serialization.Serializable
 data class ReadMessageRequest(
     val chatroomId: String,
     val opponentId: String,
-    val messageSequence: Int,
+    val sequence: Int,
 )

--- a/core/network/src/main/java/com/idle/network/model/chat/ReadMessageRequest.kt
+++ b/core/network/src/main/java/com/idle/network/model/chat/ReadMessageRequest.kt
@@ -6,4 +6,5 @@ import kotlinx.serialization.Serializable
 data class ReadMessageRequest(
     val chatroomId: String,
     val opponentId: String,
+    val messageSequence: Int,
 )

--- a/core/network/src/main/java/com/idle/network/model/chat/ReadMessageResponse.kt
+++ b/core/network/src/main/java/com/idle/network/model/chat/ReadMessageResponse.kt
@@ -7,10 +7,12 @@ import kotlinx.serialization.Serializable
 data class ReadMessageResponse(
     val readByUserId: String?,
     val chatroomId: String?,
+    val messageSequence: Int?,
     override val type: String = READ_TYPE,
 ) : ChatResponse() {
     override fun toVO() = ReadMessage(
         opponentId = readByUserId ?: "",
         chatroomId = chatroomId ?: "",
+        sequence = messageSequence ?: -1
     )
 }

--- a/core/network/src/main/java/com/idle/network/model/chat/ReadMessageResponse.kt
+++ b/core/network/src/main/java/com/idle/network/model/chat/ReadMessageResponse.kt
@@ -7,12 +7,12 @@ import kotlinx.serialization.Serializable
 data class ReadMessageResponse(
     val readByUserId: String?,
     val chatroomId: String?,
-    val messageSequence: Int?,
+    val sequence: Int?,
     override val type: String = READ_TYPE,
 ) : ChatResponse() {
     override fun toVO() = ReadMessage(
         opponentId = readByUserId ?: "",
         chatroomId = chatroomId ?: "",
-        sequence = messageSequence ?: -1
+        sequence = sequence ?: -1
     )
 }

--- a/core/network/src/main/java/com/idle/network/source/ChatDataSource.kt
+++ b/core/network/src/main/java/com/idle/network/source/ChatDataSource.kt
@@ -122,17 +122,21 @@ class ChatDataSource @Inject constructor(
         runCatching {
             Log.d("test", "/pub/send/${userType.apiValue.lowercase()}")
 
-            session?.convertAndSend(
+            val result = session?.convertAndSend(
                 headers = StompSendHeaders(destination = "/pub/send/${userType.apiValue.lowercase()}"),
                 body = sendMessageRequest,
                 serializer = SendMessageRequest.serializer(),
             )
+
+            Log.d("test", result.toString())
         }
 
     suspend fun readMessage(
         userType: UserType,
         readMessageRequest: ReadMessageRequest
     ): Result<Unit> = runCatching {
+        Log.d("test", "/pub/read/${userType.apiValue.lowercase()}")
+
         session?.convertAndSend(
             headers = StompSendHeaders(destination = "/pub/read/${userType.apiValue.lowercase()}"),
             body = readMessageRequest,

--- a/core/network/src/main/java/com/idle/network/source/ChatDataSource.kt
+++ b/core/network/src/main/java/com/idle/network/source/ChatDataSource.kt
@@ -1,11 +1,9 @@
 package com.idle.network.source
 
-import android.util.Log
 import com.idle.domain.model.auth.UserType
 import com.idle.network.BuildConfig
 import com.idle.network.api.ChatApi
 import com.idle.network.di.TokenManager
-import com.idle.network.model.chat.ChatMessageResponse
 import com.idle.network.model.chat.ChatResponse
 import com.idle.network.model.chat.GenerateChatRoomResponse
 import com.idle.network.model.chat.GetChatMessageResponse
@@ -93,7 +91,6 @@ class ChatDataSource @Inject constructor(
             connectionAttempts++
             connectWebSocket().getOrThrow()
         } else {
-            Log.d("test connect", throwable.stackTraceToString())
             throw throwable
         }
     }
@@ -102,7 +99,6 @@ class ChatDataSource @Inject constructor(
         session?.disconnect()
         Result.success(Unit)
     } catch (e: Exception) {
-        Log.d("test disconnect", e.stackTraceToString())
         Result.failure(e)
     }
 
@@ -111,7 +107,6 @@ class ChatDataSource @Inject constructor(
             StompSubscribeHeaders(destination = "/sub/${userId}"),
             chatResponseSerializer,
         )?.map {
-            Log.d("test", it.toString())
             it
         } ?: flow { throw IOException("웹소켓을 먼저 연결해주세요.") }
 
@@ -120,23 +115,17 @@ class ChatDataSource @Inject constructor(
         sendMessageRequest: SendMessageRequest
     ): Result<Unit> =
         runCatching {
-            Log.d("test", "/pub/send/${userType.apiValue.lowercase()}")
-
             val result = session?.convertAndSend(
                 headers = StompSendHeaders(destination = "/pub/send/${userType.apiValue.lowercase()}"),
                 body = sendMessageRequest,
                 serializer = SendMessageRequest.serializer(),
             )
-
-            Log.d("test", result.toString())
         }
 
     suspend fun readMessage(
         userType: UserType,
         readMessageRequest: ReadMessageRequest
     ): Result<Unit> = runCatching {
-        Log.d("test", "/pub/read/${userType.apiValue.lowercase()}")
-
         session?.convertAndSend(
             headers = StompSendHeaders(destination = "/pub/read/${userType.apiValue.lowercase()}"),
             body = readMessageRequest,

--- a/core/network/src/main/java/com/idle/network/source/ChatDataSource.kt
+++ b/core/network/src/main/java/com/idle/network/source/ChatDataSource.kt
@@ -8,6 +8,7 @@ import com.idle.network.di.TokenManager
 import com.idle.network.model.chat.ChatMessageResponse
 import com.idle.network.model.chat.ChatResponse
 import com.idle.network.model.chat.GenerateChatRoomResponse
+import com.idle.network.model.chat.GetChatMessageResponse
 import com.idle.network.model.chat.GetChatRoomResponse
 import com.idle.network.model.chat.ReadMessageRequest
 import com.idle.network.model.chat.SendMessageRequest
@@ -47,7 +48,7 @@ class ChatDataSource @Inject constructor(
     suspend fun getWorkerChatRoomMessages(
         roomId: String,
         messageId: String?,
-    ): Result<List<ChatMessageResponse>> =
+    ): Result<GetChatMessageResponse> =
         safeApiCall {
             chatApi.getWorkerChatRoomMessages(
                 chatRoomId = roomId,
@@ -58,7 +59,7 @@ class ChatDataSource @Inject constructor(
     suspend fun getCenterChatRoomMessages(
         roomId: String,
         messageId: String?,
-    ): Result<List<ChatMessageResponse>> =
+    ): Result<GetChatMessageResponse> =
         safeApiCall {
             chatApi.getCenterChatRoomMessages(
                 chatRoomId = roomId,

--- a/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ChattingDetailViewModel.kt
+++ b/feature/chatting-detail/src/main/java/com/idle/chatting_detail/ChattingDetailViewModel.kt
@@ -187,6 +187,7 @@ class ChattingDetailViewModel @Inject constructor(
             myId = myId,
             opponentId = opponentId,
             userType = myUserType,
+            sequence = _chatMessages.value?.lastOrNull()?.sequence ?: return
         ).onSuccess {
             _chatMessages.value = _chatMessages.value?.map {
                 if (it.receiverId == myId) it.copy(isRead = true) else it


### PR DESCRIPTION
## 1. 🔥 변경된 내용
- **채팅 메시지에 Sequence 추가**

## 2. 💡 알게된 부분
- Room에서 @Upsert를 사용하여, 없을경우 Insert, 없을 경우 Update를 해주는 어노테이션이 존재,
- Sequence를 사용하여 서버 <-> 클라이언트 통신간에 유실된 메세지를 찾을 수 있으며, 
서버에서는 isRead와 같은 FullScan Column을 지울 수 있으므로, 서버딴에서 join이 하나 사라지는 것이라 쿼리 성능이 상승할 수 있음